### PR TITLE
[FEAT] Auth도메인 관련기능 완성

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
@@ -1,0 +1,160 @@
+package com.kakaobase.snsapp.domain.auth.controller;
+
+import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
+import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
+import com.kakaobase.snsapp.domain.auth.service.UserAuthenticationService;
+import com.kakaobase.snsapp.domain.auth.util.CookieUtil;
+import com.kakaobase.snsapp.global.common.response.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 인증 관련 API 컨트롤러
+ * 로그인, 로그아웃, 토큰 재발급 등의 인증 관련 API를 처리합니다.
+ */
+@Tag(name = "인증 API", description = "로그인, 로그아웃, 토큰 관련 API")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final UserAuthenticationService userAuthenticationService;
+    private final CookieUtil cookieUtil;
+
+    /**
+     * 로그인 API
+     * 이메일과 비밀번호로 로그인하여 JWT 토큰을 발급받습니다.
+     * Access Token은 응답 본문에, Refresh Token은 HttpOnly Secure 쿠키로 전달됩니다.
+     *
+     * @param request 로그인 요청 정보 (이메일, 비밀번호)
+     * @param httpRequest HTTP 요청 객체
+     * @param httpResponse HTTP 응답 객체
+     * @return 액세스 토큰을 포함한 응답
+     */
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT 토큰을 발급합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.TokenResponse.class))),
+            @ApiResponse(responseCode = "400", description = "필수 입력값 누락 또는 이메일 형식 오류",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.RefreshTokenMissing.class))),
+            @ApiResponse(responseCode = "401", description = "등록되지 않은 이메일 또는 비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.RefreshTokenInvalid.class)))
+    })
+    @PostMapping("/tokens")
+    public CustomResponse<AuthResponseDto.TokenResponse> login(
+            @Parameter(description = "로그인 정보", required = true)
+            @Valid @RequestBody AuthRequestDto.Login request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse) {
+
+        log.info("로그인 요청: {}", request.email());
+
+        // 로그인 처리 및 토큰 발급
+        UserAuthenticationService.TokenWithCookie result = userAuthenticationService.login(
+                request.email(),
+                request.password(),
+                httpRequest.getHeader("User-Agent")
+        );
+
+        // 리프레시 토큰을 쿠키에 설정
+        httpResponse.addCookie(result.refreshTokenCookie());
+
+        log.info("로그인 성공: {}", request.email());
+
+        // 액세스 토큰을 응답 본문에 포함
+        return CustomResponse.success(
+                "로그인에 성공하였습니다.",
+                new AuthResponseDto.TokenResponse(result.accessToken())
+        );
+    }
+
+    /**
+     * 액세스 토큰 재발급 API
+     * 리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.
+     * 리프레시 토큰은 쿠키에서 자동으로 전송됩니다.
+     *
+     * @param httpRequest HTTP 요청 객체
+     * @return 새로 발급된 액세스 토큰을 포함한 응답
+     */
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.TokenResponse.class))),
+            @ApiResponse(responseCode = "400", description = "리프레시 토큰 없음",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.RefreshTokenMissing.class))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.RefreshTokenInvalid.class)))
+    })
+    @PostMapping("/tokens/refresh")
+    public CustomResponse<AuthResponseDto.TokenResponse> refreshToken(
+            HttpServletRequest httpRequest) {
+
+        log.info("액세스 토큰 재발급 요청");
+
+        // 쿠키에서 리프레시 토큰 추출
+        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(httpRequest);
+
+        // 액세스 토큰 재발급
+        String newAccessToken = userAuthenticationService.refreshAuthentication(refreshToken);
+
+        log.info("액세스 토큰 재발급 성공");
+
+        // 새 액세스 토큰을 응답 본문에 포함
+        return CustomResponse.success(
+                "Access Token이 재발급되었습니다.",
+                new AuthResponseDto.TokenResponse(newAccessToken)
+        );
+    }
+
+    /**
+     * 로그아웃 API
+     * 현재 사용 중인 토큰을 무효화하고 로그아웃합니다.
+     * 리프레시 토큰은 서버에서 블랙리스트에 등록되고, 쿠키에서 제거됩니다.
+     *
+     * @param httpRequest HTTP 요청 객체
+     * @param httpResponse HTTP 응답 객체
+     * @return 로그아웃 성공 메시지
+     */
+    @Operation(summary = "로그아웃", description = "현재 사용 중인 토큰을 무효화하고 로그아웃합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "400", description = "리프레시 토큰 없음",
+                    content = @Content(schema = @Schema(implementation = AuthResponseDto.RefreshTokenMissing.class)))
+    })
+    @DeleteMapping("/tokens")
+    public CustomResponse<Void> logout(
+            HttpServletRequest httpRequest,
+            HttpServletResponse httpResponse) {
+
+        log.info("로그아웃 요청");
+
+        // 쿠키에서 리프레시 토큰 추출
+        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(httpRequest);
+
+        // 토큰 무효화 처리
+        if (refreshToken != null) {
+            userAuthenticationService.logout(refreshToken);
+            log.info("리프레시 토큰 무효화 완료");
+        }
+
+        // 쿠키에서 리프레시 토큰 제거
+        httpResponse.addCookie(cookieUtil.clearRefreshTokenCookie());
+
+        log.info("로그아웃 성공");
+
+        return CustomResponse.success("정상적으로 로그아웃되었습니다.");
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,86 @@
+package com.kakaobase.snsapp.domain.auth.converter;
+
+import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
+import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
+import com.kakaobase.snsapp.domain.auth.entity.AuthToken;
+import com.kakaobase.snsapp.domain.auth.entity.RevokedRefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Auth 도메인의 객체 변환을 담당하는 컨버터입니다.
+ * DTO와 Entity 사이의 변환을 처리합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AuthConverter {
+
+    /**
+     * 로그인 정보와 생성된 토큰 정보로 AuthToken 엔티티를 생성합니다.
+     *
+     * @param memberId 회원 ID
+     * @param refreshTokenHash 리프레시 토큰 해시 값
+     * @param userAgent 사용자 브라우저 정보
+     * @param expirationTime 토큰 만료 시간
+     * @return 생성된 AuthToken 엔티티
+     */
+    public AuthToken toAuthTokenEntity(
+            Long memberId,
+            String refreshTokenHash,
+            String userAgent,
+            LocalDateTime expirationTime
+    ) {
+        // 기기 ID 생성 (UUID v4)
+        String deviceId = UUID.randomUUID().toString();
+
+        // AuthToken 엔티티 생성 및 반환
+        return AuthToken.builder()
+                .memberId(memberId)
+                .refreshTokenHash(refreshTokenHash)
+                .deviceId(deviceId)
+                .userAgent(userAgent)
+                .expiresAt(expirationTime)
+                .build();
+    }
+
+    /**
+     * 취소할 토큰 정보로 RevokedRefreshToken 엔티티를 생성합니다.
+     *
+     * @param refreshTokenHash 취소할 리프레시 토큰 해시 값
+     * @param memberId 회원 ID
+     * @return 생성된 RevokedRefreshToken 엔티티
+     */
+    public RevokedRefreshToken toRevokedTokenEntity(String refreshTokenHash, Long memberId) {
+        return RevokedRefreshToken.builder()
+                .refreshTokenHash(refreshTokenHash)
+                .memberId(memberId)
+                .revokedAt(LocalDateTime.now())
+                .build();
+    }
+
+    /**
+     * 액세스 토큰과 리프레시 토큰으로 응답 DTO를 생성합니다.
+     *
+     * @param accessToken 액세스 토큰
+     * @param refreshToken 리프레시 토큰 (클라이언트에게 직접 보내지 않고 쿠키에 설정됨)
+     * @return 토큰 응답 DTO
+     */
+    public AuthResponseDto.TokenResponse toTokenResponseDto(String accessToken, String refreshToken) {
+        // refreshToken은 파라미터로 받지만 실제로는 쿠키에 설정되므로 응답 DTO에는 포함되지 않음
+        return new AuthResponseDto.TokenResponse(accessToken);
+    }
+
+    /**
+     * 액세스 토큰만으로 응답 DTO를 생성합니다.
+     * 리프레시 토큰은 쿠키로 전송되므로 응답 본문에는 포함되지 않습니다.
+     *
+     * @param accessToken 액세스 토큰
+     * @return 토큰 응답 DTO
+     */
+    public AuthResponseDto.TokenResponse toAccessTokenOnlyResponseDto(String accessToken) {
+        return new AuthResponseDto.TokenResponse(accessToken);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthRequestDto.java
@@ -1,0 +1,45 @@
+package com.kakaobase.snsapp.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * Auth 도메인의 요청 DTO를 정의하는 클래스입니다.
+ * 각 요청 유형에 맞는 중첩 레코드 클래스로 구성되어 있습니다.
+ * 로그인, 비밀번호 변경, 프로필 이미지 업로드 등의 요청을 처리합니다.
+ */
+public class AuthRequestDto {
+
+    /**
+     * 로그인 요청을 위한 DTO입니다.
+     * 사용자의 이메일과 비밀번호를 검증하고, 성공 시 토큰을 발급받습니다.
+     */
+    @Schema(description = "로그인 요청 DTO")
+    public record Login(
+            @Schema(description = "이메일", example = "example@domain.com")
+            @NotBlank(message = "이메일은 필수 입력값입니다.")
+            @Email(message = "이메일 형식이 올바르지 않습니다.")
+            String email,
+
+            @Schema(description = "비밀번호", example = "Test1234!")
+            @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+            String password
+    ) {}
+
+    /**
+     * 토큰 재발급 요청을 위한 DTO입니다.
+     * 클라이언트는 RefreshToken을 쿠키로 전송하므로 요청 본문은 비어있습니다.
+     */
+    @Schema(description = "토큰 재발급 요청 DTO")
+    public record TokenRefresh() {}
+
+    /**
+     * 로그아웃 요청을 위한 DTO입니다.
+     * 클라이언트는 RefreshToken을 쿠키로 전송하고 AccessToken을 헤더로 전송하므로
+     * 요청 본문은 비어있습니다.
+     */
+    @Schema(description = "로그아웃 요청 DTO")
+    public record Logout() {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
@@ -1,0 +1,66 @@
+package com.kakaobase.snsapp.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 인증 관련 응답 DTO 모음 클래스입니다.
+ */
+public class AuthResponseDto {
+
+    /**
+     * 액세스 토큰 응답 DTO
+     * - RefreshToken은 쿠키로 전달됨
+     */
+    @Schema(description = "로그인 또는 토큰 재발급 성공 응답 DTO")
+    public record TokenResponse(
+
+            @Schema(description = "AccessToken (JWT 형식)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
+            String accessToken
+
+    ) {}
+
+    /**
+     * 인증 실패 공통 응답 DTO
+     */
+    @Schema(description = "인증 실패 응답 DTO")
+    public record Failure(
+            @Schema(description = "에러 코드", example = "invalid_password")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "비밀번호가 일치하지 않습니다.")
+            String message,
+
+            @Schema(description = "문제가 발생한 필드", example = "password")
+            String field
+    ) {}
+
+    /**
+     * RefreshToken 누락 에러 응답 DTO
+     */
+    @Schema(description = "RefreshToken 누락 실패 응답 DTO")
+    public record RefreshTokenMissing(
+            @Schema(description = "에러 코드", example = "refresh_token_missing")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "RefreshToken이 쿠키에 포함되어 있지 않습니다.")
+            String message,
+
+            @Schema(description = "에러 필드", example = "refreshToken")
+            String field
+    ) {}
+
+    /**
+     * RefreshToken 무효 응답 DTO
+     */
+    @Schema(description = "RefreshToken 무효 실패 응답 DTO")
+    public record RefreshTokenInvalid(
+            @Schema(description = "에러 코드", example = "refresh_token_invalid")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "RefreshToken이 만료되었거나 유효하지 않습니다.")
+            String message,
+
+            @Schema(description = "에러 필드", example = "refreshToken")
+            String field
+    ) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/entity/AuthToken.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/entity/AuthToken.java
@@ -1,0 +1,103 @@
+package com.kakaobase.snsapp.domain.auth.entity;
+
+import com.kakaobase.snsapp.global.common.entity.BaseUpdateTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 인증 토큰 정보를 저장하는 엔티티입니다.
+ * 리프레시 토큰 및 관련 정보를 관리합니다.
+ */
+@Entity
+@Table(name = "auth_tokens")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+public class AuthToken extends BaseUpdateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 토큰을 발급받은 회원의 ID입니다.
+     */
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /**
+     * 리프레시 토큰의 해시값입니다.
+     * SHA-256 암호화를 통해 저장됩니다.
+     */
+    @Column(name = "refresh_token_hash", nullable = false, length = 43)
+    private String refreshTokenHash;
+
+    /**
+     * 사용자 기기의 고유 식별자입니다.
+     * UUID v4 형식으로 저장됩니다.
+     */
+    @Column(name = "device_id", nullable = false, length = 36)
+    private String deviceId;
+
+    /**
+     * 토큰이 발급된 기기의 User-Agent 정보입니다.
+     */
+    @Column(name = "user_agent", nullable = false, length = 512)
+    private String userAgent;
+
+    /**
+     * 토큰의 만료 시간입니다.
+     */
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    /**
+     * 리프레시 토큰을 갱신합니다.
+     *
+     * @param refreshTokenHash 새 리프레시 토큰 해시
+     * @param expiresAt 새 만료 시간
+     */
+    public void updateToken(String refreshTokenHash, LocalDateTime expiresAt) {
+        this.refreshTokenHash = refreshTokenHash;
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 토큰이 만료되었는지 확인합니다.
+     *
+     * @return 현재 시간이 만료 시간을 지났으면 true, 그렇지 않으면 false
+     */
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    /**
+     * 특정 해시값이 현재 토큰의 해시값과 일치하는지 확인합니다.
+     *
+     * @param tokenHash 비교할 토큰 해시
+     * @return 해시값이 일치하면 true, 그렇지 않으면 false
+     */
+    public boolean isTokenMatch(String tokenHash) {
+        return this.refreshTokenHash.equals(tokenHash);
+    }
+
+    /**
+     * 이 토큰이 특정 디바이스의 것인지 확인합니다.
+     */
+    public boolean isFromDevice(String deviceId) {
+        return this.deviceId.equals(deviceId);
+    }
+
+    /**
+     * 이 토큰이 특정 User-Agent로 발급되었는지 확인합니다.
+     */
+    public boolean isFromUserAgent(String agent) {
+        return this.userAgent.equals(agent);
+    }
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/entity/RevokedRefreshToken.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/entity/RevokedRefreshToken.java
@@ -1,0 +1,65 @@
+package com.kakaobase.snsapp.domain.auth.entity;
+
+import com.kakaobase.snsapp.global.common.entity.BaseCreatedTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+/**
+ * 취소된 리프레시 토큰 정보를 저장하는 엔티티입니다.
+ * 로그아웃 등으로 인해 더 이상 유효하지 않은 토큰을 관리합니다.
+ */
+@Entity
+@Table(name = "revoked_refresh_tokens")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
+public class RevokedRefreshToken extends BaseCreatedTimeEntity {
+
+    /**
+     * 취소된, SHA-256으로 해시된 리프레시 토큰 값입니다.
+     * 기본 키로 사용됩니다.
+     */
+    @Id
+    @Column(name = "revoked_refresh_token_hash", nullable = false, length = 43)
+    private String refreshTokenHash;
+
+    /**
+     * 리프레시 토큰을 발급받은 회원의 ID입니다.
+     */
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    /**
+     * 리프레시 토큰이 취소된 시간입니다.
+     * BaseCreatedTimeEntity의 createdAt 필드가 이 역할을 합니다.
+     * revoked_at 컬럼에 매핑됩니다.
+     */
+    @Column(name = "revoked_at", insertable = false, updatable = false)
+    private LocalDateTime revokedAt;
+
+    /**
+     * 토큰이 특정 회원의 것인지 확인합니다.
+     *
+     * @param memberId 확인할 회원 ID
+     * @return 토큰이 해당 회원의 것이면 true, 아니면 false
+     */
+    public boolean isTokenForMember(Long memberId) {
+        return this.memberId.equals(memberId);
+    }
+
+    /**
+     * 해시된 토큰과 사용자 정보를 기반으로 취소 토큰 객체를 생성합니다.
+     */
+    public static RevokedRefreshToken from(String refreshTokenHash, Long memberId) {
+        return RevokedRefreshToken.builder()
+                .refreshTokenHash(refreshTokenHash)
+                .memberId(memberId)
+                .build();
+    }
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,34 @@
+package com.kakaobase.snsapp.domain.auth.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 인증 도메인 특화 에러 코드를 정의합니다.
+ * 로그인, 토큰, 인증 관련 에러를 포함하고 있습니다.
+ * Spring Security 관련 에러는 SecurityExceptionHandler에서 처리되므로 여기서는
+ * 비즈니스 로직 관련 에러만 정의합니다.
+ */
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    // 로그인 관련 에러
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "invalid_password", "비밀번호가 일치하지 않습니다.", "password"),
+    USER_DELETED(HttpStatus.NOT_FOUND, "deleted_user", "삭제된 유저입니다.", "userId"),
+    USER_BANNED(HttpStatus.FORBIDDEN, "banned_user", "벤처리된 유저입니다.", "userId"),
+
+    // 리프레시 토큰 관련 에러 (Spring Security 외부에서 처리되는 경우)
+    REFRESH_TOKEN_MISSING(HttpStatus.BAD_REQUEST, "refresh_token_missing", "refreshToken이 쿠키에 존재하지 않습니다.", "refreshToken"),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "refresh_token_invalid", "refreshToken이 유효하지 않습니다.", "refreshToken"),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "refresh_token_invalid", "refreshToken이 만료되었습니다.", "refreshToken"),
+    REFRESH_TOKEN_REVOKED(HttpStatus.UNAUTHORIZED, "refresh_token_invalid", "사용할 수 없는 refreshToken입니다.", "refreshToken");
+
+    private final HttpStatus status;
+    private final String error;
+    private final String message;
+    private final String field;
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/exception/AuthException.java
@@ -1,0 +1,44 @@
+package com.kakaobase.snsapp.domain.auth.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import com.kakaobase.snsapp.global.error.exception.CustomException;
+
+/**
+ * 인증 도메인에서 발생하는 예외를 처리하는 커스텀 예외 클래스입니다.
+ * 로그인, 토큰, 인증 관련 비즈니스 예외는 모두 이 클래스를 사용합니다.
+ * Spring Security 관련 예외는 SecurityExceptionHandler에서 처리합니다.
+ */
+public class AuthException extends CustomException {
+
+    /**
+     * 인증 에러 코드를 받아 AuthException을 생성합니다.
+     *
+     * @param errorCode 인증 에러 코드 (AuthErrorCode)
+     */
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    /**
+     * 인증 에러 코드와 필드를 받아 AuthException을 생성합니다.
+     * 에러가 발생한 필드를 동적으로 지정할 때 사용합니다.
+     *
+     * @param errorCode 인증 에러 코드 (BaseErrorCode)
+     * @param field 에러가 발생한 필드
+     */
+    public AuthException(BaseErrorCode errorCode, String field) {
+        super(errorCode, field);
+    }
+
+    /**
+     * 인증 에러 코드와 필드, 추가 메시지를 받아 AuthException을 생성합니다.
+     * 에러 메시지에 추가적인 정보를 포함할 때 사용합니다.
+     *
+     * @param errorCode 인증 에러 코드 (BaseErrorCode)
+     * @param field 에러가 발생한 필드
+     * @param additionalMessage 추가 메시지
+     */
+    public AuthException(BaseErrorCode errorCode, String field, String additionalMessage) {
+        super(errorCode, field, additionalMessage);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/repository/AuthTokenRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/repository/AuthTokenRepository.java
@@ -1,0 +1,60 @@
+package com.kakaobase.snsapp.domain.auth.repository;
+
+import com.kakaobase.snsapp.domain.auth.entity.AuthToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface AuthTokenRepository extends JpaRepository<AuthToken, Long> {
+
+    /**
+     * RefreshToken 해시값으로 AuthToken 조회
+     *
+     * @param refreshTokenHash 해시된 리프레시 토큰
+     * @return 해당 토큰이 존재하면 Optional 반환
+     */
+    Optional<AuthToken> findByRefreshTokenHash(String refreshTokenHash);
+
+    /**
+     * 디바이스 ID와 사용자 ID로 AuthToken 조회 (디바이스 기반 로그아웃용)
+     *
+     * @param deviceId 디바이스 식별자
+     * @param memberId 사용자 ID
+     * @return 해당 토큰이 존재하면 Optional 반환
+     */
+    Optional<AuthToken> findByDeviceIdAndMemberId(String deviceId, Long memberId);
+
+    /**
+     * 사용자 ID로 발급된 모든 AuthToken 조회
+     *
+     * @param memberId 사용자 ID
+     * @return 해당 사용자의 모든 토큰 리스트
+     */
+    List<AuthToken> findAllByMemberId(Long memberId);
+
+    /**
+     * 특정 디바이스와 사용자에 해당하는 토큰 삭제 (디바이스 로그아웃)
+     *
+     * @param deviceId 디바이스 ID
+     * @param memberId 사용자 ID
+     * @return 삭제된 행 수
+     */
+    @Modifying
+    int deleteByDeviceIdAndMemberId(String deviceId, Long memberId);
+
+    /**
+     * 특정 만료 시간 이전에 만료된 토큰들을 삭제합니다.
+     * 데이터베이스 정리 작업에 사용됩니다.
+     *
+     * @param expirationTime 기준 만료 시간
+     * @return 삭제된 행 수
+     */
+    @Modifying
+    @Query("DELETE FROM AuthToken a WHERE a.expiresAt < :expirationTime")
+    int deleteAllExpiredTokensBefore(@Param("expirationTime") LocalDateTime expirationTime);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/repository/RevokedRefreshTokenRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/repository/RevokedRefreshTokenRepository.java
@@ -1,0 +1,56 @@
+package com.kakaobase.snsapp.domain.auth.repository;
+
+import com.kakaobase.snsapp.domain.auth.entity.RevokedRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 취소된 리프레시 토큰 정보에 접근하기 위한 레포지토리 인터페이스입니다.
+ * 로그아웃 된 토큰이나 보안상 무효화된 토큰 관리를 위한 메서드들을 제공합니다.
+ */
+@Repository
+public interface RevokedRefreshTokenRepository extends JpaRepository<RevokedRefreshToken, String> {
+
+    /**
+     * 특정 리프레시 토큰 해시가 취소 목록에 존재하는지 확인합니다.
+     * 토큰 유효성 검증 과정에서 사용됩니다.
+     *
+     * @param refreshTokenHash 리프레시 토큰 해시값
+     * @return 취소 목록에 존재하면 true, 아니면 false
+     */
+    boolean existsByRefreshTokenHash(String refreshTokenHash);
+
+    /**
+     * 특정 회원 ID와 관련된 모든 취소된 리프레시 토큰을 조회합니다.
+     * 회원별 토큰 관리에 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     * @return 해당 회원의 취소된 토큰 목록
+     */
+    List<RevokedRefreshToken> findByMemberId(Long memberId);
+
+    /**
+     * 특정 회원 ID와 관련된 모든 취소된 리프레시 토큰을 삭제합니다.
+     * 회원 탈퇴 시 관련 데이터 정리에 사용될 수 있습니다.
+     *
+     * @param memberId 회원 ID
+     * @return 삭제된 행 수
+     */
+    int deleteByMemberId(Long memberId);
+
+    /**
+     * 특정 시간 이전에 취소된 토큰들을 삭제합니다.
+     * 데이터베이스 정리 작업에 사용됩니다.
+     *
+     * @param revokedBefore 기준 취소 시간
+     * @return 삭제된 행 수
+     */
+    @Query("DELETE FROM RevokedRefreshToken r WHERE r.revokedAt < :revokedBefore")
+    int deleteByRevokedAtBefore(@Param("revokedBefore") LocalDateTime revokedBefore);
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/service/SecurityTokenManager.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/service/SecurityTokenManager.java
@@ -1,0 +1,172 @@
+package com.kakaobase.snsapp.domain.auth.service;
+
+import com.kakaobase.snsapp.domain.auth.converter.AuthConverter;
+import com.kakaobase.snsapp.domain.auth.entity.AuthToken;
+import com.kakaobase.snsapp.domain.auth.entity.RevokedRefreshToken;
+import com.kakaobase.snsapp.domain.auth.exception.AuthErrorCode;
+import com.kakaobase.snsapp.domain.auth.exception.AuthException;
+import com.kakaobase.snsapp.domain.auth.repository.AuthTokenRepository;
+import com.kakaobase.snsapp.domain.auth.repository.RevokedRefreshTokenRepository;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 보안 토큰(리프레시 토큰)의 생성, 검증, 관리를 담당하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SecurityTokenManager {
+
+    private final AuthTokenRepository authTokenRepository;
+    private final RevokedRefreshTokenRepository revokedTokenRepository;
+    private final AuthConverter authConverter;
+
+    @Value("${app.jwt.refresh.expiration-time}")
+    private long refreshTokenExpirationTimeMillis;
+
+    /**
+     * 리프레시 토큰 생성 및 저장
+     */
+    @Transactional
+    public String createRefreshToken(Long userId, String userAgent) {
+        // 1. 랜덤 토큰 생성
+        String rawToken = generateSecureToken();
+        String hashedToken = hashToken(rawToken);
+
+        // 2. 만료 시간 계산
+        LocalDateTime expiryTime = LocalDateTime.now()
+                .plus(Duration.ofMillis(refreshTokenExpirationTimeMillis));
+
+        // 3. AuthConverter를 사용하여 토큰 엔티티 생성 및 저장
+        AuthToken tokenEntity = authConverter.toAuthTokenEntity(
+                userId,
+                hashedToken,
+                userAgent,
+                expiryTime
+        );
+
+        authTokenRepository.save(tokenEntity);
+
+        return rawToken;
+    }
+
+    /**
+     * 리프레시 토큰 검증 및 사용자 ID 반환
+     */
+    public Long validateRefreshTokenAndGetUserId(String rawToken) {
+        String hashedToken = hashToken(rawToken);
+
+        // 1. 취소된 토큰인지 확인
+        if (isTokenRevoked(hashedToken)) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_REVOKED);
+        }
+
+        // 2. 토큰 조회
+        AuthToken tokenEntity = authTokenRepository.findByRefreshTokenHash(hashedToken)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID));
+
+        // 3. 만료 확인
+        if (isTokenExpired(tokenEntity)) {
+            revokeToken(tokenEntity);
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        return tokenEntity.getMemberId();
+    }
+
+    /**
+     * 리프레시 토큰 취소
+     */
+    @Transactional
+    public void revokeRefreshToken(String rawToken) {
+        String hashedToken = hashToken(rawToken);
+
+        AuthToken tokenEntity = authTokenRepository.findByRefreshTokenHash(hashedToken)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID));
+
+        revokeToken(tokenEntity);
+    }
+
+
+    /**
+     * 현재 토큰을 제외한 모든 토큰 취소
+     */
+    @Transactional
+    public void revokeAllTokensExcept(Long memberId, String currentRawToken) {
+        String currentHashedToken = hashToken(currentRawToken);
+        List<AuthToken> tokens = authTokenRepository.findAllByMemberId(memberId);
+
+        for (AuthToken token : tokens) {
+            if (!token.getRefreshTokenHash().equals(currentHashedToken)) {
+                revokeToken(token);
+            }
+        }
+    }
+
+    /**
+     * 토큰 취소 처리 (내부 메서드)
+     */
+    @Transactional
+    public void revokeToken(AuthToken token) {
+        // AuthConverter를 사용하여 취소된 토큰 엔티티 생성
+        RevokedRefreshToken revokedToken = authConverter.toRevokedTokenEntity(
+                token.getRefreshTokenHash(),
+                token.getMemberId()
+        );
+
+        // 기존 토큰 삭제 및 취소 토큰 저장
+        authTokenRepository.delete(token);
+        revokedTokenRepository.save(revokedToken);
+    }
+
+    /**
+     * 토큰이 취소되었는지 확인
+     */
+    private boolean isTokenRevoked(String hashedToken) {
+        return revokedTokenRepository.existsByRefreshTokenHash(hashedToken);
+    }
+
+    /**
+     * 토큰 만료 여부 확인
+     */
+    private boolean isTokenExpired(AuthToken token) {
+        return token.getExpiresAt().isBefore(LocalDateTime.now());
+    }
+
+    /**
+     * 안전한 랜덤 토큰 생성
+     */
+    private String generateSecureToken() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    /**
+     * 토큰 해싱 (SHA-256)
+     */
+    private String hashToken(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Failed to hash token", e);
+            throw new AuthException(GeneralErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/service/UserAuthenticationService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/service/UserAuthenticationService.java
@@ -1,0 +1,154 @@
+package com.kakaobase.snsapp.domain.auth.service;
+
+import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
+import com.kakaobase.snsapp.domain.auth.exception.AuthErrorCode;
+import com.kakaobase.snsapp.domain.auth.exception.AuthException;
+import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.auth.util.CookieUtil;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import com.kakaobase.snsapp.global.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자 인증 관련 비즈니스 로직을 처리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserAuthenticationService {
+
+    private final MemberRepository memberRepository;
+    private final SecurityTokenManager securityTokenManager;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * 사용자 로그인 처리 및 인증 토큰 발급
+     */
+    @Transactional
+    public TokenWithCookie login(String email, String password, String userAgent) {
+        // 1. 사용자 인증
+        Member member = authenticateUser(email, password);
+
+        // 2. 인증 객체 생성
+        Authentication authentication = createAuthenticationFromMember(member);
+
+        // 3. 리프레시 토큰 생성 및 저장
+        String refreshToken = securityTokenManager.createRefreshToken(
+                member.getId(),
+                userAgent
+        );
+
+        // 4. 액세스 토큰 생성
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+
+        // 5. 리프레시 토큰 쿠키 생성
+        Cookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+
+        return new TokenWithCookie(accessToken, refreshTokenCookie);
+    }
+
+    /**
+     * 리프레시 토큰을 사용해 새 액세스 토큰 발급
+     */
+    @Transactional
+    public String refreshAuthentication(String refreshToken) {
+        if (refreshToken == null) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISSING);
+        }
+
+        // 1. 리프레시 토큰 검증 및 사용자 ID 추출
+        Long memberId = securityTokenManager.validateRefreshTokenAndGetUserId(refreshToken);
+
+        // 2. 사용자 정보 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
+
+        // 3. 사용자 상태 확인
+        validateUserStatus(member);
+
+        // 4. 인증 객체 생성
+        Authentication authentication = createAuthenticationFromMember(member);
+
+        // 5. 새 액세스 토큰 생성
+        return jwtTokenProvider.createAccessToken(authentication);
+    }
+
+    /**
+     * 로그아웃 처리
+     */
+    @Transactional
+    public void logout(String refreshToken) {
+        if (refreshToken == null) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISSING);
+        }
+        securityTokenManager.revokeRefreshToken(refreshToken);
+    }
+
+    /**
+     * 다른 모든 디바이스 로그아웃
+     */
+    @Transactional
+    public void logoutOtherDevices(Long memberId, String currentRefreshToken) {
+        if (currentRefreshToken == null) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISSING);
+        }
+        securityTokenManager.revokeAllTokensExcept(memberId, currentRefreshToken);
+    }
+
+    /**
+     * 사용자 인증 (이메일/비밀번호 검증)
+     */
+    private Member authenticateUser(String email, String password) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(GeneralErrorCode.RESOURCE_NOT_FOUND, email));
+
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new AuthException(AuthErrorCode.INVALID_PASSWORD);
+        }
+
+        validateUserStatus(member);
+
+        return member;
+    }
+
+    /**
+     * 사용자 상태 검증 (활성/비활성/차단 등)
+     */
+    private void validateUserStatus(Member member) {
+        if (member.isDeleted()) {
+            throw new AuthException(AuthErrorCode.USER_DELETED);
+        }
+
+        if (member.getIsBanned()) {
+            throw new AuthException(AuthErrorCode.USER_BANNED);
+        }
+    }
+
+    /**
+     * Member 엔티티로부터 Authentication 객체 생성
+     */
+    private Authentication createAuthenticationFromMember(Member member) {
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+    }
+
+    /**
+     * 액세스 토큰과 리프레시 토큰 쿠키를 포함하는 응답 DTO
+     */
+    public record TokenWithCookie(String accessToken, Cookie refreshTokenCookie) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
@@ -1,0 +1,87 @@
+package com.kakaobase.snsapp.domain.auth.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 인증 관련 쿠키를 생성하고 관리하는 유틸리티 클래스
+ * 리프레시 토큰을 위한 보안 쿠키 생성 및 추출 기능을 제공합니다.
+ */
+@Component
+public class CookieUtil {
+
+    /**
+     * application.yml에서 주입받은 리프레시 토큰 쿠키 관련 설정값들
+     */
+    @Value("${app.jwt.refresh.token-name}")
+    private String refreshTokenCookieName;
+
+    @Value("${app.jwt.refresh.expiration-time}")
+    private long refreshTokenExpiration;
+
+    @Value("${app.jwt.refresh.path}")
+    private String refreshTokenCookiePath;
+
+    @Value("${app.jwt.secure}")
+    private boolean secureCookie;
+
+    /**
+     * 리프레시 토큰을 담은 쿠키를 생성합니다.
+     * 생성된 쿠키는 JavaScript에서 접근할 수 없도록 HttpOnly로 설정되며,
+     * 특정 경로(/auth/tokens/refresh)에서만 전송되도록 설정됩니다.
+     *
+     * @param refreshToken 리프레시 토큰 값
+     * @return 생성된 쿠키
+     */
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+        // 토큰을 담은 쿠키 객체 생성
+        Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+
+        // 쿠키 만료 시간 설정 (초 단위로 변환)
+        cookie.setMaxAge((int) (refreshTokenExpiration / 1000));
+
+        // 쿠키 경로 설정 (토큰 재발급 엔드포인트로 제한)
+        cookie.setPath(refreshTokenCookiePath);
+
+        // 보안 설정
+        cookie.setHttpOnly(true);     // JavaScript에서 접근 불가
+        cookie.setSecure(secureCookie); // HTTPS에서만 전송 (프로덕션 환경)
+
+        return cookie;
+    }
+
+    /**
+     * HTTP 요청의 쿠키에서 리프레시 토큰을 추출합니다.
+     *
+     * @param request HTTP 요청
+     * @return 추출된 리프레시 토큰, 없으면 null
+     */
+    public String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (refreshTokenCookieName.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 로그아웃 시 사용할 빈 리프레시 토큰 쿠키를 생성합니다.
+     * 생성된 쿠키는 즉시 만료되도록 설정됩니다.
+     *
+     * @return 만료된 쿠키
+     */
+    public Cookie clearRefreshTokenCookie() {
+        Cookie cookie = new Cookie(refreshTokenCookieName, null);
+        cookie.setMaxAge(0);  // 즉시 만료
+        cookie.setPath(refreshTokenCookiePath);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secureCookie);
+        return cookie;
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/HashUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/HashUtil.java
@@ -1,0 +1,43 @@
+package com.kakaobase.snsapp.domain.auth.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * 문자열을 SHA-256 방식으로 해싱하는 유틸리티 클래스입니다.
+ * - 주로 RefreshToken, 비밀번호, 식별자 등의 단방향 암호화에 사용됩니다.
+ * - 순수 함수로 구성되며, 멱등성과 예외 처리를 보장합니다.
+ */
+public class HashUtil {
+
+    /**
+     * 입력 문자열을 SHA-256 방식으로 해싱하여 Hex 문자열로 반환합니다.
+     *
+     * @param input 해시할 문자열 (예: 원본 RefreshToken)
+     * @return SHA-256 해시 결과 (Hex 인코딩된 문자열)
+     */
+    public static String sha256(String input) {
+        try {
+            // SHA-256 알고리즘 객체 생성
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+            // 입력 문자열을 UTF-8 인코딩된 바이트 배열로 변환 후 해싱 수행
+            byte[] encodedHash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+
+            // 해시 결과를 Hex 문자열로 변환
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : encodedHash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0'); // 한 자리일 경우 앞에 0 붙이기
+                hexString.append(hex);
+            }
+
+            return hexString.toString();
+
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 알고리즘이 없을 경우 발생할 수 있는 예외 (일반적으로 발생하지 않음)
+            throw new RuntimeException("SHA-256 해싱 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/global/error/code/GeneralErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/global/error/code/GeneralErrorCode.java
@@ -21,23 +21,4 @@ public enum GeneralErrorCode implements BaseErrorCode {
     private final String message;
     private final String field;
 
-    @Override
-    public HttpStatus getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getError() {
-        return error;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
-
-    @Override
-    public String getField() {
-        return field; // 기본은 null, 상황에 따라 덮어쓸 수 있음
-    }
 }

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtTokenProvider.java
@@ -1,9 +1,11 @@
 package com.kakaobase.snsapp.global.security.jwt;
 
+import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -27,31 +29,34 @@ public class JwtTokenProvider {
      * @param accessTokenValidityTime Access Token의 유효 시간(밀리초)
      */
     public JwtTokenProvider(
-            @Value("${jwt.secret}") String secret,
-            @Value("${jwt.token.access-expiration-time}") long accessTokenValidityTime) {
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.access.expiration-time}") long accessTokenValidityTime) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenValidityInMilliseconds = accessTokenValidityTime;
     }
 
     /**
-     * 사용자 ID와 역할 정보를 기반으로 Access Token을 생성합니다.
+     * 생성된 인증객체를 기반으로 Access Token을 생성합니다.
      *
-     * @param userId 사용자 ID
-     * @param role 사용자 역할
-     * @param className 사용자의 기수(제주1기, 판교2기 등)
-     * @return 생성된 Access Token
+     * @param authentication 인증객체
      */
-    public String createAccessToken(String userId, String role, String className) {
+    public String createAccessToken(Authentication authentication) {
+        CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
+        String userId = user.getId();
+        String role = user.getRole();
+        String className = user.getClassName();
+
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
 
         return Jwts.builder()
                 .setSubject(userId)
                 .claim("role", role)
-                .claim("class_name", className)  // 기수 정보 추가
+                .claim("class_name", className)
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
+
 }

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtUtil.java
@@ -29,7 +29,7 @@ public class JwtUtil {
      *
      * @param secret JWT 서명에 사용된 비밀키
      */
-    public JwtUtil(@Value("${jwt.secret}") String secret) {
+    public JwtUtil(@Value("${app.jwt.secret}") String secret) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,8 +31,15 @@ spring:
           writetimeout: 5000
 
 
-
-jwt:
-  secret: ${JWT_SECRET}
-  token:
-    access-expiration-time: 1800000 # 30분
+app:
+  jwt:
+    secret: ${JWT_SECRET}
+    secure: true
+    issuer: kakaobase
+    audience: web
+    access:
+      expiration-time: 1800000 # 30분
+    refresh:
+      expiration-time: 604800000 # 7일
+      token-name: kakaobase_refresh_token
+      path: /auth/tokens/refresh


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #8 Auth Domain 

## 📌 개요
### 사용자가 로그인할 수 있는 전반적인 기능을 추가하였습니다
- 사용자 로그인 시 AccessToken, Refresh토큰을 발급
- 사용자가 AccessToken을 요청하면 사용자의 쿠키에 있는 리프레시 토큰을기반으로 재발급
- 로그아웃시 사용자에게 빈 cookie를 주입함으로써 refresh토큰 무효화

## 🔁 변경 사항
로그인 Contoller추가
refresh토큰 관련된 entity추가
AuthToken, RevokedToken 레포지토리 추가
Auth도메인 요청/응답 Dto추가
Auth Converter추가
Jwt를 authentication인증객체로 발급받도록 변경
Cookie생성 및 검사하는 CookieUtil추가
refresh토큰을 해싱하는 HashUtil추가
UserAuthenticationService: 사용자의 로그인, AccessToken 발급, 로그아웃을 수행하는 서비스
SecurityTokenManager: 실질적인 refresh토큰 생성, 검사, 파기를 수행하는 서비스

## 👀 기타 더 이야기해볼 점
refresh토큰관리랑 Service로직 구현하는데 시간이 좀 걸렸습니다
Dto랑 Converter이렇게 쓰는게 맞나 솔직히 잘 모르겠습니다.. 추후 리펙토링 필요
refresh토큰의 경우 난수 생성+Base64URL을 써서 원본값을 Cookie로 전송한뒤,
백엔드에서는 sha256으로 해싱한 값을 DB에 저장합니다.
난수와 Base64로 생성된 값을 rawToken, 해싱된 토큰값을 hashedToken이라고 하였습니다
HashUtil의 경우 다른 로직에도 해싱이 필요하면 golbal로 이동될 예정입니다

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.