### PR TITLE
[FEAT] 게시글 CRUD구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 
     //RDB
     implementation 'mysql:mysql-connector-java:8.0.33'
-    implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
     //JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.kakaobase.snsapp.domain.auth.controller;
 
 import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
 import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
+import com.kakaobase.snsapp.domain.auth.exception.AuthErrorCode;
+import com.kakaobase.snsapp.domain.auth.exception.AuthException;
 import com.kakaobase.snsapp.domain.auth.service.UserAuthenticationService;
 import com.kakaobase.snsapp.domain.auth.util.CookieUtil;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
@@ -105,6 +107,11 @@ public class AuthController {
 
         // 쿠키에서 리프레시 토큰 추출
         String refreshToken = cookieUtil.extractRefreshTokenFromCookie(httpRequest);
+
+        // 리프레시 토큰이 없으면 예외 발생
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISSING);
+        }
 
         // 액세스 토큰 재발급
         String newAccessToken = userAuthenticationService.refreshAuthentication(refreshToken);

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.auth.principal;
 
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -13,12 +14,12 @@ import java.util.Collections;
  * Spring Security의 UserDetails 인터페이스를 구현한 사용자 인증 정보 클래스입니다.
  * 인증된 사용자의 정보와 권한을 캡슐화합니다.
  */
