### PR TITLE
[FEAT] Post 도메인 엔티티, 레포지토리 완성

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/entity/Member.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/entity/Member.java
@@ -1,18 +1,21 @@
 package com.kakaobase.snsapp.domain.members.entity;
 
 import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
-import com.kakaobase.snsapp.global.common.entity.BaseUpdateTimeEntity;
 import jakarta.persistence.*;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.*;
 
 @Entity
-@Table(name = "members")
+@Table(
+        name = "member",
+        indexes = {
+                @Index(name = "idx_email_not_deleted", columnList = "email, deleted_at"),
+                @Index(name = "idx_nickname_not_deleted", columnList = "nickname, deleted_at"),
+                @Index(name = "idx_role_not_deleted", columnList = "role, deleted_at")
+        }
+)
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -1,0 +1,147 @@
+package com.kakaobase.snsapp.domain.posts.entity;
+
+import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 게시글 정보를 담는 엔티티
+ * <p>
+ * 게시글의 내용, 좋아요 수, 댓글 수 등을 관리합니다.
+ * BaseSoftDeletableEntity를 상속받아 생성 시간, 수정 시간, 삭제 시간 정보를 관리합니다.
+ * </p>
+ */
+@Entity
+@Table(
+        name = "posts",
+        indexes = {
+                @Index(name = "idx_member_board_deleted_created",
+                        columnList = "member_id, board_type, deleted_at, created_at DESC"),
+                @Index(name = "idx_board_deleted_created",
+                        columnList = "board_type, deleted_at, created_at DESC, id DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE posts SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+public class Post extends BaseSoftDeletableEntity {
+
+    /**
+     * 게시판 유형을 정의하는 열거형
+     * <p>
+     * 게시글이 속한 게시판의 유형을 나타냅니다.
+     * </p>
+     */
+    public enum BoardType {
+        ALL,        // 전체 게시판
+        PANGYO_1,   // 판교 1기 게시판
+        PANGYO_2,   // 판교 2기 게시판
+        JEJU_1,     // 제주 1기 게시판
+        JEJU_2,     // 제주 2기 게시판
+        JEJU_3      // 제주 3기 게시판
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "board_type", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private BoardType boardType;
+
+    @Column(length = 3000)
+    private String content;
+
+    @Column(name = "youtube_url", length = 512)
+    private String youtubeUrl;
+
+    @Column(name = "youtube_summary", length = 255)
+    private String youtubeSummary;
+
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount;
+
+    @Column(name = "comment_count", nullable = false)
+    private Integer commentCount;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostImage> images = new ArrayList<>();
+
+    /**
+     * 게시글 생성을 위한 생성자
+     *
+     * @param memberId 작성자 ID
+     * @param boardType 게시판 유형
+     * @param content 내용
+     * @param youtubeUrl 유튜브 URL
+     */
+    public Post(Long memberId, BoardType boardType, String content, String youtubeUrl) {
+        this.memberId = memberId;
+        this.boardType = boardType;
+        this.content = content;
+        this.youtubeUrl = youtubeUrl;
+        this.likeCount = 0;
+        this.commentCount = 0;
+    }
+
+    /**
+     * 유튜브 요약 내용을 설정합니다.
+     *
+     * @param summary 유튜브 영상의 요약 내용
+     */
+    public void setYoutubeSummary(String summary) {
+        this.youtubeSummary = summary;
+    }
+
+    /**
+     * 게시글에 이미지를 추가합니다.
+     *
+     * @param image 추가할 이미지
+     */
+    public void addImage(PostImage image) {
+        this.images.add(image);
+    }
+
+    /**
+     * 좋아요 수를 증가시킵니다.
+     */
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    /**
+     * 좋아요 수를 감소시킵니다.
+     */
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    /**
+     * 댓글 수를 증가시킵니다.
+     */
+    public void increaseCommentCount() {
+        this.commentCount++;
+    }
+
+    /**
+     * 댓글 수를 감소시킵니다.
+     */
+    public void decreaseCommentCount() {
+        if (this.commentCount > 0) {
+            this.commentCount--;
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostImage.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostImage.java
@@ -1,0 +1,53 @@
+package com.kakaobase.snsapp.domain.posts.entity;
+
+import com.kakaobase.snsapp.global.common.entity.BaseUpdateTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 게시글 이미지 정보를 담는 엔티티
+ * <p>
+ * 게시글에 첨부된 이미지의 URL과 순서 정보를 관리합니다.
+ * BaseUpdateTimeEntity를 상속받아 생성 시간, 수정 시간 정보를 관리합니다.
+ * </p>
+ */
+@Entity
+@Table(
+        name = "post_imgs",
+        indexes = {
+                @Index(name = "idx_post_sort", columnList = "post_id, sort_index")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage extends BaseUpdateTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "sort_index", nullable = false)
+    private Integer sortIndex;
+
+    @Column(name = "img_url", nullable = false, length = 512)
+    private String imgUrl;
+
+    /**
+     * 이미지 정보 생성을 위한 생성자
+     *
+     * @param post 연결된 게시글
+     * @param sortIndex 이미지 정렬 순서
+     * @param imgUrl 이미지 URL
+     */
+    public PostImage(Post post, Integer sortIndex, String imgUrl) {
+        this.post = post;
+        this.sortIndex = sortIndex;
+        this.imgUrl = imgUrl;
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostImageRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostImageRepository.java
@@ -1,0 +1,101 @@
+package com.kakaobase.snsapp.domain.posts.repository;
+
+import com.kakaobase.snsapp.domain.posts.entity.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 게시글 이미지 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>게시글 이미지에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    /**
+     * 특정 게시글의 이미지를 순서대로 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @return 게시글에 첨부된 이미지 목록 (순서대로 정렬됨)
+     */
+    List<PostImage> findByPostIdOrderBySortIndexAsc(Long postId);
+
+    /**
+     * 특정 게시글의 이미지를 ID로 조회합니다.
+     *
+     * @param id 이미지 ID
+     * @param postId 게시글 ID
+     * @return 조건에 맞는 이미지 (Optional)
+     */
+    Optional<PostImage> findByIdAndPostId(Long id, Long postId);
+
+    /**
+     * 특정 게시글의 특정 순서에 있는 이미지를 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @param sortIndex 이미지 순서
+     * @return 조건에 맞는 이미지 (Optional)
+     */
+    Optional<PostImage> findByPostIdAndSortIndex(Long postId, Integer sortIndex);
+
+    /**
+     * 특정 게시글의 이미지 중 지정된 이미지 URL을 가진 이미지를 찾습니다.
+     *
+     * @param postId 게시글 ID
+     * @param imgUrl 이미지 URL
+     * @return 조건에 맞는 이미지 목록
+     */
+    List<PostImage> findByPostIdAndImgUrl(Long postId, String imgUrl);
+
+    /**
+     * 특정 게시글의 모든 이미지를 삭제합니다.
+     *
+     * @param postId 게시글 ID
+     */
+    @Modifying
+    @Query("DELETE FROM PostImage pi WHERE pi.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
+
+    /**
+     * 특정 게시글의 이미지 수를 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @return 이미지 수
+     */
+    long countByPostId(Long postId);
+
+    /**
+     * 특정 게시글의 최대 이미지 정렬 인덱스를 조회합니다.
+     * 새 이미지 추가 시 다음 인덱스 결정에 사용됩니다.
+     *
+     * @param postId 게시글 ID
+     * @return 최대 정렬 인덱스 (결과가 없으면 null)
+     */
+    @Query("SELECT MAX(pi.sortIndex) FROM PostImage pi WHERE pi.post.id = :postId")
+    Integer findMaxSortIndexByPostId(@Param("postId") Long postId);
+
+    /**
+     * 특정 게시글의 이미지 순서를 업데이트합니다.
+     *
+     * @param id 이미지 ID
+     * @param sortIndex 새 정렬 인덱스
+     */
+    @Modifying
+    @Query("UPDATE PostImage pi SET pi.sortIndex = :sortIndex WHERE pi.id = :id")
+    void updateSortIndex(@Param("id") Long id, @Param("sortIndex") Integer sortIndex);
+
+    /**
+     * 특정 이미지 URL을 사용하는 모든 이미지를 찾습니다.
+     * S3에서 이미지 삭제 시 참조 확인에 사용됩니다.
+     *
+     * @param imgUrl 이미지 URL
+     * @return 해당 URL을 사용하는 이미지 목록
+     */
+    List<PostImage> findByImgUrl(String imgUrl);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -1,0 +1,130 @@
+package com.kakaobase.snsapp.domain.posts.repository;
+
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 게시글 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>게시글에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * 특정 회원이 작성한 게시글을 최신순으로 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 회원이 작성한 게시글 목록 (페이지네이션 적용)
+     */
+    Page<Post> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    /**
+     * 특정 회원이 작성한 특정 게시판의 게시글을 최신순으로 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param boardType 게시판 타입
+     * @param pageable 페이지네이션 정보
+     * @return 회원이 작성한 특정 게시판의 게시글 목록 (페이지네이션 적용)
+     */
+    Page<Post> findByMemberIdAndBoardTypeOrderByCreatedAtDesc(
+            Long memberId, Post.BoardType boardType, Pageable pageable);
+
+    /**
+     * 특정 게시판의 게시글을 최신순으로 조회합니다.
+     *
+     * @param boardType 게시판 타입
+     * @param pageable 페이지네이션 정보
+     * @return 특정 게시판의 게시글 목록 (페이지네이션 적용)
+     */
+    Page<Post> findByBoardTypeOrderByCreatedAtDesc(Post.BoardType boardType, Pageable pageable);
+
+    /**
+     * 게시글을 ID와 작성자 ID로 찾습니다.
+     * 주로 게시글 수정/삭제 권한 확인에 사용됩니다.
+     *
+     * @param id 게시글 ID
+     * @param memberId 회원 ID
+     * @return 조건에 맞는 게시글 (Optional)
+     */
+    Optional<Post> findByIdAndMemberId(Long id, Long memberId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 게시글 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 회원이 좋아요를 누른 게시글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT p FROM Post p JOIN PostLike pl ON p.id = pl.postId WHERE pl.memberId = :memberId ORDER BY pl.createdAt DESC")
+    Page<Post> findPostsLikedByMember(@Param("memberId") Long memberId, Pageable pageable);
+
+    /**
+     * 게시글 좋아요 수를 증가시킵니다.
+     *
+     * @param postId 게시글 ID
+     */
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :postId")
+    void increaseLikeCount(@Param("postId") Long postId);
+
+    /**
+     * 게시글 좋아요 수를 감소시킵니다.
+     *
+     * @param postId 게시글 ID
+     */
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = CASE WHEN p.likeCount > 0 THEN p.likeCount - 1 ELSE 0 END WHERE p.id = :postId")
+    void decreaseLikeCount(@Param("postId") Long postId);
+
+    /**
+     * 게시글 댓글 수를 증가시킵니다.
+     *
+     * @param postId 게시글 ID
+     */
+    @Modifying
+    @Query("UPDATE Post p SET p.commentCount = p.commentCount + 1 WHERE p.id = :postId")
+    void increaseCommentCount(@Param("postId") Long postId);
+
+    /**
+     * 게시글 댓글 수를 감소시킵니다.
+     *
+     * @param postId 게시글 ID
+     */
+    @Modifying
+    @Query("UPDATE Post p SET p.commentCount = CASE WHEN p.commentCount > 0 THEN p.commentCount - 1 ELSE 0 END WHERE p.id = :postId")
+    void decreaseCommentCount(@Param("postId") Long postId);
+
+    /**
+     * 제목이나 내용에 특정 키워드가 포함된 게시글을 검색합니다.
+     *
+     * @param keyword 검색 키워드
+     * @param pageable 페이지네이션 정보
+     * @return 검색 결과 게시글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT p FROM Post p WHERE p.content LIKE %:keyword%")
+    Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    /**
+     * 특정 게시판에서 제목이나 내용에 특정 키워드가 포함된 게시글을 검색합니다.
+     *
+     * @param boardType 게시판 타입
+     * @param keyword 검색 키워드
+     * @param pageable 페이지네이션 정보
+     * @return 검색 결과 게시글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT p FROM Post p WHERE p.boardType = :boardType AND p.content LIKE %:keyword%")
+    Page<Post> searchByBoardTypeAndKeyword(
+            @Param("boardType") Post.BoardType boardType,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+}

--- a/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
@@ -1,11 +1,10 @@
 package com.kakaobase.snsapp.global.common.s3.controller;
 
+import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
 import com.kakaobase.snsapp.global.common.s3.service.S3Service;
 import com.kakaobase.snsapp.global.common.s3.dto.PresignedUrlResponseDto;
-import com.kakaobase.snsapp.global.common.s3.exception.S3ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -74,20 +73,14 @@ public class S3Controller {
     @GetMapping("/presigned-url")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<CustomResponse<PresignedUrlResponseDto>> getPresignedUrl(
-            @Parameter(description = "업로드할 파일명", example = "profile.jpg", required = true)
             @RequestParam @NotBlank(message = "파일명은 필수입니다") String fileName,
-
-            @Parameter(description = "파일 크기 (바이트 단위)", example = "1024000", required = true)
             @RequestParam @Positive(message = "파일 크기는 0보다 커야 합니다") Long fileSize,
-
-            @Parameter(description = "파일의 MIME 타입", example = "image/jpeg", required = true)
             @RequestParam @NotBlank(message = "MIME 타입은 필수입니다") String mimeType,
-
-            @Parameter(description = "이미지 사용 용도 (profile_image, post_image 등)", example = "profile_image", required = true)
-            @RequestParam @NotBlank(message = "이미지 타입은 필수입니다") String type
+            @RequestParam @NotBlank(message = "이미지 타입은 필수입니다") String type,
+            @RequestParam(required = false) Post.BoardType boardType
     ) {
         // Presigned URL 생성 및 반환
-        PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type);
+        PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type, boardType);
 
         return ResponseEntity.ok(
                 CustomResponse.success("S3에 이미지를 업로드할 수 있도록 presigned URL을 발급했습니다.", response)

--- a/src/main/java/com/kakaobase/snsapp/global/common/s3/exception/S3ErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/s3/exception/S3ErrorCode.java
@@ -22,7 +22,7 @@ public enum S3ErrorCode implements BaseErrorCode {
 
 
     // 403 Forbidden
-    S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, "s3_access_denied", "S3 리소스에 대한 접근이 거부되었습니다.", null);s
+    S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, "s3_access_denied", "S3 리소스에 대한 접근이 거부되었습니다.", null);
 
 
     private final HttpStatus status;

--- a/src/main/java/com/kakaobase/snsapp/global/common/s3/exception/S3Exception.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/s3/exception/S3Exception.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.global.common.s3.exception;
 
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
 import com.kakaobase.snsapp.global.error.exception.CustomException;
 
 /**
@@ -17,7 +18,7 @@ public class S3Exception extends CustomException {
      *
      * @param errorCode S3 관련 에러 코드 (S3ErrorCode 열거형)
      */
-    public S3Exception(S3ErrorCode errorCode) {
+    public S3Exception(BaseErrorCode errorCode) {
         super(errorCode);
     }
 
@@ -27,7 +28,7 @@ public class S3Exception extends CustomException {
      * @param errorCode S3 관련 에러 코드 (S3ErrorCode 열거형)
      * @param field 예외가 발생한 필드
      */
-    public S3Exception(S3ErrorCode errorCode, String field) {
+    public S3Exception(BaseErrorCode errorCode, String field) {
         super(errorCode, field);
     }
 
@@ -38,7 +39,7 @@ public class S3Exception extends CustomException {
      * @param field 예외가 발생한 필드
      * @param additionalMessage 추가 오류 메시지
      */
-    public S3Exception(S3ErrorCode errorCode, String field, String additionalMessage) {
+    public S3Exception(BaseErrorCode errorCode, String field, String additionalMessage) {
         super(errorCode, field, additionalMessage);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #13 Post Post 도메인 엔티티, 레포지토리 완성

## 📌 개요
- Post도메인에 필요한 Entity, Repository구현

## 🔁 변경 사항
- 이미지 업로드시 버킷내에 유저 프로필/게시글로 나누는 디렉토리 구조를
게시글은 게시판 종류별로 디렉토리 위치에 업로드 하도록 변경
- Post Entity 생성
- PostImage Entity 생성
- PostRepository 생성
- PostImageRepository생성
- Member Entity의 @Table에 인덱싱 정보 추가
- S3Exception가 매개변수 타입을 S3ErrorCode로 받는걸 BaseErrorCode타입으로 받도록 변경

## 👀 기타 더 이야기해볼 점
현재 Entity에 @Where로 작성되어있는 걸 나중에 @Fileter로 변경해야함

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.