### PR TITLE
Feature/#18 authentication bug fix

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
@@ -60,11 +60,11 @@ public class PostController {
             throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
         }
 
-//        // 사용자 인증 정보 확인
-//        if (authentication != null && authentication.isAuthenticated() && !authentication.getPrincipal().equals("anonymousUser")) {
-//            memberId = Long.parseLong(authentication.getName());
-//            followingIds = postService.getFollowingIds(memberId);
-//        }
+        // 사용자 인증 정보 확인
+        if (authentication != null && authentication.isAuthenticated() && !authentication.getPrincipal().equals("anonymousUser")) {
+            memberId = Long.parseLong(authentication.getName());
+            //followingIds = postService.getFollowingIds(memberId);
+        }
 
         // 게시판 타입 변환
         Post.BoardType boardType = PostConverter.toBoardType(postType);
@@ -79,11 +79,11 @@ public class PostController {
                 : List.of();
 
         // 게시글별 좋아요한 사용자 목록 조회 (최대 2명)
-        Map<Long, List<String>> whoLikedMap = postService.getWhoLikedPosts(posts, 2);
+        //Map<Long, List<String>> whoLikedMap = postService.getWhoLikedPosts(posts, 2);
 
         // 응답 생성
         PostResponseDto.PostListResponse response = PostConverter.toPostListResponse(
-                posts, memberInfoMap, likedPostIds, followingIds, memberId, whoLikedMap);
+                posts, memberInfoMap, likedPostIds, followingIds, memberId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -80,8 +80,8 @@ public class PostConverter {
             Map<Long, Map<String, String>> memberInfoMap,
             List<Long> likedPostIds,
             List<Long> followingIds,
-            Long myId,
-            Map<Long, List<String>> whoLikedMap) {
+            Long myId //,Map<Long, List<String>> whoLikedMap
+            ) {
 
         List<PostResponseDto.PostListItem> items = posts.stream()
                 .map(post -> {
@@ -107,7 +107,7 @@ public class PostConverter {
                     boolean isLiked = likedPostIds.contains(post.getId());
 
                     // 좋아요 누른 사용자 목록
-                    List<String> whoLiked = whoLikedMap.getOrDefault(post.getId(), List.of());
+                    //List<String> whoLiked = whoLikedMap.getOrDefault(post.getId(), List.of());
 
                     return new PostResponseDto.PostListItem(
                             post.getId(),
@@ -119,8 +119,8 @@ public class PostConverter {
                             post.getLikeCount(),
                             post.getCommentCount(),
                             isMine,
-                            isLiked,
-                            whoLiked
+                            isLiked
+                            //whoLiked
                     );
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -119,11 +119,11 @@ public class PostResponseDto {
 
             @Schema(description = "좋아요 여부", example = "false")
             @JsonProperty("is_liked")
-            Boolean isLiked,
+            Boolean isLiked
 
-            @Schema(description = "좋아요 누른 사용자 목록", example = "[\"backend.sam\", \"choi.dan\"]")
-            @JsonProperty("who_liked")
-            List<String> whoLiked
+//            @Schema(description = "좋아요 누른 사용자 목록", example = "[\"backend.sam\", \"choi.dan\"]")
+//            @JsonProperty("who_liked")
+//            List<String> whoLiked
     ) {}
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostLike.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostLike.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.domain.posts.entity;
 
-import com.kakaobase.snsapp.global.common.entity.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @IdClass(PostLike.PostLikeId.class)
-public class PostLike extends BaseCreatedTimeEntity {
+public class PostLike {
 
     @Id
     @Column(name = "member_id", nullable = false)

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
@@ -23,7 +23,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * 특정 회원이 특정 게시글에 좋아요를 눌렀는지 확인합니다.
      *
      * @param memberId 회원 ID
-     * @param postId 게시글 ID
+     * @param postId   게시글 ID
      * @return 좋아요 정보 (Optional)
      */
     Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
@@ -32,7 +32,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * 특정 회원이 특정 게시글에 좋아요를 눌렀는지 여부를 확인합니다.
      *
      * @param memberId 회원 ID
-     * @param postId 게시글 ID
+     * @param postId   게시글 ID
      * @return 좋아요를 눌렀으면 true, 아니면 false
      */
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
@@ -51,7 +51,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * 게시글 목록 조회 시 좋아요 여부를 확인하는 데 사용됩니다.
      *
      * @param memberId 회원 ID
-     * @param posts 게시글 목록
+     * @param postIds  게시글 목록
      * @return 좋아요를 누른 게시글 ID 목록
      */
     @Query("SELECT pl.postId FROM PostLike pl WHERE pl.memberId = :memberId AND pl.postId IN :postIds")
@@ -91,14 +91,27 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * @param memberId 회원 ID
      */
     void deleteByMemberId(Long memberId);
+
     /**
-     * 특정 게시글에 좋아요를 누른 상위 N명의 회원 ID를 조회합니다.
-     * 게시글에 좋아요를 누른 사용자 목록을 표시할 때 사용됩니다.
+     * 특정 게시글에 좋아요를 누른 회원 ID를 커서 기반으로 조회합니다.
+     * 게시글에 좋아요를 누른 회원 중 활성 상태인 회원만 조회합니다.
      *
      * @param postId 게시글 ID
-     * @param limit 최대 조회할 회원 수
-     * @return 좋아요를 누른 회원 ID 목록 (최대 limit명)
+     * @param lastMemberId 마지막으로 조회한 회원 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 회원 수
+     * @return 좋아요를 누른 활성 회원 ID 목록
      */
-    @Query(value = "SELECT pl.member_id FROM posts_likes pl WHERE pl.post_id = :postId ORDER BY pl.created_at DESC LIMIT :limit", nativeQuery = true)
-    List<Long> findTopNMemberIdsByPostId(@Param("postId") Long postId, @Param("limit") int limit);
+//    @Query(value = "SELECT pl.members_id FROM post_likes pl " +
+//            "JOIN members m ON pl.members_id = m.id " +
+//            "WHERE pl.posts_id = :postId " +
+//            "AND m.deleted_at IS NULL " +
+//            "AND (:lastMemberId IS NULL OR pl.members_id < :lastMemberId) " +
+//            "ORDER BY pl.members_id DESC " +
+//            "LIMIT :limit",
+//            nativeQuery = true)
+//    List<Long> findMemberIdsByPostIdWithCursor(
+//            @Param("postId") Long postId,
+//            @Param("lastMemberId") Long lastMemberId,
+//            @Param("limit") int limit);
+
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -60,15 +60,24 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndMemberId(Long id, Long memberId);
 
     /**
-     * 특정 회원이 좋아요를 누른 게시글 목록을 조회합니다.
+     * 특정 회원이 좋아요를 누른 게시글 목록을 게시글 ID 기준으로 커서 기반 페이징으로 조회합니다.
+     * 게시글 ID 내림차순으로 조회하므로 대략적인 최신순으로 볼 수 있습니다.
      *
      * @param memberId 회원 ID
-     * @param pageable 페이지네이션 정보
-     * @return 회원이 좋아요를 누른 게시글 목록 (페이지네이션 적용)
+     * @param lastPostId 마지막으로 조회한 게시글 ID (첫 페이지에서는 null 또는 Long.MAX_VALUE)
+     * @param limit 조회할 게시글 수
+     * @return 회원이 좋아요를 누른 게시글 목록
      */
-    @Query("SELECT p FROM Post p JOIN PostLike pl ON p.id = pl.postId WHERE pl.memberId = :memberId ORDER BY pl.createdAt DESC")
-    Page<Post> findPostsLikedByMember(@Param("memberId") Long memberId, Pageable pageable);
-
+    @Query("SELECT p FROM Post p " +
+            "JOIN PostLike pl ON p.id = pl.postId " +
+            "WHERE pl.memberId = :memberId " +
+            "AND p.deletedAt IS NULL " +
+            "AND (:lastPostId IS NULL OR p.id < :lastPostId) " +
+            "ORDER BY p.id DESC")
+    List<Post> findPostsLikedByMemberWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("lastPostId") Long lastPostId,
+            @Param("limit") int limit);
     /**
      * 게시글 좋아요 수를 증가시킵니다.
      *

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
@@ -125,29 +125,29 @@ public class PostLikeService {
         return postLikeRepository.findPostIdsByMemberIdAndPostIdIn(memberId, postIds);
     }
 
-    /**
-     * 게시글에 좋아요한 사용자 닉네임 목록을 조회합니다.
-     *
-     * @param postId 게시글 ID
-     * @param limit 최대 조회 수
-     * @return 좋아요한 사용자의 닉네임 목록
-     */
-    public List<String> findWhoLikedPost(Long postId, int limit) {
-        List<Long> memberIds = postLikeRepository.findTopNMemberIdsByPostId(postId, limit);
-
-        if (memberIds.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        // 회원 정보 조회
-        Map<Long, Map<String, String>> memberInfoMap = memberService.getMemberInfoMapByIds(memberIds);
-
-        // 닉네임만 추출하여 반환
-        return memberIds.stream()
-                .map(memberId -> memberInfoMap.getOrDefault(memberId, Map.of("nickname", "알 수 없음")))
-                .map(info -> info.get("nickname"))
-                .collect(Collectors.toList());
-    }
+//    /**
+//     * 게시글에 좋아요한 사용자 닉네임 목록을 조회합니다.
+//     *
+//     * @param postId 게시글 ID
+//     * @param limit 최대 조회 수
+//     * @return 좋아요한 사용자의 닉네임 목록
+//     */
+//    public List<String> findWhoLikedPost(Long postId, int limit) {
+//        List<Long> memberIds = postLikeRepository.findTopMemberIdsByPostId(postId, limit);
+//
+//        if (memberIds.isEmpty()) {
+//            return new ArrayList<>();
+//        }
+//
+//        // 회원 정보 조회
+//        Map<Long, Map<String, String>> memberInfoMap = memberService.getMemberInfoMapByIds(memberIds);
+//
+//        // 닉네임만 추출하여 반환
+//        return memberIds.stream()
+//                .map(memberId -> memberInfoMap.getOrDefault(memberId, Map.of("nickname", "알 수 없음")))
+//                .map(info -> info.get("nickname"))
+//                .collect(Collectors.toList());
+//    }
 
     /**
      * 게시글 삭제 시 연관된 좋아요를 일괄 삭제합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -147,23 +147,23 @@ public class PostService {
         return memberService.getMemberInfoMapByIds(memberIds);
     }
 
-    /**
-     * 게시글에 좋아요한 사용자 목록을 조회합니다.
-     *
-     * @param posts 게시글 목록
-     * @param limit 조회할 사용자 수 제한
-     * @return 게시글 ID를 키로 하고 좋아요한 사용자 닉네임 목록을 값으로 하는 맵
-     */
-    public Map<Long, List<String>> getWhoLikedPosts(List<Post> posts, int limit) {
-        Map<Long, List<String>> result = new HashMap<>();
-
-        for (Post post : posts) {
-            List<String> whoLiked = postLikeService.findWhoLikedPost(post.getId(), limit);
-            result.put(post.getId(), whoLiked);
-        }
-
-        return result;
-    }
+//    /**
+//     * 게시글에 좋아요한 사용자 목록을 조회합니다.
+//     *
+//     * @param posts 게시글 목록
+//     * @param limit 조회할 사용자 수 제한
+//     * @return 게시글 ID를 키로 하고 좋아요한 사용자 닉네임 목록을 값으로 하는 맵
+//     */
+//    public Map<Long, List<String>> getWhoLikedPosts(List<Post> posts, int limit) {
+//        Map<Long, List<String>> result = new HashMap<>();
+//
+//        for (Post post : posts) {
+//            List<String> whoLiked = postLikeService.findWhoLikedPost(post.getId(), limit);
+//            result.put(post.getId(), whoLiked);
+//        }
+//
+//        return result;
+//    }
 
 //    /**
 //     * 사용자가 팔로우하는 회원 ID 목록을 조회합니다.
@@ -187,7 +187,7 @@ public class PostService {
 //    }
 //
 //    /**
-//     * 유튜브 요약 내용을 업데이트합니다.
+//     * 유튜브 요약 내용을 업데이트합니다.`
 //     *
 //     * @param postId 게시글 ID
 //     * @param summary 요약 내용

--- a/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
@@ -80,7 +80,7 @@ public class S3Controller {
             @RequestParam(required = false) Post.BoardType boardType
     ) {
         // Presigned URL 생성 및 반환
-        PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type, boardType);
+        PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type);
 
         return ResponseEntity.ok(
                 CustomResponse.success("S3에 이미지를 업로드할 수 있도록 presigned URL을 발급했습니다.", response)

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.kakaobase.snsapp.global.security.config;
 
-import com.kakaobase.snsapp.global.security.config.CustomAccessDeniedHandler;
-import com.kakaobase.snsapp.global.security.config.CustomAuthenticationEntryPoint;
 import com.kakaobase.snsapp.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,10 +2,10 @@ spring:
   application:
     name : 22-tenten-be
   datasource:
-    url: jdbc:mariadb://localhost:3306/kakaobase_db?serverTimezone=UTC&characterEncoding=UTF-8
+    url: ${MYSQL_URL}
     username: root
-    password: ' '  # 비밀번호는 XAMPP 기본값 (빈칸)
-    driver-class-name: org.mariadb.jdbc.Driver
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
@@ -65,3 +65,10 @@ logging:
     com.kakaobase.snsapp.domain.auth: DEBUG
     com.kakaobase.snsapp.domain.posts: DEBUG
     org.springframework.security: DEBUG
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui/index.html
+    url: /v3/api-docs


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #18

## 📌 개요
- 게시글 CRUD가 안되는 에러, 게시글 좋아요 안되는 에러 수정

## 🔁 변경 사항
- created_at이 없는 PostLikesEntity가 BaseCreatedAtEntity를 상속받고 있어 해당 상속을 제거
- Post Service, PostRepository 등 여러 곳에 흩어져 있던 팔로우관련 로직을 전부 주석처리 혹은 제거
- S3 공용 Controller가 Query Parameter로 BoardType을 받던 로직을 받지 않도록 수정

## 👀 기타 더 이야기해볼 점
### 에러 원인
1. 게시글 좋아요 문제
PostLike Entity가 CreatedAt컬럼이 없는데 BaseCreatedAt Entity를 상속받고 있었음
이를 제거하고 PostLikeRepo, PostRepo에서 PostLike의 CreateAt을 사용하는 쿼리 제거

2. 게시글 조회, 삭제 문제
현재 구현안된 follows에 관한 로직이 PostService, PoseRepository이곳 저곳 흩어져 있었음
예를 들어 팔로우한 유저가 게시글에 좋아요 누른 여부를 보여주는 기능,
게시글 목록조회, 게시글 상세조회에서 해당 게시글 작성자의 팔로우 여부 변수를 표시하는 등
-> 해당 관련 코드를 전부 주석처리하거나 삭제

###그외
S3공용 Controller가 S3버킷의 파일 구조를 위해 BoardType을 받고 있었음
이를 api명세대로 fileName, fileSize, mimeType, type(프로필 이미지or게시글 이미지)만 받도록 수정
다만 이를 어떻게 게시판 종류별로 디렉토링할지는 차후 고민해 봐야함

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.