+@Slf4j
 @Getter
 public class CustomUserDetails implements UserDetails {
 
     private final Member member;
     private final String id;
-    private final String username;
     private final String role;
     private final String className;
     private final boolean isBanned;
@@ -31,7 +32,6 @@ public class CustomUserDetails implements UserDetails {
     public CustomUserDetails(Member member) {
         this.member = member;
         this.id = member.getId().toString();
-        this.username = member.getEmail();
         this.role = member.getRole();
         this.className = member.getClassName();
         this.isBanned = member.getIsBanned();
@@ -58,13 +58,14 @@ public class CustomUserDetails implements UserDetails {
     }
 
     /**
-     * 사용자의 식별자를 반환합니다. 여기서는 이메일을 사용합니다.
+     * 사용자의 식별자를 반환합니다. memberId를 반환합니다.
      *
-     * @return 사용자 식별자 (이메일)
+     * @return 사용자 식별자 (memberid)
      */
     @Override
     public String getUsername() {
-        return username;
+        log.debug("CustomUserDetails.getUsername() 호출: {}", id);
+        return String.valueOf(member.getId());
     }
 
     /**
@@ -105,7 +106,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         // 삭제 여부와 밴 여부를 함께 확인
-        return !member.isDeleted() && member.getIsBanned();
+        return !member.isDeleted() && !member.getIsBanned();
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/members/entity/Member.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/entity/Member.java
@@ -9,7 +9,7 @@ import org.hibernate.annotations.*;
 
 @Entity
 @Table(
-        name = "member",
+        name = "members",
         indexes = {
                 @Index(name = "idx_email_not_deleted", columnList = "email, deleted_at"),
                 @Index(name = "idx_nickname_not_deleted", columnList = "nickname, deleted_at"),

--- a/src/main/java/com/kakaobase/snsapp/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/repository/MemberRepository.java
@@ -85,4 +85,43 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      */
     @Query("SELECT m FROM Member m WHERE m.id = :id")
     Optional<Member> findProfileById(@Param("id") Long id);
+
+    /**
+     * 여러 회원 ID로 회원 목록을 조회합니다.
+     * 게시글 목록 조회 시 여러 작성자 정보를 한 번에 가져오는 데 사용됩니다.
+     *
+     * @param ids 조회할 회원 ID 목록
+     * @return 조회된 회원 엔티티 목록
+     */
+    List<Member> findAllByIdIn(List<Long> ids);
+
+    /**
+     * 닉네임 일부로 회원을 검색하고 결과 수를 제한합니다.
+     * 회원 검색 기능에 사용되며, 대소문자를 구분하지 않고 일부만 일치해도 결과에 포함됩니다.
+     *
+     * @param nickname 검색할 닉네임 문자열 (부분 일치)
+     * @param limit 최대 결과 수
+     * @return 검색된 회원 엔티티 목록 (최대 limit개)
+     */
+    @Query("SELECT m FROM Member m WHERE LOWER(m.nickname) LIKE LOWER(CONCAT('%', :nickname, '%')) ORDER BY m.nickname ASC LIMIT :limit")
+    List<Member> findByNicknameContainingLimit(String nickname, int limit);
+
+    /**
+     * 정확한 닉네임으로 회원을 조회합니다.
+     * 특정 닉네임을 가진 회원의 정보가 필요할 때 사용됩니다.
+     *
+     * @param nickname 조회할 정확한 닉네임
+     * @return 조회된 회원 엔티티 (Optional)
+     */
+    Optional<Member> findByNickname(String nickname);
+
+    /**
+     * 여러 닉네임으로 회원 목록을 조회합니다.
+     * 여러 닉네임에 해당하는 회원 정보를 한 번에 가져오는 데 사용됩니다.
+     * 주로 'who_liked' 목록 처리 시 닉네임 목록을 ID로 변환할 때 활용됩니다.
+     *
+     * @param nicknames 조회할 닉네임 목록
+     * @return 조회된 회원 엔티티 목록
+     */
+    List<Member> findAllByNicknameIn(List<String> nicknames);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -7,11 +7,15 @@ import com.kakaobase.snsapp.domain.members.exception.MemberErrorCode;
 import com.kakaobase.snsapp.domain.members.exception.MemberException;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
-import com.kakaobase.snsapp.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 회원 관련 비즈니스 로직을 처리하는 서비스입니다.
@@ -50,5 +54,117 @@ public class MemberService {
         memberRepository.save(member);
 
         log.info("회원가입 완료: {} (ID: {})", request.email(), member.getId());
+    }
+
+    /**
+     * 회원 ID로 회원 정보를 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 회원 정보 (닉네임, 프로필 이미지)
+     * @throws MemberException 회원을 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public Map<String, String> getMemberInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND, "memberId"));
+
+        Map<String, String> memberInfo = new HashMap<>();
+        memberInfo.put("nickname", member.getNickname());
+        memberInfo.put("imageUrl", member.getProfileImgUrl());
+
+        return memberInfo;
+    }
+
+    /**
+     * 여러 회원 ID에 대한 회원 정보를 일괄 조회합니다.
+     *
+     * @param memberIds 회원 ID 목록
+     * @return 회원 ID를 키로 하고 회원 정보(닉네임, 프로필 이미지)를 값으로 하는 맵
+     */
+    @Transactional(readOnly = true)
+    public Map<Long, Map<String, String>> getMemberInfoMapByIds(List<Long> memberIds) {
+        List<Member> members = memberRepository.findAllByIdIn(memberIds);
+
+        return members.stream()
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        member -> {
+                            Map<String, String> info = new HashMap<>();
+                            info.put("nickname", member.getNickname());
+                            info.put("imageUrl", member.getProfileImgUrl());
+                            return info;
+                        }
+                ));
+    }
+
+    /**
+     * 닉네임으로 회원을 검색합니다.
+     *
+     * @param nickname 검색할 닉네임 (부분 일치)
+     * @param limit 최대 검색 결과 수
+     * @return 검색된 회원 ID 목록
+     */
+    @Transactional(readOnly = true)
+    public List<Long> searchMembersByNickname(String nickname, int limit) {
+        return memberRepository.findByNicknameContainingLimit(nickname, limit)
+                .stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 닉네임으로 회원을 조회합니다.
+     *
+     * @param nickname 닉네임 (정확히 일치)
+     * @return 회원 ID (없으면 null)
+     */
+    @Transactional(readOnly = true)
+    public Long findIdByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname)
+                .map(Member::getId)
+                .orElse(null);
+    }
+
+    /**
+     * 여러 닉네임에 대한 회원 ID를 일괄 조회합니다.
+     *
+     * @param nicknames 닉네임 목록
+     * @return 닉네임을 키로 하고 회원 ID를 값으로 하는 맵
+     */
+    @Transactional(readOnly = true)
+    public Map<String, Long> getMemberIdsByNicknames(List<String> nicknames) {
+        List<Member> members = memberRepository.findAllByNicknameIn(nicknames);
+
+        return members.stream()
+                .collect(Collectors.toMap(
+                        Member::getNickname,
+                        Member::getId
+                ));
+    }
+
+    /**
+     * 회원의 className(기수)을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 회원의 className
+     * @throws MemberException 회원을 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public String getMemberClassName(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND, "memberId"));
+
+        return member.getClassName();
+    }
+
+    /**
+     * 회원이 존재하는지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 존재 여부
+     */
+    @Transactional(readOnly = true)
+    public boolean existsById(Long memberId) {
+        return memberRepository.existsById(memberId);
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
@@ -1,0 +1,242 @@
+package com.kakaobase.snsapp.domain.posts.controller;
+
+import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
+import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
+import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.exception.PostErrorCode;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.domain.posts.service.PostLikeService;
+import com.kakaobase.snsapp.domain.posts.service.PostService;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import com.kakaobase.snsapp.global.security.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 게시글 관련 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/posts")
+@RequiredArgsConstructor
+@Tag(name = "게시글 API", description = "게시글 CRUD 및 좋아요 기능을 제공하는 API")
+public class PostController {
+
+    private final PostService postService;
+    private final PostLikeService postLikeService;
+
+    /**
+     * 게시글 목록을 조회합니다.
+     * 커서 기반 페이지네이션을 적용합니다.
+     */
+    @GetMapping("/{postType}")
+    @Operation(summary = "게시글 목록 조회", description = "게시판 유형별로 게시글 목록을 조회합니다.")
+    @PreAuthorize("@accessChecker.hasAccessToBoard(#postType)")
+    public ResponseEntity<PostResponseDto.PostListResponse> getPosts(
+            @Parameter(description = "게시판 유형") @PathVariable String postType,
+            @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
+            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = null;
+        List<Long> followingIds = List.of();
+
+        // 유효성 검증
+        if (limit < 1) {
+            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
+        }
+
+//        // 사용자 인증 정보 확인
+//        if (authentication != null && authentication.isAuthenticated() && !authentication.getPrincipal().equals("anonymousUser")) {
+//            memberId = Long.parseLong(authentication.getName());
+//            followingIds = postService.getFollowingIds(memberId);
+//        }
+
+        // 게시판 타입 변환
+        Post.BoardType boardType = PostConverter.toBoardType(postType);
+
+        // 커서 기반 페이지네이션 조회
+        List<Post> posts = postService.findByCursor(boardType, limit, cursor);
+
+        // 회원 정보 및 좋아요 정보 조회
+        Map<Long, Map<String, String>> memberInfoMap = postService.getMemberInfoByPosts(posts);
+        List<Long> likedPostIds = memberId != null
+                ? postLikeService.findLikedPostIdsByMember(memberId, posts)
+                : List.of();
+
+        // 게시글별 좋아요한 사용자 목록 조회 (최대 2명)
+        Map<Long, List<String>> whoLikedMap = postService.getWhoLikedPosts(posts, 2);
+
+        // 응답 생성
+        PostResponseDto.PostListResponse response = PostConverter.toPostListResponse(
+                posts, memberInfoMap, likedPostIds, followingIds, memberId, whoLikedMap);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 게시글 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{postType}/{postId}")
+    @Operation(summary = "게시글 상세 조회", description = "게시글의 상세 정보를 조회합니다.")
+    @PreAuthorize("@accessChecker.hasAccessToBoard(#postType)")
+    public ResponseEntity<PostResponseDto.PostDetailResponse> getPostDetail(
+            @Parameter(description = "게시판 유형") @PathVariable String postType,
+            @Parameter(description = "게시글 ID") @PathVariable Long postId) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = null;
+        boolean isFollowing = false;
+
+        // 사용자 인증 정보 확인
+        if (authentication != null && authentication.isAuthenticated() && !authentication.getPrincipal().equals("anonymousUser")) {
+            memberId = Long.parseLong(authentication.getName());
+        }
+
+        // 게시글 조회
+        Post post = postService.findById(postId);
+
+        // 게시판 타입 검증
+        Post.BoardType boardType = PostConverter.toBoardType(postType);
+        if (!post.getBoardType().equals(boardType)) {
+            throw new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postId", "요청한 게시판에 해당 게시글이 존재하지 않습니다.");
+        }
+
+        // 작성자 정보 조회
+        Map<String, String> userInfo = postService.getMemberInfo(post.getMemberId());
+
+        // 본인 게시글 여부, 좋아요 여부, 팔로우 여부 확인
+        boolean isMine = memberId != null && memberId.equals(post.getMemberId());
+        boolean isLiked = memberId != null && postLikeService.isLikedByMember(postId, memberId);
+
+//        // 팔로우 여부 확인
+//        if (memberId != null && !isMine) {
+//            isFollowing = postService.isFollowing(memberId, post.getMemberId());
+//        }
+
+        // 응답 생성
+        PostResponseDto.PostDetailResponse response = PostConverter.toPostDetailResponse(
+                post, userInfo, isMine, isLiked, isFollowing);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 새 게시글을 생성합니다.
+     */
+    @PostMapping("/{postType}")
+    @Operation(summary = "게시글 생성", description = "새 게시글을 생성합니다.")
+    @PreAuthorize("isAuthenticated() && @accessChecker.hasAccessToBoard(#postType)")
+    public ResponseEntity<PostResponseDto.PostCreateResponse> createPost(
+            @Parameter(description = "게시판 유형") @PathVariable String postType,
+            @Valid @RequestBody PostRequestDto.PostCreateRequestDto requestDto) {
+
+        // SecurityUtil 사용하여 ID 가져오기 - 이 시점에서는 인증된 사용자임이 보장됨
+        Long memberId = SecurityUtil.getMemberIdAsLong()
+                .orElseThrow(() -> new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "memberId", "memberId를 찾을 수 없습니다"));
+
+
+        // 게시글 내용 유효성 검증
+        if (requestDto.isEmpty()) {
+            throw new PostException(PostErrorCode.EMPTY_POST_CONTENT);
+        }
+
+        // 유튜브 URL 유효성 검증
+        if (!requestDto.isValidYoutubeUrl()) {
+            throw new PostException(PostErrorCode.INVALID_YOUTUBE_URL);
+        }
+
+        // 게시판 타입 변환
+        Post.BoardType boardType = PostConverter.toBoardType(postType);
+
+        // 게시글 생성
+        Post createdPost = postService.createPost(boardType, requestDto, memberId);
+
+        // 작성자 정보 조회
+        Map<String, String> userInfo = postService.getMemberInfo(memberId);
+
+        // 응답 생성
+        PostResponseDto.PostCreateResponse response = PostConverter.toPostCreateResponse(
+                createdPost, userInfo, false);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 게시글을 삭제합니다.
+     */
+    @DeleteMapping("/{postType}/{postId}")
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+    @PreAuthorize("@accessChecker.hasAccessToBoard(#postType) and @accessChecker.isPostOwner(#postId, authentication)")
+    public ResponseEntity<PostResponseDto.PostDeleteResponse> deletePost(
+            @Parameter(description = "게시판 유형") @PathVariable String postType,
+            @Parameter(description = "게시글 ID") @PathVariable Long postId) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = Long.parseLong(authentication.getName());
+
+        // 게시글 삭제
+        postService.deletePost(postId, memberId);
+
+        // 응답 생성
+        PostResponseDto.PostDeleteResponse response = PostConverter.toPostDeleteResponse();
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 게시글에 좋아요를 추가합니다.
+     */
+    @PostMapping("/{postId}/likes")
+    @Operation(summary = "게시글 좋아요 추가", description = "게시글에 좋아요를 추가합니다.")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PostResponseDto.PostLikeResponse> addLike(
+            @Parameter(description = "게시글 ID") @PathVariable Long postId) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = Long.parseLong(authentication.getName());
+
+        // 좋아요 추가
+        postLikeService.addLike(postId, memberId);
+
+        // 응답 생성
+        PostResponseDto.PostLikeResponse response = PostConverter.toPostLikeResponse(true);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 게시글 좋아요를 취소합니다.
+     */
+    @DeleteMapping("/{postId}/likes")
+    @Operation(summary = "게시글 좋아요 취소", description = "게시글 좋아요를 취소합니다.")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PostResponseDto.PostLikeResponse> removeLike(
+            @Parameter(description = "게시글 ID") @PathVariable Long postId) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long memberId = Long.parseLong(authentication.getName());
+
+        // 좋아요 취소
+        postLikeService.removeLike(postId, memberId);
+
+        // 응답 생성
+        PostResponseDto.PostLikeResponse response = PostConverter.toPostLikeResponse(false);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
@@ -60,11 +60,11 @@ public class PostController {
             throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
         }
 
-//        // 사용자 인증 정보 확인
-//        if (authentication != null && authentication.isAuthenticated() && !authentication.getPrincipal().equals("anonymousUser")) {
-//            memberId = Long.parseLong(authentication.getName());
-//            followingIds = postService.getFollowingIds(memberId);
-//        }
+        // 사용자 인증 정보 확인
+        if (authentication != null && authentication.isAuthenticated() && !authentication.getPrincipal().equals("anonymousUser")) {
+            memberId = Long.parseLong(authentication.getName());
+            //followingIds = postService.getFollowingIds(memberId);
+        }
 
         // 게시판 타입 변환
         Post.BoardType boardType = PostConverter.toBoardType(postType);
@@ -79,11 +79,11 @@ public class PostController {
                 : List.of();
 
         // 게시글별 좋아요한 사용자 목록 조회 (최대 2명)
-        Map<Long, List<String>> whoLikedMap = postService.getWhoLikedPosts(posts, 2);
+        //Map<Long, List<String>> whoLikedMap = postService.getWhoLikedPosts(posts, 2);
 
         // 응답 생성
         PostResponseDto.PostListResponse response = PostConverter.toPostListResponse(
-                posts, memberInfoMap, likedPostIds, followingIds, memberId, whoLikedMap);
+                posts, memberInfoMap, likedPostIds, followingIds, memberId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -1,0 +1,246 @@
+package com.kakaobase.snsapp.domain.posts.converter;
+
+import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.entity.PostImage;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Post 도메인의 Entity와 DTO 간 변환을 담당하는 Converter 클래스
+ */
+public class PostConverter {
+
+    /**
+     * Post 엔티티를 상세 응답 DTO로 변환합니다.
+     *
+     * @param post 게시글 엔티티
+     * @param userInfo 작성자 정보 (닉네임, 프로필 이미지 등)
+     * @param isMine 본인 게시글 여부
+     * @param isLiked 좋아요 여부
+     * @param isFollowing 작성자 팔로우 여부
+     * @return 게시글 상세 응답 DTO
+     */
+    public static PostResponseDto.PostDetailResponse toPostDetailResponse(
+            Post post,
+            Map<String, String> userInfo,
+            boolean isMine,
+            boolean isLiked,
+            boolean isFollowing) {
+
+        // 사용자 정보 생성
+        PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
+                post.getMemberId(),
+                userInfo.getOrDefault("nickname", "알 수 없음"),
+                userInfo.getOrDefault("imageUrl", null),
+                isFollowing
+        );
+
+        // 이미지 URL 가져오기 (첫 번째 이미지만 사용)
+        String imageUrl = post.getImages().stream()
+                .min((i1, i2) -> Integer.compare(i1.getSortIndex(), i2.getSortIndex()))
+                .map(PostImage::getImgUrl)
+                .orElse(null);
+
+        // 상세 정보 생성
+        PostResponseDto.PostDetail data = new PostResponseDto.PostDetail(
+                post.getId(),
+                user,
+                post.getContent(),
+                imageUrl,
+                post.getYoutubeUrl(),
+                post.getYoutubeSummary(),
+                post.getCreatedAt(),
+                post.getLikeCount(),
+                post.getCommentCount(),
+                isMine,
+                isLiked
+        );
+
+        return new PostResponseDto.PostDetailResponse(
+                "게시글 상세 정보를 불러왔습니다.",
+                data
+        );
+    }
+
+    /**
+     * Post 엔티티 목록을 목록 응답 DTO로 변환합니다.
+     *
+     * @param posts 게시글 엔티티 목록
+     * @param memberInfoMap 회원 정보 맵 (회원 ID -> 맵(닉네임, 프로필 이미지))
+     * @param likedPostIds 좋아요한 게시글 ID 목록
+     * @param followingIds 팔로우 중인 사용자 ID 목록
+     * @param myId 현재 로그인한 사용자 ID
+     * @param whoLikedMap 게시글별 좋아요 누른 사용자 목록 맵 (게시글 ID -> 닉네임 목록)
+     * @return 게시글 목록 응답 DTO
+     */
+    public static PostResponseDto.PostListResponse toPostListResponse(
+            List<Post> posts,
+            Map<Long, Map<String, String>> memberInfoMap,
+            List<Long> likedPostIds,
+            List<Long> followingIds,
+            Long myId,
+            Map<Long, List<String>> whoLikedMap) {
+
+        List<PostResponseDto.PostListItem> items = posts.stream()
+                .map(post -> {
+                    Map<String, String> userInfo = memberInfoMap.getOrDefault(
+                            post.getMemberId(),
+                            Map.of("nickname", "알 수 없음", "imageUrl", null)
+                    );
+
+                    PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
+                            post.getMemberId(),
+                            userInfo.getOrDefault("nickname", "알 수 없음"),
+                            userInfo.getOrDefault("imageUrl", null),
+                            followingIds.contains(post.getMemberId())
+                    );
+
+                    // 이미지 URL 가져오기 (첫 번째 이미지만 사용)
+                    String imageUrl = post.getImages().stream()
+                            .min((i1, i2) -> Integer.compare(i1.getSortIndex(), i2.getSortIndex()))
+                            .map(PostImage::getImgUrl)
+                            .orElse(null);
+
+                    boolean isMine = myId != null && myId.equals(post.getMemberId());
+                    boolean isLiked = likedPostIds.contains(post.getId());
+
+                    // 좋아요 누른 사용자 목록
+                    List<String> whoLiked = whoLikedMap.getOrDefault(post.getId(), List.of());
+
+                    return new PostResponseDto.PostListItem(
+                            post.getId(),
+                            user,
+                            post.getContent(),
+                            imageUrl,
+                            post.getYoutubeUrl(),
+                            post.getCreatedAt(),
+                            post.getLikeCount(),
+                            post.getCommentCount(),
+                            isMine,
+                            isLiked,
+                            whoLiked
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new PostResponseDto.PostListResponse(
+                "게시글을 불러오는데 성공하였습니다",
+                items
+        );
+    }
+
+    /**
+     * Post 엔티티를 생성 응답 DTO로 변환합니다.
+     *
+     * @param post 생성된 게시글 엔티티
+     * @param userInfo 작성자 정보 (닉네임, 프로필 이미지 등)
+     * @param isFollowing 작성자 팔로우 여부
+     * @return 게시글 생성 응답 DTO
+     */
+    public static PostResponseDto.PostCreateResponse toPostCreateResponse(
+            Post post,
+            Map<String, String> userInfo,
+            boolean isFollowing) {
+
+        // 사용자 정보 생성
+        PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
+                post.getMemberId(),
+                userInfo.getOrDefault("nickname", "알 수 없음"),
+                userInfo.getOrDefault("imageUrl", null),
+                isFollowing
+        );
+
+        // 이미지 URL 가져오기 (첫 번째 이미지만 사용)
+        String imageUrl = post.getImages().stream()
+                .min((i1, i2) -> Integer.compare(i1.getSortIndex(), i2.getSortIndex()))
+                .map(PostImage::getImgUrl)
+                .orElse(null);
+
+        // 상세 정보 생성
+        PostResponseDto.PostDetail data = new PostResponseDto.PostDetail(
+                post.getId(),
+                user,
+                post.getContent(),
+                imageUrl,
+                post.getYoutubeUrl(),
+                post.getYoutubeSummary(),
+                post.getCreatedAt(),
+                post.getLikeCount(),
+                post.getCommentCount(),
+                true, // 본인 게시글이므로 true
+                false // 생성 시점에는 좋아요를 누르지 않았으므로 false
+        );
+
+        return new PostResponseDto.PostCreateResponse(
+                "게시글이 작성되었습니다.",
+                data
+        );
+    }
+
+    /**
+     * 게시글 삭제 응답 DTO를 생성합니다.
+     *
+     * @return 게시글 삭제 응답 DTO
+     */
+    public static PostResponseDto.PostDeleteResponse toPostDeleteResponse() {
+        return new PostResponseDto.PostDeleteResponse(
+                "게시글이 삭제되었습니다.",
+                null
+        );
+    }
+
+    /**
+     * 게시글 좋아요 응답 DTO를 생성합니다.
+     *
+     * @param isAdd 좋아요 추가 여부 (true: 추가, false: 취소)
+     * @return 게시글 좋아요 응답 DTO
+     */
+    public static PostResponseDto.PostLikeResponse toPostLikeResponse(boolean isAdd) {
+        String message = isAdd
+                ? "좋아요가 성공적으로 등록되었습니다."
+                : "좋아요가 성공적으로 취소되었습니다.";
+
+        return new PostResponseDto.PostLikeResponse(
+                message,
+                null
+        );
+    }
+
+    /**
+     * 문자열 형태의 postType을 BoardType enum으로 변환합니다.
+     *
+     * @param postType 게시판 타입 문자열
+     * @return BoardType enum 값
+     * @throws IllegalArgumentException 유효하지 않은 postType인 경우
+     */
+    public static Post.BoardType toBoardType(String postType) {
+        try {
+            if ("all".equalsIgnoreCase(postType)) {
+                return Post.BoardType.ALL;
+            }
+
+            // snake_case를 대문자와 underscore로 변환 (pangyo_1 -> PANGYO_1)
+            String enumFormat = postType.toUpperCase();
+            return Post.BoardType.valueOf(enumFormat);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 게시판 타입입니다: " + postType);
+        }
+    }
+
+    /**
+     * BoardType enum을 문자열 형태의 postType으로 변환합니다.
+     *
+     * @param boardType BoardType enum 값
+     * @return 게시판 타입 문자열
+     */
+    public static String toPostType(Post.BoardType boardType) {
+        if (boardType == Post.BoardType.ALL) {
+            return "all";
+        }
+
+        // 대문자와 underscore를 snake_case로 변환 (PANGYO_1 -> pangyo_1)
+        return boardType.name().toLowerCase();
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -32,8 +32,8 @@ public class PostConverter {
         // 사용자 정보 생성
         PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
                 post.getMemberId(),
-                userInfo.getOrDefault("nickname", "알 수 없음"),
-                userInfo.getOrDefault("imageUrl", null),
+                userInfo.get("nickname"),
+                userInfo.get("imageUrl"),
                 isFollowing
         );
 
@@ -72,7 +72,6 @@ public class PostConverter {
      * @param likedPostIds 좋아요한 게시글 ID 목록
      * @param followingIds 팔로우 중인 사용자 ID 목록
      * @param myId 현재 로그인한 사용자 ID
-     * @param whoLikedMap 게시글별 좋아요 누른 사용자 목록 맵 (게시글 ID -> 닉네임 목록)
      * @return 게시글 목록 응답 DTO
      */
     public static PostResponseDto.PostListResponse toPostListResponse(
@@ -80,20 +79,22 @@ public class PostConverter {
             Map<Long, Map<String, String>> memberInfoMap,
             List<Long> likedPostIds,
             List<Long> followingIds,
-            Long myId,
-            Map<Long, List<String>> whoLikedMap) {
+            Long myId //,Map<Long, List<String>> whoLikedMap
+            ) {
 
         List<PostResponseDto.PostListItem> items = posts.stream()
                 .map(post -> {
-                    Map<String, String> userInfo = memberInfoMap.getOrDefault(
-                            post.getMemberId(),
-                            Map.of("nickname", "알 수 없음", "imageUrl", null)
-                    );
+                    Map<String, String> userInfo = memberInfoMap.get(post.getMemberId());
+                    if (userInfo == null) {
+                        // 서비스 레이어에서 memberInfoMap 구성 시 모든 회원 정보가 포함되어야 함
+                        // 여기서 NullPointerException이 발생하면 서비스 레이어의 문제
+                        throw new IllegalStateException("사용자 정보를 찾을 수 없습니다: " + post.getMemberId());
+                    }
 
                     PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
                             post.getMemberId(),
-                            userInfo.getOrDefault("nickname", "알 수 없음"),
-                            userInfo.getOrDefault("imageUrl", null),
+                            userInfo.get("nickname"),
+                            userInfo.get("imageUrl"),
                             followingIds.contains(post.getMemberId())
                     );
 
@@ -106,9 +107,6 @@ public class PostConverter {
                     boolean isMine = myId != null && myId.equals(post.getMemberId());
                     boolean isLiked = likedPostIds.contains(post.getId());
 
-                    // 좋아요 누른 사용자 목록
-                    List<String> whoLiked = whoLikedMap.getOrDefault(post.getId(), List.of());
-
                     return new PostResponseDto.PostListItem(
                             post.getId(),
                             user,
@@ -119,8 +117,7 @@ public class PostConverter {
                             post.getLikeCount(),
                             post.getCommentCount(),
                             isMine,
-                            isLiked,
-                            whoLiked
+                            isLiked
                     );
                 })
                 .collect(Collectors.toList());
@@ -147,8 +144,8 @@ public class PostConverter {
         // 사용자 정보 생성
         PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
                 post.getMemberId(),
-                userInfo.getOrDefault("nickname", "알 수 없음"),
-                userInfo.getOrDefault("imageUrl", null),
+                userInfo.get("nickname"),
+                userInfo.get("imageUrl"),
                 isFollowing
         );
 
@@ -236,11 +233,6 @@ public class PostConverter {
      * @return 게시판 타입 문자열
      */
     public static String toPostType(Post.BoardType boardType) {
-        if (boardType == Post.BoardType.ALL) {
-            return "all";
-        }
-
-        // 대문자와 underscore를 snake_case로 변환 (PANGYO_1 -> pangyo_1)
         return boardType.name().toLowerCase();
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostRequestDto.java
@@ -1,0 +1,85 @@
+package com.kakaobase.snsapp.domain.posts.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 게시글 도메인의 요청 DTO를 관리하는 통합 클래스
+ */
+public class PostRequestDto {
+
+    /**
+     * 게시글 생성 요청 DTO
+     */
+    @Schema(description = "게시글 생성 요청")
+    public record PostCreateRequestDto(
+            @Schema(description = "게시글 본문", example = "오늘도 열심히 개발 중입니다!", maxLength = 2000)
+            @Size(max = 2000, message = "게시글 본문은 최대 2000자까지 작성할 수 있습니다.")
+            String content,
+
+            @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/bucket/uploads/dev.jpg", required = false)
+            String image_url,
+
+            @Schema(description = "유튜브 URL", example = "https://www.youtube.com/watch?v=abcd1234", required = false)
+            String youtube_url
+    ) {
+        /**
+         * 게시글 내용이 비어있는지 검증합니다.
+         * 내용, 이미지, 유튜브 링크 중 하나는 반드시 존재해야 합니다.
+         *
+         * @return 내용이 비어있으면 true, 아니면 false
+         */
+        public boolean isEmpty() {
+            return (content == null || content.trim().isEmpty())
+                    && (image_url == null || image_url.trim().isEmpty())
+                    && (youtube_url == null || youtube_url.trim().isEmpty());
+        }
+
+        /**
+         * 유튜브 URL이 유효한지 검증합니다.
+         *
+         * @return 유효하면 true, 아니면 false
+         */
+        public boolean isValidYoutubeUrl() {
+            if (youtube_url == null || youtube_url.trim().isEmpty()) {
+                return true; // 빈 값은 유효하다고 처리
+            }
+
+            // 유튜브 URL 형식 검증 (youtube.com 또는 youtu.be 도메인 확인)
+            return youtube_url.contains("youtube.com") || youtube_url.contains("youtu.be");
+        }
+    }
+
+    /**
+     * 게시글 검색 요청 DTO
+     */
+    @Schema(description = "게시글 검색 요청")
+    public record PostSearchRequestDto(
+            @Schema(description = "한 페이지에 표시할 게시글 수", example = "12", defaultValue = "12")
+            Integer limit,
+
+            @Schema(description = "마지막으로 조회한 게시글 ID (다음 페이지 요청 시)", example = "123")
+            Long cursor,
+
+            @Schema(description = "마지막으로 조회한 게시글 생성일시 (다음 페이지 요청 시)", example = "2024-04-23T10:00:00Z")
+            String created_at
+    ) {}
+
+    /**
+     * 이미지 URL 요청 DTO (S3 Presigned URL 발급 요청 시 사용)
+     */
+    @Schema(description = "이미지 업로드 URL 요청")
+    public record ImageUrlRequestDto(
+            @Schema(description = "파일명", example = "profile.jpg", required = true)
+            @NotBlank(message = "파일명은 필수입니다")
+            String filename,
+
+            @Schema(description = "파일 크기(바이트)", example = "1024000", required = true)
+            Long size,
+
+            @Schema(description = "파일 MIME 타입", example = "image/jpeg", required = true)
+            @NotBlank(message = "MIME 타입은 필수입니다")
+            String mime_type
+    ) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -1,0 +1,184 @@
+package com.kakaobase.snsapp.domain.posts.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 게시글 도메인의 응답 DTO를 관리하는 통합 클래스
+ */
+public class PostResponseDto {
+
+    /**
+     * 게시글 상세 정보 응답 DTO
+     */
+    @Schema(description = "게시글 상세 정보 응답")
+    public record PostDetailResponse(
+            @Schema(description = "응답 메시지", example = "게시글 상세 정보를 불러왔습니다.")
+            String message,
+
+            @Schema(description = "응답 데이터")
+            PostDetail data
+    ) {}
+
+    @Schema(description = "게시글 상세 정보")
+    public record PostDetail(
+            @Schema(description = "게시글 ID", example = "123")
+            Long id,
+
+            @Schema(description = "작성자 정보")
+            UserInfo user,
+
+            @Schema(description = "게시글 내용", example = "오늘도 Typescript 공부 중입니다.")
+            String content,
+
+            @Schema(description = "이미지 URL", example = "https://s3.../uploads/dev.jpg")
+            @JsonProperty("image_url")
+            String imageUrl,
+
+            @Schema(description = "유튜브 URL", example = "https://www.youtube.com/watch?v=abcd1234")
+            @JsonProperty("youtube_url")
+            String youtubeUrl,
+
+            @Schema(description = "유튜브 요약", example = "이 영상은 타입스크립트의 제네릭에 대해 설명합니다.")
+            @JsonProperty("youtube_summary")
+            String youtubeSummary,
+
+            @Schema(description = "생성 시간", example = "2024-04-23T12:34:56Z")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+            @JsonProperty("created_at")
+            LocalDateTime createdAt,
+
+            @Schema(description = "좋아요 수", example = "5")
+            @JsonProperty("like_count")
+            Integer likeCount,
+
+            @Schema(description = "댓글 수", example = "12")
+            @JsonProperty("comment_count")
+            Integer commentCount,
+
+            @Schema(description = "본인 게시글 여부", example = "true")
+            @JsonProperty("is_mine")
+            Boolean isMine,
+
+            @Schema(description = "좋아요 여부", example = "true")
+            @JsonProperty("is_liked")
+            Boolean isLiked
+    ) {}
+
+    /**
+     * 게시글 목록 조회 응답 DTO
+     */
+    @Schema(description = "게시글 목록 조회 응답")
+    public record PostListResponse(
+            @Schema(description = "응답 메시지", example = "게시글을 불러오는데 성공하였습니다")
+            String message,
+
+            @Schema(description = "게시글 목록 데이터")
+            List<PostListItem> data
+    ) {}
+
+    @Schema(description = "게시글 목록 아이템")
+    public record PostListItem(
+            @Schema(description = "게시글 ID", example = "123")
+            Long id,
+
+            @Schema(description = "작성자 정보")
+            UserInfo user,
+
+            @Schema(description = "게시글 내용", example = "이벤트 버블링 헷갈릴 때는...")
+            String content,
+
+            @Schema(description = "이미지 URL", example = "https://s3.../event-tip.png")
+            @JsonProperty("image_url")
+            String imageUrl,
+
+            @Schema(description = "유튜브 URL", example = "https://www.youtube.com/watch?v=abcd1234")
+            @JsonProperty("youtube_url")
+            String youtubeUrl,
+
+            @Schema(description = "생성 시간", example = "2024-04-23T10:00:00Z")
+            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
+            @JsonProperty("created_at")
+            LocalDateTime createdAt,
+
+            @Schema(description = "좋아요 수", example = "5")
+            @JsonProperty("like_count")
+            Integer likeCount,
+
+            @Schema(description = "댓글 수", example = "2")
+            @JsonProperty("comment_count")
+            Integer commentCount,
+
+            @Schema(description = "본인 게시글 여부", example = "true")
+            @JsonProperty("is_mine")
+            Boolean isMine,
+
+            @Schema(description = "좋아요 여부", example = "false")
+            @JsonProperty("is_liked")
+            Boolean isLiked,
+
+            @Schema(description = "좋아요 누른 사용자 목록", example = "[\"backend.sam\", \"choi.dan\"]")
+            @JsonProperty("who_liked")
+            List<String> whoLiked
+    ) {}
+
+    /**
+     * 사용자 정보 DTO
+     */
+    @Schema(description = "사용자 정보")
+    public record UserInfo(
+            @Schema(description = "사용자 ID", example = "7")
+            Long id,
+
+            @Schema(description = "닉네임", example = "frontend.kim")
+            String nickname,
+
+            @Schema(description = "프로필 이미지 URL", example = "https://s3.../avatar.png")
+            @JsonProperty("image_url")
+            String imageUrl,
+
+            @Schema(description = "팔로우 여부", example = "true")
+            @JsonProperty("is_following")
+            Boolean isFollowing
+    ) {}
+
+    /**
+     * 게시글 생성 응답 DTO
+     */
+    @Schema(description = "게시글 생성 응답")
+    public record PostCreateResponse(
+            @Schema(description = "응답 메시지", example = "게시글이 작성되었습니다.")
+            String message,
+
+            @Schema(description = "생성된 게시글 정보")
+            PostDetail data
+    ) {}
+
+    /**
+     * 게시글 삭제 응답 DTO
+     */
+    @Schema(description = "게시글 삭제 응답")
+    public record PostDeleteResponse(
+            @Schema(description = "응답 메시지", example = "게시글이 삭제되었습니다.")
+            String message,
+
+            @Schema(description = "데이터", example = "null")
+            Object data
+    ) {}
+
+    /**
+     * 게시글 좋아요 응답 DTO
+     */
+    @Schema(description = "게시글 좋아요 응답")
+    public record PostLikeResponse(
+            @Schema(description = "응답 메시지", example = "좋아요가 성공적으로 등록되었습니다.")
+            String message,
+
+            @Schema(description = "데이터", example = "null")
+            Object data
+    ) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -119,11 +119,11 @@ public class PostResponseDto {
 
             @Schema(description = "좋아요 여부", example = "false")
             @JsonProperty("is_liked")
-            Boolean isLiked,
+            Boolean isLiked
 
-            @Schema(description = "좋아요 누른 사용자 목록", example = "[\"backend.sam\", \"choi.dan\"]")
-            @JsonProperty("who_liked")
-            List<String> whoLiked
+//            @Schema(description = "좋아요 누른 사용자 목록", example = "[\"backend.sam\", \"choi.dan\"]")
+//            @JsonProperty("who_liked")
+//            List<String> whoLiked
     ) {}
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostLike.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostLike.java
@@ -1,0 +1,80 @@
+package com.kakaobase.snsapp.domain.posts.entity;
+
+import com.kakaobase.snsapp.global.common.entity.BaseCreatedTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 게시글 좋아요 정보를 담는 엔티티
+ * <p>
+ * 게시글에 좋아요를 누른 회원 정보를 관리합니다.
+ * BaseCreatedTimeEntity를 상속받아 생성 시간 정보를 관리합니다.
+ * 복합 기본키를 사용합니다 (회원 ID + 게시글 ID).
+ * </p>
+ */
+@Entity
+@Table(
+        name = "posts_likes",
+        indexes = {
+                @Index(name = "idx_member_id", columnList = "member_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(PostLike.PostLikeId.class)
+public class PostLike extends BaseCreatedTimeEntity {
+
+    @Id
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Id
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    /**
+     * 좋아요 정보 생성을 위한 생성자
+     *
+     * @param memberId 좋아요를 누른 회원 ID
+     * @param postId 좋아요가 눌린 게시글 ID
+     */
+    public PostLike(Long memberId, Long postId) {
+        this.memberId = memberId;
+        this.postId = postId;
+    }
+
+    /**
+     * PostLike 엔티티의 복합 기본키 클래스
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PostLikeId implements java.io.Serializable {
+        private Long memberId;
+        private Long postId;
+
+        public PostLikeId(Long memberId, Long postId) {
+            this.memberId = memberId;
+            this.postId = postId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            PostLikeId that = (PostLikeId) o;
+
+            if (!memberId.equals(that.memberId)) return false;
+            return postId.equals(that.postId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = memberId.hashCode();
+            result = 31 * result + postId.hashCode();
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostLike.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/PostLike.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.domain.posts.entity;
 
-import com.kakaobase.snsapp.global.common.entity.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -24,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @IdClass(PostLike.PostLikeId.class)
-public class PostLike extends BaseCreatedTimeEntity {
+public class PostLike {
 
     @Id
     @Column(name = "member_id", nullable = false)

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/exception/PostErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/exception/PostErrorCode.java
@@ -1,0 +1,34 @@
+package com.kakaobase.snsapp.domain.posts.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PostErrorCode implements BaseErrorCode {
+
+    // 게시글 내용 관련 에러
+    EMPTY_POST_CONTENT(HttpStatus.BAD_REQUEST, "empty_post_content", "글 내용, 이미지, 유튜브 링크 중 하나는 필수입니다.", null),
+    CONTENT_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "content_length_exceeded", "게시글 본문은 최대 2000자까지 작성할 수 있습니다.", "content"),
+
+    // 권한 관련 에러
+    POST_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "forbidden", "본인의 게시글만 삭제할 수 있습니다.", "postId"),
+    POST_TYPE_FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden", "해당 게시판에 접근할 권한이 없습니다.", "postType"),
+
+    // 이미지 관련 에러
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "invalid_image_url", "유효하지 않은 이미지 주소입니다.", "image_url"),
+
+    // 유튜브 관련 에러
+    INVALID_YOUTUBE_URL(HttpStatus.BAD_REQUEST, "invalid_format", "유튜브 링크가 유효하지 않습니다.", "youtube_url"),
+
+    // 좋아요 관련 에러
+    ALREADY_LIKED(HttpStatus.CONFLICT, "state_conflict", "이미 좋아요한 게시글입니다.", null),
+    ALREADY_UNLIKED(HttpStatus.CONFLICT, "state_conflict", "이미 좋아요를 취소한 게시글입니다.", null);
+
+    private final HttpStatus status;
+    private final String error;
+    private final String message;
+    private final String field;
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/exception/PostException.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/exception/PostException.java
@@ -1,0 +1,63 @@
+package com.kakaobase.snsapp.domain.posts.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import com.kakaobase.snsapp.global.error.exception.CustomException;
+
+/**
+ * 게시글 도메인에서 발생하는 예외를 처리하는 클래스입니다.
+ * CustomException을 상속받아 게시글 관련 예외를 특화하여 처리합니다.
+ */
+public class PostException extends CustomException {
+
+    /**
+     * 게시글 관련 에러 코드를 받아 PostException을 생성합니다.
+     *
+     * @param errorCode 에러 코드 (PostErrorCode)
+     */
+    public PostException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    /**
+     * 게시글 관련 에러 코드와 필드를 받아 PostException을 생성합니다.
+     *
+     * @param errorCode 에러 코드 (PostErrorCode)
+     * @param field 에러가 발생한 필드
+     */
+    public PostException(BaseErrorCode errorCode, String field) {
+        super(errorCode, field);
+    }
+
+    /**
+     * 게시글 관련 에러 코드, 필드, 추가 메시지를 받아 PostException을 생성합니다.
+     *
+     * @param errorCode 에러 코드 (PostErrorCode)
+     * @param field 에러가 발생한 필드
+     * @param additionalMessage 추가 메시지
+     */
+    public PostException(BaseErrorCode errorCode, String field, String additionalMessage) {
+        super(errorCode, field, additionalMessage);
+    }
+
+    /**
+     * 특정 게시글 ID에 대한 에러를 생성하는 편의 메서드
+     *
+     * @param errorCode 에러 코드
+     * @param postId 게시글 ID
+     * @return 게시글 ID 정보가 포함된 예외
+     */
+    public static PostException forPostId(BaseErrorCode errorCode, Long postId) {
+        return new PostException(errorCode, "postId", "게시글 ID: " + postId);
+    }
+
+    /**
+     * 특정 게시판 타입에 대한 에러를 생성하는 편의 메서드
+     *
+     * @param errorCode 에러 코드
+     * @param postType 게시판 타입
+     * @return 게시판 타입 정보가 포함된 예외
+     */
+    public static PostException forPostType(BaseErrorCode errorCode, String postType) {
+        return new PostException(errorCode, "postType", "게시판 타입: " + postType);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
@@ -1,0 +1,104 @@
+package com.kakaobase.snsapp.domain.posts.repository;
+
+import com.kakaobase.snsapp.domain.posts.entity.PostLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 게시글 좋아요 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>게시글 좋아요에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.PostLikeId> {
+
+    /**
+     * 특정 회원이 특정 게시글에 좋아요를 눌렀는지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param postId 게시글 ID
+     * @return 좋아요 정보 (Optional)
+     */
+    Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
+
+    /**
+     * 특정 회원이 특정 게시글에 좋아요를 눌렀는지 여부를 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param postId 게시글 ID
+     * @return 좋아요를 눌렀으면 true, 아니면 false
+     */
+    boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 게시글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 좋아요를 누른 게시글 ID 목록
+     */
+    @Query("SELECT pl.postId FROM PostLike pl WHERE pl.memberId = :memberId")
+    List<Long> findPostIdsByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 회원이 주어진 게시글 목록 중 좋아요를 누른 게시글 ID 목록을 조회합니다.
+     * 게시글 목록 조회 시 좋아요 여부를 확인하는 데 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     * @param posts 게시글 목록
+     * @return 좋아요를 누른 게시글 ID 목록
+     */
+    @Query("SELECT pl.postId FROM PostLike pl WHERE pl.memberId = :memberId AND pl.postId IN :postIds")
+    List<Long> findPostIdsByMemberIdAndPostIdIn(
+            @Param("memberId") Long memberId,
+            @Param("postIds") List<Long> postIds);
+
+    /**
+     * 특정 게시글의 좋아요 수를 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @return 좋아요 수
+     */
+    long countByPostId(Long postId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 게시글 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 좋아요를 누른 게시글 ID 목록 (페이지네이션 적용)
+     */
+    Page<PostLike> findByMemberId(Long memberId, Pageable pageable);
+
+    /**
+     * 특정 게시글의 모든 좋아요를 삭제합니다.
+     * 게시글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param postId 게시글 ID
+     */
+    void deleteByPostId(Long postId);
+
+    /**
+     * 특정 회원의 모든 좋아요를 삭제합니다.
+     * 회원 탈퇴 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     */
+    void deleteByMemberId(Long memberId);
+    /**
+     * 특정 게시글에 좋아요를 누른 상위 N명의 회원 ID를 조회합니다.
+     * 게시글에 좋아요를 누른 사용자 목록을 표시할 때 사용됩니다.
+     *
+     * @param postId 게시글 ID
+     * @param limit 최대 조회할 회원 수
+     * @return 좋아요를 누른 회원 ID 목록 (최대 limit명)
+     */
+    @Query(value = "SELECT pl.member_id FROM posts_likes pl WHERE pl.post_id = :postId ORDER BY pl.created_at DESC LIMIT :limit", nativeQuery = true)
+    List<Long> findTopNMemberIdsByPostId(@Param("postId") Long postId, @Param("limit") int limit);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
@@ -23,7 +23,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * 특정 회원이 특정 게시글에 좋아요를 눌렀는지 확인합니다.
      *
      * @param memberId 회원 ID
-     * @param postId 게시글 ID
+     * @param postId   게시글 ID
      * @return 좋아요 정보 (Optional)
      */
     Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
@@ -32,7 +32,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * 특정 회원이 특정 게시글에 좋아요를 눌렀는지 여부를 확인합니다.
      *
      * @param memberId 회원 ID
-     * @param postId 게시글 ID
+     * @param postId   게시글 ID
      * @return 좋아요를 눌렀으면 true, 아니면 false
      */
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
@@ -51,7 +51,7 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * 게시글 목록 조회 시 좋아요 여부를 확인하는 데 사용됩니다.
      *
      * @param memberId 회원 ID
-     * @param posts 게시글 목록
+     * @param postIds  게시글 목록
      * @return 좋아요를 누른 게시글 ID 목록
      */
     @Query("SELECT pl.postId FROM PostLike pl WHERE pl.memberId = :memberId AND pl.postId IN :postIds")
@@ -91,14 +91,27 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      * @param memberId 회원 ID
      */
     void deleteByMemberId(Long memberId);
+
     /**
-     * 특정 게시글에 좋아요를 누른 상위 N명의 회원 ID를 조회합니다.
-     * 게시글에 좋아요를 누른 사용자 목록을 표시할 때 사용됩니다.
+     * 특정 게시글에 좋아요를 누른 회원 ID를 커서 기반으로 조회합니다.
+     * 게시글에 좋아요를 누른 회원 중 활성 상태인 회원만 조회합니다.
      *
      * @param postId 게시글 ID
-     * @param limit 최대 조회할 회원 수
-     * @return 좋아요를 누른 회원 ID 목록 (최대 limit명)
+     * @param lastMemberId 마지막으로 조회한 회원 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 회원 수
+     * @return 좋아요를 누른 활성 회원 ID 목록
      */
-    @Query(value = "SELECT pl.member_id FROM posts_likes pl WHERE pl.post_id = :postId ORDER BY pl.created_at DESC LIMIT :limit", nativeQuery = true)
-    List<Long> findTopNMemberIdsByPostId(@Param("postId") Long postId, @Param("limit") int limit);
+//    @Query(value = "SELECT pl.members_id FROM post_likes pl " +
+//            "JOIN members m ON pl.members_id = m.id " +
+//            "WHERE pl.posts_id = :postId " +
+//            "AND m.deleted_at IS NULL " +
+//            "AND (:lastMemberId IS NULL OR pl.members_id < :lastMemberId) " +
+//            "ORDER BY pl.members_id DESC " +
+//            "LIMIT :limit",
+//            nativeQuery = true)
+//    List<Long> findMemberIdsByPostIdWithCursor(
+//            @Param("postId") Long postId,
+//            @Param("lastMemberId") Long lastMemberId,
+//            @Param("limit") int limit);
+
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -127,4 +128,25 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("boardType") Post.BoardType boardType,
             @Param("keyword") String keyword,
             Pageable pageable);
+
+    /**
+     * 특정 게시판의 최신 게시글을 생성일시와 ID 기준으로 내림차순 정렬하여 조회합니다.
+     *
+     * @param boardType 게시판 유형
+     * @param limit 조회할 게시글 수
+     * @return 최신 게시글 목록
+     */
+    @Query(value = "SELECT p FROM Post p WHERE p.boardType = :boardType AND p.deletedAt IS NULL ORDER BY p.createdAt DESC, p.id DESC LIMIT :limit")
+    List<Post> findTopNByBoardTypeOrderByCreatedAtDescIdDesc(@Param("boardType") Post.BoardType boardType, @Param("limit") int limit);
+
+    /**
+     * 특정 게시판에서 주어진 ID보다 작은 게시글을 ID 기준으로 내림차순 정렬하여 조회합니다.
+     *
+     * @param boardType 게시판 유형
+     * @param cursor 마지막으로 조회한 게시글 ID
+     * @param limit 조회할 게시글 수
+     * @return 다음 페이지 게시글 목록
+     */
+    @Query(value = "SELECT p FROM Post p WHERE p.boardType = :boardType AND p.id < :cursor AND p.deletedAt IS NULL ORDER BY p.id DESC LIMIT :limit")
+    List<Post> findByBoardTypeAndIdLessThanOrderByIdDesc(@Param("boardType") Post.BoardType boardType, @Param("cursor") Long cursor, @Param("limit") int limit);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -60,15 +60,24 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndMemberId(Long id, Long memberId);
 
     /**
-     * 특정 회원이 좋아요를 누른 게시글 목록을 조회합니다.
+     * 특정 회원이 좋아요를 누른 게시글 목록을 게시글 ID 기준으로 커서 기반 페이징으로 조회합니다.
+     * 게시글 ID 내림차순으로 조회하므로 대략적인 최신순으로 볼 수 있습니다.
      *
      * @param memberId 회원 ID
-     * @param pageable 페이지네이션 정보
-     * @return 회원이 좋아요를 누른 게시글 목록 (페이지네이션 적용)
+     * @param lastPostId 마지막으로 조회한 게시글 ID (첫 페이지에서는 null 또는 Long.MAX_VALUE)
+     * @param limit 조회할 게시글 수
+     * @return 회원이 좋아요를 누른 게시글 목록
      */
-    @Query("SELECT p FROM Post p JOIN PostLike pl ON p.id = pl.postId WHERE pl.memberId = :memberId ORDER BY pl.createdAt DESC")
-    Page<Post> findPostsLikedByMember(@Param("memberId") Long memberId, Pageable pageable);
-
+    @Query("SELECT p FROM Post p " +
+            "JOIN PostLike pl ON p.id = pl.postId " +
+            "WHERE pl.memberId = :memberId " +
+            "AND p.deletedAt IS NULL " +
+            "AND (:lastPostId IS NULL OR p.id < :lastPostId) " +
+            "ORDER BY p.id DESC")
+    List<Post> findPostsLikedByMemberWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("lastPostId") Long lastPostId,
+            @Param("limit") int limit);
     /**
      * 게시글 좋아요 수를 증가시킵니다.
      *

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
@@ -125,29 +125,29 @@ public class PostLikeService {
         return postLikeRepository.findPostIdsByMemberIdAndPostIdIn(memberId, postIds);
     }
 
-    /**
-     * 게시글에 좋아요한 사용자 닉네임 목록을 조회합니다.
-     *
-     * @param postId 게시글 ID
-     * @param limit 최대 조회 수
-     * @return 좋아요한 사용자의 닉네임 목록
-     */
-    public List<String> findWhoLikedPost(Long postId, int limit) {
-        List<Long> memberIds = postLikeRepository.findTopNMemberIdsByPostId(postId, limit);
-
-        if (memberIds.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        // 회원 정보 조회
-        Map<Long, Map<String, String>> memberInfoMap = memberService.getMemberInfoMapByIds(memberIds);
-
-        // 닉네임만 추출하여 반환
-        return memberIds.stream()
-                .map(memberId -> memberInfoMap.getOrDefault(memberId, Map.of("nickname", "알 수 없음")))
-                .map(info -> info.get("nickname"))
-                .collect(Collectors.toList());
-    }
+//    /**
+//     * 게시글에 좋아요한 사용자 닉네임 목록을 조회합니다.
+//     *
+//     * @param postId 게시글 ID
+//     * @param limit 최대 조회 수
+//     * @return 좋아요한 사용자의 닉네임 목록
+//     */
+//    public List<String> findWhoLikedPost(Long postId, int limit) {
+//        List<Long> memberIds = postLikeRepository.findTopMemberIdsByPostId(postId, limit);
+//
+//        if (memberIds.isEmpty()) {
+//            return new ArrayList<>();
+//        }
+//
+//        // 회원 정보 조회
+//        Map<Long, Map<String, String>> memberInfoMap = memberService.getMemberInfoMapByIds(memberIds);
+//
+//        // 닉네임만 추출하여 반환
+//        return memberIds.stream()
+//                .map(memberId -> memberInfoMap.getOrDefault(memberId, Map.of("nickname", "알 수 없음")))
+//                .map(info -> info.get("nickname"))
+//                .collect(Collectors.toList());
+//    }
 
     /**
      * 게시글 삭제 시 연관된 좋아요를 일괄 삭제합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
@@ -1,0 +1,162 @@
+package com.kakaobase.snsapp.domain.posts.service;
+
+import com.kakaobase.snsapp.domain.members.service.MemberService;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.entity.PostLike;
+import com.kakaobase.snsapp.domain.posts.exception.PostErrorCode;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.domain.posts.repository.PostLikeRepository;
+import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 게시글 좋아요 관련 비즈니스 로직을 처리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostLikeService {
+
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final MemberService memberService;
+
+    /**
+     * 게시글에 좋아요를 추가합니다.
+     *
+     * @param postId 게시글 ID
+     * @param memberId 회원 ID
+     * @throws PostException 게시글이 없거나 이미 좋아요한 경우
+     */
+    @Transactional
+    public void addLike(Long postId, Long memberId) {
+        // 게시글 존재 여부 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postId"));
+
+        // 이미 좋아요한 경우 확인
+        if (postLikeRepository.existsByMemberIdAndPostId(memberId, postId)) {
+            throw new PostException(PostErrorCode.ALREADY_LIKED);
+        }
+
+        // 좋아요 엔티티 생성 및 저장
+        PostLike postLike = new PostLike(memberId, postId);
+        postLikeRepository.save(postLike);
+
+        // 게시글 좋아요 수 증가
+        postRepository.increaseLikeCount(postId);
+
+        log.info("게시글 좋아요 추가 완료: 게시글 ID={}, 회원 ID={}", postId, memberId);
+    }
+
+    /**
+     * 게시글 좋아요를 취소합니다.
+     *
+     * @param postId 게시글 ID
+     * @param memberId 회원 ID
+     * @throws PostException 게시글이 없거나 좋아요하지 않은 경우
+     */
+    @Transactional
+    public void removeLike(Long postId, Long memberId) {
+        // 게시글 존재 여부 확인
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postId"));
+
+        // 좋아요 존재 여부 확인
+        PostLike postLike = postLikeRepository.findByMemberIdAndPostId(memberId, postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.ALREADY_UNLIKED));
+
+        // 좋아요 삭제
+        postLikeRepository.delete(postLike);
+
+        // 게시글 좋아요 수 감소
+        postRepository.decreaseLikeCount(postId);
+
+        log.info("게시글 좋아요 취소 완료: 게시글 ID={}, 회원 ID={}", postId, memberId);
+    }
+
+    /**
+     * 회원이 게시글에 좋아요했는지 확인합니다.
+     *
+     * @param postId 게시글 ID
+     * @param memberId 회원 ID
+     * @return 좋아요 여부
+     */
+    public boolean isLikedByMember(Long postId, Long memberId) {
+        return postLikeRepository.existsByMemberIdAndPostId(memberId, postId);
+    }
+
+    /**
+     * 회원이 좋아요한 게시글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 좋아요한 게시글 ID 목록
+     */
+    public List<Long> findLikedPostIdsByMember(Long memberId) {
+        return postLikeRepository.findPostIdsByMemberId(memberId);
+    }
+
+    /**
+     * 회원이 특정 게시글 목록 중 좋아요한 게시글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param posts 게시글 목록
+     * @return 좋아요한 게시글 ID 목록
+     */
+    public List<Long> findLikedPostIdsByMember(Long memberId, List<Post> posts) {
+        if (posts.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> postIds = posts.stream()
+                .map(Post::getId)
+                .collect(Collectors.toList());
+
+        return postLikeRepository.findPostIdsByMemberIdAndPostIdIn(memberId, postIds);
+    }
+
+    /**
+     * 게시글에 좋아요한 사용자 닉네임 목록을 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @param limit 최대 조회 수
+     * @return 좋아요한 사용자의 닉네임 목록
+     */
+    public List<String> findWhoLikedPost(Long postId, int limit) {
+        List<Long> memberIds = postLikeRepository.findTopNMemberIdsByPostId(postId, limit);
+
+        if (memberIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // 회원 정보 조회
+        Map<Long, Map<String, String>> memberInfoMap = memberService.getMemberInfoMapByIds(memberIds);
+
+        // 닉네임만 추출하여 반환
+        return memberIds.stream()
+                .map(memberId -> memberInfoMap.getOrDefault(memberId, Map.of("nickname", "알 수 없음")))
+                .map(info -> info.get("nickname"))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 게시글 삭제 시 연관된 좋아요를 일괄 삭제합니다.
+     *
+     * @param postId 게시글 ID
+     */
+    @Transactional
+    public void deleteAllByPostId(Long postId) {
+        postLikeRepository.deleteByPostId(postId);
+        log.info("게시글 관련 좋아요 일괄 삭제 완료: 게시글 ID={}", postId);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -1,0 +1,201 @@
+package com.kakaobase.snsapp.domain.posts.service;
+
+import com.kakaobase.snsapp.domain.members.service.MemberService;
+import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.entity.PostImage;
+import com.kakaobase.snsapp.domain.posts.exception.PostErrorCode;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.global.common.s3.service.S3Service;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 게시글 관련 비즈니스 로직을 처리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final S3Service s3Service;
+    private final MemberService memberService;
+    private final PostLikeService postLikeService;
+
+    /**
+     * 게시글을 생성합니다.
+     *
+     * @param boardType 게시판 유형
+     * @param requestDto 게시글 생성 요청 DTO
+     * @param memberId 작성자 ID
+     * @return 생성된 게시글 엔티티
+     */
+    @Transactional
+    public Post createPost(Post.BoardType boardType, PostRequestDto.PostCreateRequestDto requestDto, Long memberId) {
+        // 이미지 URL 유효성 검증
+        if (StringUtils.hasText(requestDto.image_url()) && !s3Service.isValidImageUrl(requestDto.image_url())) {
+            throw new PostException(PostErrorCode.INVALID_IMAGE_URL);
+        }
+
+        // 게시글 엔티티 생성
+        Post post = new Post(
+                memberId,
+                boardType,
+                requestDto.content(),
+                requestDto.youtube_url()
+        );
+
+        // 게시글 저장
+        Post savedPost = postRepository.save(post);
+
+        // 이미지 처리 (단일 이미지)
+        if (StringUtils.hasText(requestDto.image_url())) {
+            PostImage postImage = new PostImage(savedPost, 0, requestDto.image_url());
+            savedPost.addImage(postImage);
+        }
+
+        log.info("게시글 생성 완료: 게시글 ID={}, 작성자 ID={}, 게시판={}", savedPost.getId(), memberId, boardType);
+        return savedPost;
+    }
+
+    /**
+     * 커서 기반 페이지네이션으로 게시글을 조회합니다.
+     *
+     * @param boardType 게시판 유형
+     * @param limit 한 페이지에 표시할 게시글 수
+     * @param cursor 마지막으로 조회한 게시글 ID
+     * @return 게시글 목록
+     */
+    public List<Post> findByCursor(Post.BoardType boardType, int limit, Long cursor) {
+        if (cursor == null) {
+            // 첫 페이지 조회
+            return postRepository.findTopNByBoardTypeOrderByCreatedAtDescIdDesc(boardType, limit);
+        } else {
+            // 다음 페이지 조회 (cursor 이후 데이터)
+            return postRepository.findByBoardTypeAndIdLessThanOrderByIdDesc(boardType, cursor, limit);
+        }
+    }
+
+    /**
+     * 게시글 ID로 게시글을 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @return 조회된 게시글 엔티티
+     */
+    public Post findById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postId", "해당 게시글을 찾을 수 없습니다"));
+    }
+
+    /**
+     * 게시글을 삭제합니다.
+     *
+     * @param postId 게시글 ID
+     * @param memberId 삭제자 ID
+     */
+    @Transactional
+    public void deletePost(Long postId, Long memberId) {
+        // 게시글 조회 - AccessChecker에서 이미 권한 검증을 했으므로 간소화 가능
+        Post post = findById(postId);
+
+        // 소프트 삭제 처리
+        postRepository.delete(post);
+
+        log.info("게시글 삭제 완료: 게시글 ID={}, 삭제자 ID={}", postId, memberId);
+    }
+
+    /**
+     * 회원 ID로 회원 정보를 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 회원 정보 (닉네임, 프로필 이미지)
+     */
+    public Map<String, String> getMemberInfo(Long memberId) {
+        return memberService.getMemberInfo(memberId);
+    }
+
+    /**
+     * 게시글 목록에 포함된 회원 정보를 조회합니다.
+     *
+     * @param posts 게시글 목록
+     * @return 회원 ID를 키로 하고 회원 정보(닉네임, 프로필 이미지)를 값으로 하는 맵
+     */
+    public Map<Long, Map<String, String>> getMemberInfoByPosts(List<Post> posts) {
+        // 게시글에 포함된 회원 ID 목록 추출
+        List<Long> memberIds = posts.stream()
+                .map(Post::getMemberId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (memberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        // MemberService를 통해 회원 정보 조회
+        return memberService.getMemberInfoMapByIds(memberIds);
+    }
+
+    /**
+     * 게시글에 좋아요한 사용자 목록을 조회합니다.
+     *
+     * @param posts 게시글 목록
+     * @param limit 조회할 사용자 수 제한
+     * @return 게시글 ID를 키로 하고 좋아요한 사용자 닉네임 목록을 값으로 하는 맵
+     */
+    public Map<Long, List<String>> getWhoLikedPosts(List<Post> posts, int limit) {
+        Map<Long, List<String>> result = new HashMap<>();
+
+        for (Post post : posts) {
+            List<String> whoLiked = postLikeService.findWhoLikedPost(post.getId(), limit);
+            result.put(post.getId(), whoLiked);
+        }
+
+        return result;
+    }
+
+//    /**
+//     * 사용자가 팔로우하는 회원 ID 목록을 조회합니다.
+//     *
+//     * @param memberId 사용자 ID
+//     * @return 팔로우하는 회원 ID 목록
+//     */
+//    public List<Long> getFollowingIds(Long memberId) {
+//        return followService.getFollowingIds(memberId);
+//    }
+//
+//    /**
+//     * 사용자가 특정 회원을 팔로우하는지 확인합니다.
+//     *
+//     * @param memberId 사용자 ID
+//     * @param targetId 대상 회원 ID
+//     * @return 팔로우 여부
+//     */
+//    public boolean isFollowing(Long memberId, Long targetId) {
+//        return followService.isFollowing(memberId, targetId);
+//    }
+//
+//    /**
+//     * 유튜브 요약 내용을 업데이트합니다.
+//     *
+//     * @param postId 게시글 ID
+//     * @param summary 요약 내용
+//     */
+//    @Transactional
+//    public void updateYoutubeSummary(Long postId, String summary) {
+//        Post post = findById(postId);
+//        post.updateYoutubeSummary(summary);
+//        log.info("유튜브 요약 업데이트 완료: 게시글 ID={}", postId);
+//    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -147,23 +147,23 @@ public class PostService {
         return memberService.getMemberInfoMapByIds(memberIds);
     }
 
-    /**
-     * 게시글에 좋아요한 사용자 목록을 조회합니다.
-     *
-     * @param posts 게시글 목록
-     * @param limit 조회할 사용자 수 제한
-     * @return 게시글 ID를 키로 하고 좋아요한 사용자 닉네임 목록을 값으로 하는 맵
-     */
-    public Map<Long, List<String>> getWhoLikedPosts(List<Post> posts, int limit) {
-        Map<Long, List<String>> result = new HashMap<>();
-
-        for (Post post : posts) {
-            List<String> whoLiked = postLikeService.findWhoLikedPost(post.getId(), limit);
-            result.put(post.getId(), whoLiked);
-        }
-
-        return result;
-    }
+//    /**
+//     * 게시글에 좋아요한 사용자 목록을 조회합니다.
+//     *
+//     * @param posts 게시글 목록
+//     * @param limit 조회할 사용자 수 제한
+//     * @return 게시글 ID를 키로 하고 좋아요한 사용자 닉네임 목록을 값으로 하는 맵
+//     */
+//    public Map<Long, List<String>> getWhoLikedPosts(List<Post> posts, int limit) {
+//        Map<Long, List<String>> result = new HashMap<>();
+//
+//        for (Post post : posts) {
+//            List<String> whoLiked = postLikeService.findWhoLikedPost(post.getId(), limit);
+//            result.put(post.getId(), whoLiked);
+//        }
+//
+//        return result;
+//    }
 
 //    /**
 //     * 사용자가 팔로우하는 회원 ID 목록을 조회합니다.
@@ -187,7 +187,7 @@ public class PostService {
 //    }
 //
 //    /**
-//     * 유튜브 요약 내용을 업데이트합니다.
+//     * 유튜브 요약 내용을 업데이트합니다.`
 //     *
 //     * @param postId 게시글 ID
 //     * @param summary 요약 내용

--- a/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
@@ -80,7 +80,7 @@ public class S3Controller {
             @RequestParam(required = false) Post.BoardType boardType
     ) {
         // Presigned URL 생성 및 반환
-        PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type, boardType);
+        PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type);
 
         return ResponseEntity.ok(
                 CustomResponse.success("S3에 이미지를 업로드할 수 있도록 presigned URL을 발급했습니다.", response)

--- a/src/main/java/com/kakaobase/snsapp/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaobase/snsapp/global/error/handler/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import com.kakaobase.snsapp.global.error.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -66,6 +67,21 @@ public class GlobalExceptionHandler {
                 .status(GeneralErrorCode.INVALID_FORMAT.getStatus())
                 .body(GeneralErrorCode.INVALID_FORMAT.getErrorResponse());
     }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CustomResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException e) {
+        log.error("HttpMessageNotReadable Exception: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(GeneralErrorCode.INVALID_FORMAT.getStatus())
+                .body(CustomResponse.failure(
+                        GeneralErrorCode.INVALID_FORMAT.getError(),
+                        GeneralErrorCode.INVALID_FORMAT.getMessage(),
+                        null
+                ));
+    }
+
+
 
     /**
      * 필수 파라미터 누락 예외를 처리합니다.

--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -1,0 +1,110 @@
+package com.kakaobase.snsapp.global.security;
+
+import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import com.kakaobase.snsapp.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * 게시판 및 게시글 접근 권한을 검증하는 클래스
+ * Spring Security의 @PreAuthorize 어노테이션과 함께 사용됩니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AccessChecker {
+
+    private final PostRepository postRepository;
+
+    /**
+     * 사용자가 특정 게시판에 접근할 권한이 있는지 검증합니다.
+     *
+     * @param postType 게시판 타입 (예: all, pangyo_1, jeju_2)
+     * @return 접근 가능하면 true, 아니면 false
+     */
+    public boolean hasAccessToBoard(String postType) {
+        // 인증되지 않은 사용자는 'all' 게시판만 접근 가능
+        if (!SecurityUtil.isAuthenticated()) {
+            return "all".equalsIgnoreCase(postType);
+        }
+
+        // 관리자, 봇 권한이 있는 경우 모든 게시판 접근 가능
+        if (SecurityUtil.isAdminOrBot()) {
+            return true;
+        }
+
+        // 'all' 게시판은 모든 인증된 사용자 접근 가능
+        if ("all".equalsIgnoreCase(postType)) {
+            return true;
+        }
+
+        // 사용자의 기수(className) 확인
+        String className = SecurityUtil.getMemberClassName()
+                .orElseThrow(()-> new CustomException(GeneralErrorCode.RESOURCE_NOT_FOUND, "class_name", "인증객체에서 회원의 기수명을 찾을 수 없습니다"));
+
+        if (!StringUtils.hasText(className)) {
+            Long memberId = SecurityUtil.getMemberIdAsLong()
+                    .orElseThrow(()-> new CustomException(GeneralErrorCode.RESOURCE_NOT_FOUND, "memberId", "인증 객체에서 회원의 Id을 찾을 수 없습니다"));
+            log.warn("사용자 ID {}의 기수 정보가 없습니다.", memberId);
+            return false;
+        }
+
+        // postType과 사용자의 기수 일치 여부 확인
+        String normalizedPostType = postType.toUpperCase();
+
+        boolean hasAccess = className.equals(normalizedPostType);
+
+        if (!hasAccess) {
+            log.debug("사용자 ID {}(기수: {})의 게시판 접근 거부: {}",
+                    SecurityUtil.getMemberIdAsLong(), className, postType);
+        }
+
+        return hasAccess;
+    }
+
+    /**
+     * 사용자가 게시글의 소유자인지 검증합니다.
+     *
+     * @param postId 게시글 ID
+     * @param authentication 인증 정보
+     * @return 소유자이면 true, 아니면 false
+     */
+    public boolean isPostOwner(Long postId, Authentication authentication) {
+        // 관리자, 봇 권한이 있는 경우 소유자로 취급
+        if (SecurityUtil.isAdminOrBot()) {
+            return true;
+        }
+
+        // 사용자 ID 확인
+        Long memberId = SecurityUtil.getMemberIdAsLong()
+                .orElseThrow(()-> new CustomException(GeneralErrorCode.RESOURCE_NOT_FOUND, "memberId", "인증 객체에서 회원의 Id을 찾을 수 없습니다"));
+        if (memberId == null) {
+            return false;
+        }
+
+        // 게시글 조회
+        return postRepository.findByIdAndMemberId(postId, memberId).isPresent();
+    }
+
+    /**
+     * 문자열 형태의 postType을 BoardType enum으로 변환합니다.
+     *
+     * @param postType 게시판 타입 문자열
+     * @return BoardType enum 값
+     * @throws PostException 유효하지 않은 postType인 경우
+     */
+    public Post.BoardType convertToBoardType(String postType) {
+        try {
+            return PostConverter.toBoardType(postType);
+        } catch (IllegalArgumentException e) {
+            throw new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postType");
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/global/security/SecurityUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/SecurityUtil.java
@@ -21,84 +21,94 @@ import java.util.stream.Collectors;
 public class SecurityUtil {
 
     /**
-     * 현재 인증된 사용자의 ID를 Optional로 반환합니다.
+     * 현재 인증 정보를 Optional로 가져옵니다.
+     *
+     * @return 인증 정보를 담은 Optional
+     */
+    public static Optional<Authentication> getAuthentication() {
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication());
+    }
+
+    /**
+     * 현재 인증된 사용자의 멤버 ID를 String으로 반환합니다.
      * 인증 정보가 없는 경우 빈 Optional을 반환합니다.
      *
-     * @return 사용자 ID를 담은 Optional
+     * @return 멤버 ID를 담은 Optional<String>
      */
-    public static Optional<String> getCurrentUserIdOpt() {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    public static Optional<String> getMemberIdAsString() {
+        Optional<Authentication> auth = getAuthentication();
+        log.debug("인증 객체: {}", auth.orElse(null));
 
-        if (authentication == null || authentication.getPrincipal() == null || "anonymousUser".equals(authentication.getPrincipal())) {
-            return Optional.empty();
+        if (auth.isPresent()) {
+            Object principal = auth.get().getPrincipal();
+            log.debug("인증 객체의 Principal 타입: {}", principal != null ? principal.getClass().getName() : "null");
+            log.debug("인증 객체의 Principal 내용: {}", principal);
+            log.debug("인증 객체의 Name: {}", auth.get().getName());
         }
 
-        return Optional.ofNullable(authentication.getName());
+        return auth
+                .filter(a -> a.getPrincipal() != null && !"anonymousUser".equals(a.getPrincipal()))
+                .map(Authentication::getName);
     }
 
     /**
-     * 현재 인증된 사용자의 ID를 반환합니다.
-     * 인증 정보가 없는 경우 null을 반환합니다.
+     * 현재 인증된 사용자의 멤버 ID를 Long으로 반환합니다.
+     * 인증 정보가 없거나 ID를 Long으로 변환할 수 없는 경우 빈 Optional을 반환합니다.
      *
-     * @return 사용자 ID, 인증되지 않은 경우 null
+     * @return 멤버 ID를 담은 Optional<Long>
      */
-    public static String getCurrentUserId() {
-        return getCurrentUserIdOpt().orElse(null);
+    public static Optional<Long> getMemberIdAsLong() {
+        return getMemberIdAsString().flatMap(id -> {
+            try {
+                return Optional.of(Long.parseLong(id));
+            } catch (NumberFormatException e) {
+                log.warn("멤버 ID를 Long으로 변환할 수 없습니다: {}", id);
+                return Optional.empty();
+            }
+        });
     }
 
     /**
-     * 현재 인증된 사용자의 역할을 Optional로 반환합니다.
-     * 인증 정보나 역할 정보가 없는 경우 빈 Optional을 반환합니다.
+     * 현재 인증된 사용자의 권한 목록을 가져옵니다.
      *
-     * @return 사용자 역할을 담은 Optional
+     * @return 권한 문자열 집합을 담은 Optional
      */
-    public static Optional<String> getCurrentUserRoleOpt() {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || authentication.getAuthorities() == null) {
-            return Optional.empty();
-        }
-
-        Set<String> roles = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.toSet());
-
-        // "ROLE_" 접두사 제거
-        return roles.stream()
-                .findFirst()
-                .map(role -> role.startsWith("ROLE_") ? role.substring(5) : role);
+    public static Optional<Set<String>> getMemberRoles() {
+        return getAuthentication()
+                .map(Authentication::getAuthorities)
+                .map(authorities -> authorities.stream()
+                        .map(GrantedAuthority::getAuthority)
+                        .collect(Collectors.toSet()));
     }
 
     /**
-     * 현재 인증된 사용자의 역할을 반환합니다.
-     * 인증 정보나 역할 정보가 없는 경우 null을 반환합니다.
+     * 현재 인증된 사용자의 주요 권한을 반환합니다.
+     * 인증 정보나 권한 정보가 없는 경우 빈 Optional을 반환합니다.
      *
-     * @return 사용자 역할, 인증되지 않은 경우 null
+     * @return 사용자 권한을 담은 Optional
      */
-    public static String getCurrentUserRole() {
-        return getCurrentUserRoleOpt().orElse(null);
+    public static Optional<String> getMemberRole() {
+        return getMemberRoles()
+                .filter(roles -> !roles.isEmpty())
+                .flatMap(roles -> roles.stream()
+                        .findFirst()
+                        .map(role -> role.startsWith("ROLE_") ? role.substring(5) : role));
     }
 
     /**
      * 현재 인증된 사용자의 기수(class_name)를 반환합니다.
      *
-     * @return 사용자 기수, 인증되지 않았거나 정보가 없으면 null
+     * @return 사용자 기수를 담은 Optional, 인증되지 않았거나 정보가 없으면 빈 Optional
      */
-    public static String getCurrentUserClassName() {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || authentication.getDetails() == null) {
-            return null;
-        }
-
-        if (authentication.getDetails() instanceof Map) {
-            @SuppressWarnings("unchecked")
-            Map<String, String> details = (Map<String, String>) authentication.getDetails();
-            return details.get("class_name");
-        }
-
-
-        return null;
+    public static Optional<String> getMemberClassName() {
+        return getAuthentication()
+                .map(Authentication::getDetails)
+                .filter(details -> details instanceof Map)
+                .map(details -> {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> detailsMap = (Map<String, String>) details;
+                    return detailsMap.get("class_name");
+                });
     }
 
     /**
@@ -107,25 +117,24 @@ public class SecurityUtil {
      * @return 인증되었으면 true, 그렇지 않으면 false
      */
     public static boolean isAuthenticated() {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication != null &&
-                authentication.isAuthenticated() &&
-                !"anonymousUser".equals(authentication.getPrincipal());
+        return getAuthentication()
+                .filter(auth -> auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal()))
+                .isPresent();
     }
 
     /**
-     * 현재 사용자가 특정 사용자 ID와 일치하는지 확인합니다.
+     * 현재 사용자가 특정 멤버 ID와 일치하는지 확인합니다.
      *
-     * @param userId 확인할 사용자 ID
+     * @param memberId 확인할 멤버 ID
      * @return 일치하면 true, 그렇지 않으면 false
      */
-    public static boolean isCurrentUser(String userId) {
-        if (userId == null) {
+    public static boolean isCurrentMember(String memberId) {
+        if (memberId == null) {
             return false;
         }
 
-        return getCurrentUserIdOpt()
-                .map(currentUserId -> currentUserId.equals(userId))
+        return getMemberIdAsString()
+                .map(currentMemberId -> currentMemberId.equals(memberId))
                 .orElse(false);
     }
 
@@ -140,8 +149,21 @@ public class SecurityUtil {
             return false;
         }
 
-        return getCurrentUserRoleOpt()
-                .map(currentRole -> currentRole.equals(role))
+        String roleWithPrefix = role.startsWith("ROLE_") ? role : "ROLE_" + role;
+
+        return getMemberRoles()
+                .map(roles -> roles.stream()
+                        .anyMatch(r -> r.equals(role) || r.equals(roleWithPrefix)))
                 .orElse(false);
+    }
+
+    /**
+     * 현재 사용자가 관리자 또는 봇 역할을 가지고 있는지 확인합니다.
+     *
+     * @return 관리자 또는 봇 권한이 있으면 true, 아니면 false
+     */
+    public static boolean isAdminOrBot() {
+        return hasRole("ADMIN") || hasRole("BOT") ||
+                hasRole("ROLE_ADMIN") || hasRole("ROLE_BOT");
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.kakaobase.snsapp.global.security.config;
 
-import com.kakaobase.snsapp.global.security.config.CustomAccessDeniedHandler;
-import com.kakaobase.snsapp.global.security.config.CustomAuthenticationEntryPoint;
 import com.kakaobase.snsapp.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -10,20 +10,18 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 /**
  * HTTP 요청에서 JWT 토큰을 추출하고 검증하여 Security Context에 인증 정보를 설정하는 필터입니다.
- * Spring Security 필터 체인에서 작동하며, 모든 요청에 대해 한 번씩 실행됩니다.
+ * Spring Security 필터 체인에서 작동하며, 인증이 필요한 요청에 대해 실행됩니다.
  */
 @Component
 @RequiredArgsConstructor
@@ -33,6 +31,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final JwtTokenValidator jwtTokenValidator;
     private final CustomUserDetailsService userDetailsService;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    // 필터를 적용하지 않을 경로 패턴 목록
+    private final List<String> excludedPaths = List.of(
+            "/auth/tokens",
+            "/auth/tokens/refresh",
+            "/users/email/verification-requests",
+            "/users/email/verification",
+            "/users",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
+    );
+
+    /**
+     * 특정 경로에 대해 이 필터를 적용하지 않아야 하는지 결정합니다.
+     * 인증이 필요 없는 경로들(로그인, 토큰 갱신, 회원가입 등)에는 필터를 적용하지 않습니다.
+     *
+     * @param request 현재 요청
+     * @return true이면 필터를 적용하지 않음, false이면 필터 적용
+     */
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+
+        return excludedPaths.stream()
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
 
     /**
      * JWT 토큰을 검증하고 인증 정보를 설정하는 필터 메서드입니다.
@@ -47,8 +72,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        // 요청 정보 로깅
+        log.debug("JwtAuthenticationFilter 실행 - URI: {}, 메서드: {}", request.getRequestURI(), request.getMethod());
+
         // 요청에서 JWT 토큰 추출
         String token = jwtUtil.resolveToken(request);
+        log.debug("추출된 토큰: {}", token != null ? "존재함 (길이: " + token.length() + ")" : "없음");
 
         // 토큰이 존재하고 현재 인증 정보가 없는 경우에만 처리
         if (StringUtils.hasText(token) && SecurityContextHolder.getContext().getAuthentication() == null) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name : 22-tenten-be
   datasource:
-    url: jdbc:mariadb://localhost:3306/kakaobase?serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mariadb://localhost:3306/kakaobase_db?serverTimezone=UTC&characterEncoding=UTF-8
     username: root
-    password: ''  # 비밀번호는 XAMPP 기본값 (빈칸)
+    password: ' '  # 비밀번호는 XAMPP 기본값 (빈칸)
     driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     database-platform: org.hibernate.dialect.MariaDBDialect
@@ -61,3 +61,7 @@ logging:
   level:
     com.amazonaws.util.EC2MetadataUtils: ERROR # EC2 메타데이터 관련 로그 수준 조정
     com.amazonaws.services.s3: INFO            # S3 서비스 관련 로그 수준
+    com.kakaobase.snsapp.global.security: DEBUG
+    com.kakaobase.snsapp.domain.auth: DEBUG
+    com.kakaobase.snsapp.domain.posts: DEBUG
+    org.springframework.security: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,12 @@ spring:
   application:
     name : 22-tenten-be
   datasource:
-    url: jdbc:mariadb://localhost:3306/kakaobase_db?serverTimezone=UTC&characterEncoding=UTF-8
+    url: ${MYSQL_URL}
     username: root
-    password: ' '  # 비밀번호는 XAMPP 기본값 (빈칸)
-    driver-class-name: org.mariadb.jdbc.Driver
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    database-platform: org.hibernate.dialect.MariaDBDialect
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
       ddl-auto: none
     show-sql: true
@@ -43,25 +43,3 @@ app:
       expiration-time: 604800000 # 7일
       token-name: kakaobase_refresh_token
       path: /auth/tokens/refresh
-
-cloud:
-  aws:
-    credentials:
-      access-key: ${AWS_ACCESS_KEY}  # AWS IAM 사용자의 액세스 키
-      secret-key: ${AWS_SECRIT_KEY}  # AWS IAM 사용자의 시크릿 키
-    region:
-      static: ap-northeast-2  # 사용할 AWS 리전 (서울 리전)
-    s3:
-      bucket: YOUR_S3_BUCKET_NAME      # 사용할 S3 버킷 이름
-      expiration-time: 300             # Presigned URL 만료 시간(초)
-      max-file-size: 10485760          # 최대 파일 크기 (10MB)
-
-# S3 사용 시 발생할 수 있는 로깅 제어 (선택사항)
-logging:
-  level:
-    com.amazonaws.util.EC2MetadataUtils: ERROR # EC2 메타데이터 관련 로그 수준 조정
-    com.amazonaws.services.s3: INFO            # S3 서비스 관련 로그 수준
-    com.kakaobase.snsapp.global.security: DEBUG
-    com.kakaobase.snsapp.domain.auth: DEBUG
-    com.kakaobase.snsapp.domain.posts: DEBUG
-    org.springframework.security: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+    database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
       ddl-auto: none
     show-sql: true
@@ -43,3 +43,32 @@ app:
       expiration-time: 604800000 # 7일
       token-name: kakaobase_refresh_token
       path: /auth/tokens/refresh
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}  # AWS IAM 사용자의 액세스 키
+      secret-key: ${AWS_SECRIT_KEY}  # AWS IAM 사용자의 시크릿 키
+    region:
+      static: ap-northeast-2  # 사용할 AWS 리전 (서울 리전)
+    s3:
+      bucket: YOUR_S3_BUCKET_NAME      # 사용할 S3 버킷 이름
+      expiration-time: 300             # Presigned URL 만료 시간(초)
+      max-file-size: 10485760          # 최대 파일 크기 (10MB)
+
+# S3 사용 시 발생할 수 있는 로깅 제어 (선택사항)
+logging:
+  level:
+    com.amazonaws.util.EC2MetadataUtils: ERROR # EC2 메타데이터 관련 로그 수준 조정
+    com.amazonaws.services.s3: INFO            # S3 서비스 관련 로그 수준
+    com.kakaobase.snsapp.global.security: DEBUG
+    com.kakaobase.snsapp.domain.auth: DEBUG
+    com.kakaobase.snsapp.domain.posts: DEBUG
+    org.springframework.security: DEBUG
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui/index.html
+    url: /v3/api-docs


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #15

## 📌 개요
- 게시글 CRUD및 기능 구현
- 게시글 목록 조회 기능 구현
- 게시글 상세 조회 기능 구현
- 게시글 좋아요 기능 구현

## 🔁 변경 사항
### 게시글 관련
- Post관련 요청, 응답 Dto구현
- Dto기반 Converter구현
- 게시글 생성, 삭제, 목록 조회, 상세조회 Controller 구현
- 게시글 좋아요, 좋아요 취소 Controller 구현
- Controller에 맞는 비지니스 로직 구현

### 그외
- MariaDB기반의 설정을 MySQL8.0으로 변경
- Authentication 객체에서 id값을 null로 받아오는 에러를 수정
- 아직 구현되지 않은 follows관련 서비스 로직은 전부 제거하거나 주석처리

## 👀 기타 더 이야기해볼 점
게시글 목록 조회시 Cursor + Created_at을 사용해 조회하는 것을
우선은 Cursor를 기반으로 조회하도록 변경
이 부분은 차후 성능, 최적화 시 한번 더 논의해야함

Authentication 객체의 경우 일관적으로 Optional로 반환하게 로직을 수정하고,
중복되는 메서드를 제거하는 것으로 일시적으로 에러 해결.
그러나 아직 왜 String으로 반환해야 하는 로직이 필요한 지 의문점이 있음.
Spring Security의 호환성 상 Stirng이 좋다는데, 이는 차후 고도화때 조사해볼 예정

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.