### PR TITLE
[BE-FEAT] Comment-Domain구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.auth.principal;
 
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,23 +19,31 @@ import java.util.Collections;
 @Getter
 public class CustomUserDetails implements UserDetails {
 
-    private final Member member;
+    private transient String email;
+    private transient String password;
     private final String id;
     private final String role;
     private final String className;
-    private final boolean isBanned;
+    private final boolean isEnabled;
 
-    /**
-     * Member 엔티티로부터 CustomUserDetails 객체를 생성합니다.
-     *
-     * @param member 회원 엔티티
-     */
-    public CustomUserDetails(Member member) {
-        this.member = member;
-        this.id = member.getId().toString();
-        this.role = member.getRole();
-        this.className = member.getClassName();
-        this.isBanned = member.getIsBanned();
+
+
+    //JWT인증 시 사용
+    public CustomUserDetails(String id, String role, String className, boolean isEnabled) {
+        this.id = id;
+        this.role = role;
+        this.className = className;
+        this.isEnabled = isEnabled;
+    }
+
+    //로그인 시 사용
+    public CustomUserDetails(String email, String password, String id, String role, String className, boolean isEnabled) {
+        this.email = email;
+        this.password = password;
+        this.id = id;
+        this.role = role;
+        this.className = className;
+        this.isEnabled = isEnabled;
     }
 
     /**
@@ -54,7 +63,7 @@ public class CustomUserDetails implements UserDetails {
      */
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return password;
     }
 
     /**
@@ -65,7 +74,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public String getUsername() {
         log.debug("CustomUserDetails.getUsername() 호출: {}", id);
-        return String.valueOf(member.getId());
+        return id;
     }
 
     /**
@@ -106,51 +115,6 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         // 삭제 여부와 밴 여부를 함께 확인
-        return !member.isDeleted() && !member.getIsBanned();
-    }
-
-    /**
-     * 사용자의 ID를 반환합니다.
-     *
-     * @return 사용자 ID
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * 사용자의 기수(class_name)를 반환합니다.
-     *
-     * @return 사용자 기수
-     */
-    public String getClassName() {
-        return className;
-    }
-
-    /**
-     * 사용자의 역할을 반환합니다.
-     *
-     * @return 사용자 역할
-     */
-    public String getRole() {
-        return role;
-    }
-
-    /**
-     * 사용자가 밴 상태인지 확인합니다.
-     *
-     * @return 밴 상태면 true
-     */
-    public boolean isBanned() {
-        return isBanned;
-    }
-
-    /**
-     * 원본 Member 엔티티를 반환합니다.
-     *
-     * @return Member 엔티티
-     */
-    public Member getMember() {
-        return member;
+        return isEnabled;
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetailsService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetailsService.java
@@ -41,17 +41,15 @@ public class CustomUserDetailsService implements UserDetailsService {
                     throw new UsernameNotFoundException("이메일로 사용자를 찾을 수 없습니다: " + email);
                 });
 
-        if (member.isDeleted()) {
-            log.debug("탈퇴한 사용자입니다: {}", email);
-            throw new UsernameNotFoundException("탈퇴한 사용자입니다: " + email);
-        }
-
-        if (member.getIsBanned()) {
-            log.debug("계정이 정지된 사용자입니다: {}", email);
-            throw new UsernameNotFoundException("계정이 정지되었습니다: " + email);
-        }
-
-        return new CustomUserDetails(member);
+        // 로그인 시 사용하는 생성자 사용 (이메일, 비밀번호 포함)
+        return new CustomUserDetails(
+                member.getEmail(),
+                member.getPassword(),
+                member.getId().toString(),
+                member.getRole(),
+                member.getClassName(),
+                member.isEnabled()
+        );
     }
 
     /**
@@ -80,15 +78,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                     throw new CustomException(GeneralErrorCode.RESOURCE_NOT_FOUND, "사용자를 찾을 수 없습니다.");
                 });
 
-        if (member.isDeleted()) {
-            throw new CustomException(GeneralErrorCode.RESOURCE_NOT_FOUND, "탈퇴한 사용자입니다.");
-        }
 
-        if (member.getIsBanned()) {
-            log.debug("계정이 정지된 사용자입니다: {}", id);
-            throw new CustomException(GeneralErrorCode.RESOURCE_NOT_FOUND, "계정이 정지되었습니다.");
-        }
-
-        return new CustomUserDetails(member);
+        return new CustomUserDetails(member.getId().toString(), member.getRole(), member.getClassName(), member.isEnabled());
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/service/UserAuthenticationService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/service/UserAuthenticationService.java
@@ -1,10 +1,11 @@
 package com.kakaobase.snsapp.domain.auth.service;
 
-import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
 import com.kakaobase.snsapp.domain.auth.exception.AuthErrorCode;
 import com.kakaobase.snsapp.domain.auth.exception.AuthException;
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetailsService;
 import com.kakaobase.snsapp.domain.auth.util.CookieUtil;
+
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
@@ -12,6 +13,7 @@ import com.kakaobase.snsapp.global.security.jwt.JwtTokenProvider;
 import jakarta.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,28 +33,44 @@ public class UserAuthenticationService {
     private final JwtTokenProvider jwtTokenProvider;
     private final CookieUtil cookieUtil;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final CustomUserDetailsService userDetailsService;
 
     /**
      * 사용자 로그인 처리 및 인증 토큰 발급
      */
     @Transactional
     public TokenWithCookie login(String email, String password, String userAgent) {
-        // 1. 사용자 인증
-        Member member = authenticateUser(email, password);
+        // 1. 이메일로 사용자 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new AuthException(GeneralErrorCode.RESOURCE_NOT_FOUND, email));
 
-        // 2. 인증 객체 생성
-        Authentication authentication = createAuthenticationFromMember(member);
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new AuthException(AuthErrorCode.INVALID_PASSWORD);
+        }
 
-        // 3. 리프레시 토큰 생성 및 저장
+
+        // 3. CustomUserDetailsService를 사용하여 인증 객체 생성
+        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserById(member.getId().toString());
+
+        // 4. Authentication 객체 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,  // 인증 완료 후에는 credentials는 null
+                userDetails.getAuthorities()
+        );
+
+        // 5. Refresh Token 발급 및 저장
         String refreshToken = securityTokenManager.createRefreshToken(
-                member.getId(),
+                Long.parseLong(userDetails.getId()),
                 userAgent
         );
 
-        // 4. 액세스 토큰 생성
+        // 6. 액세스 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
 
-        // 5. 리프레시 토큰 쿠키 생성
+        // 7. 리프레시 토큰 쿠키 생성
         Cookie refreshTokenCookie = cookieUtil.createRefreshTokenCookie(refreshToken);
 
         return new TokenWithCookie(accessToken, refreshTokenCookie);
@@ -68,19 +86,19 @@ public class UserAuthenticationService {
         }
 
         // 1. 리프레시 토큰 검증 및 사용자 ID 추출
-        Long memberId = securityTokenManager.validateRefreshTokenAndGetUserId(refreshToken);
+        Long userId = securityTokenManager.validateRefreshTokenAndGetUserId(refreshToken);
 
-        // 2. 사용자 정보 조회
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new AuthException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
+        // 2. CustomUserDetailsService를 통해 인증 정보 로드
+        CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserById(String.valueOf(userId));
 
-        // 3. 사용자 상태 확인
-        validateUserStatus(member);
+        // 3. 인증 객체 생성
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
 
-        // 4. 인증 객체 생성
-        Authentication authentication = createAuthenticationFromMember(member);
-
-        // 5. 새 액세스 토큰 생성
+        // 4. 새 액세스 토큰 발급
         return jwtTokenProvider.createAccessToken(authentication);
     }
 
@@ -106,46 +124,6 @@ public class UserAuthenticationService {
         securityTokenManager.revokeAllTokensExcept(memberId, currentRefreshToken);
     }
 
-    /**
-     * 사용자 인증 (이메일/비밀번호 검증)
-     */
-    private Member authenticateUser(String email, String password) {
-        Member member = memberRepository.findByEmail(email)
-                .orElseThrow(() -> new AuthException(GeneralErrorCode.RESOURCE_NOT_FOUND, email));
-
-        if (!passwordEncoder.matches(password, member.getPassword())) {
-            throw new AuthException(AuthErrorCode.INVALID_PASSWORD);
-        }
-
-        validateUserStatus(member);
-
-        return member;
-    }
-
-    /**
-     * 사용자 상태 검증 (활성/비활성/차단 등)
-     */
-    private void validateUserStatus(Member member) {
-        if (member.isDeleted()) {
-            throw new AuthException(AuthErrorCode.USER_DELETED);
-        }
-
-        if (member.getIsBanned()) {
-            throw new AuthException(AuthErrorCode.USER_BANNED);
-        }
-    }
-
-    /**
-     * Member 엔티티로부터 Authentication 객체 생성
-     */
-    private Authentication createAuthenticationFromMember(Member member) {
-        CustomUserDetails userDetails = new CustomUserDetails(member);
-        return new UsernamePasswordAuthenticationToken(
-                userDetails,
-                null,
-                userDetails.getAuthorities()
-        );
-    }
 
     /**
      * 액세스 토큰과 리프레시 토큰 쿠키를 포함하는 응답 DTO

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
@@ -1,0 +1,223 @@
+package com.kakaobase.snsapp.domain.comments.controller;
+
+import com.kakaobase.snsapp.domain.comments.converter.CommentConverter;
+import com.kakaobase.snsapp.domain.comments.converter.LikeConverter;
+import com.kakaobase.snsapp.domain.comments.dto.CommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.service.CommentService;
+import com.kakaobase.snsapp.domain.comments.service.LikeService;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.service.MemberService;
+import com.kakaobase.snsapp.global.common.response.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "댓글 API", description = "게시글 댓글 관련 API")
+public class CommentController {
+
+    private final CommentService commentService;
+    private final LikeService likeService;
+    private final MemberService memberService;
+
+    /**
+     * 현재 로그인한 사용자의 Member 객체를 반환
+     *
+     * @return 현재 로그인한 사용자의 Member 객체
+     */
+    private Member getCurrentMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+        return memberService.getMemberByUsername(username);
+    }
+
+    /**
+     * 댓글 작성 API
+     */
+    @PostMapping("/posts/{postId}/comments")
+    @Operation(
+            summary = "댓글 작성",
+            description = "게시글에 댓글을 작성합니다. parentId가 없으면 일반 댓글, 있으면 대댓글로 등록됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "댓글 작성 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CreateCommentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "게시글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.CreateCommentResponse>> createComment(
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentRequestDto.CreateCommentRequest request
+    ) {
+        Member member = getCurrentMember();
+        CommentResponseDto.CreateCommentResponse response = commentService.createComment(member, postId, request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CustomResponse.success("댓글이 작성되었습니다.", response));
+    }
+
+    /**
+     * 댓글 수정 API
+     */
+    @PutMapping("/comments/{commentId}")
+    @Operation(
+            summary = "댓글 수정",
+            description = "댓글 내용을 수정합니다. 자신이 작성한 댓글만 수정할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 수정 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.MessageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.MessageResponse>> updateComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentRequestDto.UpdateCommentRequest request
+    ) {
+        Member member = getCurrentMember();
+        commentService.updateComment(member.getId(), commentId, request);
+        return ResponseEntity.ok(CustomResponse.success("댓글이 수정되었습니다."));
+    }
+
+    /**
+     * 댓글 삭제 API
+     */
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(
+            summary = "댓글 삭제",
+            description = "댓글을 삭제합니다. 자신이 작성한 댓글만 삭제할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.MessageResponse.class))),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.MessageResponse>> deleteComment(
+            @PathVariable Long commentId
+    ) {
+        Member member = getCurrentMember();
+        commentService.deleteComment(member.getId(), commentId);
+        return ResponseEntity.ok(CustomResponse.success("댓글이 삭제되었습니다."));
+    }
+
+    /**
+     * 게시글의 댓글 목록 조회 API
+     */
+    @GetMapping("/posts/{postId}/comments")
+    @Operation(
+            summary = "게시글의 댓글 목록 조회",
+            description = "게시글에 작성된 댓글 목록을 조회합니다. 페이지네이션을 지원합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CommentListResponse.class))),
+            @ApiResponse(responseCode = "404", description = "게시글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.CommentListResponse>> getCommentsByPostId(
+            @PathVariable Long postId,
+            @Parameter(description = "한 번에 불러올 댓글 수 (기본값: 12)") @RequestParam(required = false) Integer limit,
+            @Parameter(description = "페이지네이션 커서 (이전 응답의 next_cursor)") @RequestParam(required = false) Long cursor
+    ) {
+        Member member = getCurrentMember();
+        CommentRequestDto.CommentPageRequest pageRequest = new CommentRequestDto.CommentPageRequest(limit, cursor);
+        CommentResponseDto.CommentListResponse response = commentService.getCommentsByPostId(member.getId(), postId, pageRequest);
+        return ResponseEntity.ok(CustomResponse.success("댓글 목록을 조회했습니다.", response));
+    }
+
+    /**
+     * 댓글의 대댓글 목록 조회 API
+     */
+    @GetMapping("/comments/{commentId}/recomments")
+    @Operation(
+            summary = "댓글의 대댓글 목록 조회",
+            description = "특정 댓글에 작성된 대댓글 목록을 조회합니다. 페이지네이션을 지원합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "대댓글 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.RecommentListResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.RecommentListResponse>> getRecommentsByCommentId(
+            @PathVariable Long commentId,
+            @Parameter(description = "한 번에 불러올 대댓글 수 (기본값: 12)") @RequestParam(required = false) Integer limit,
+            @Parameter(description = "페이지네이션 커서 (이전 응답의 next_cursor)") @RequestParam(required = false) Long cursor
+    ) {
+        Member member = getCurrentMember();
+        CommentRequestDto.RecommentPageRequest pageRequest = new CommentRequestDto.RecommentPageRequest(limit, cursor);
+        CommentResponseDto.RecommentListResponse response = commentService.getRecommentsByCommentId(member.getId(), commentId, pageRequest);
+        return ResponseEntity.ok(CustomResponse.success("대댓글 목록을 조회했습니다.", response));
+    }
+
+    /**
+     * 댓글 좋아요 토글 API
+     */
+    @PostMapping("/comments/{commentId}/like")
+    @Operation(
+            summary = "댓글 좋아요 토글",
+            description = "댓글에 좋아요를 누르거나 취소합니다. 이미 좋아요가 되어있으면 취소되고, 없으면 추가됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "좋아요 토글 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CommentLikeResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.CommentLikeResponse>> toggleCommentLike(
+            @PathVariable Long commentId
+    ) {
+        Member member = getCurrentMember();
+        CommentResponseDto.CommentLikeResponse response = likeService.toggleCommentLike(member.getId(), commentId);
+        String message = response.liked() ? "댓글에 좋아요를 눌렀습니다." : "댓글 좋아요를 취소했습니다.";
+        return ResponseEntity.ok(CustomResponse.success(message, response));
+    }
+
+    /**
+     * 대댓글 좋아요 토글 API
+     */
+    @PostMapping("/recomments/{recommentId}/like")
+    @Operation(
+            summary = "대댓글 좋아요 토글",
+            description = "대댓글에 좋아요를 누르거나 취소합니다. 이미 좋아요가 되어있으면 취소되고, 없으면 추가됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "좋아요 토글 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.RecommentLikeResponse.class))),
+            @ApiResponse(responseCode = "404", description = "대댓글 없음",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.ErrorResponse.class)))
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.RecommentLikeResponse>> toggleRecommentLike(
+            @PathVariable Long recommentId
+    ) {
+        Member member = getCurrentMember();
+        CommentResponseDto.RecommentLikeResponse response = likeService.toggleRecommentLike(member.getId(), recommentId);
+        String message = response.liked() ? "대댓글에 좋아요를 눌렀습니다." : "대댓글 좋아요를 취소했습니다.";
+        return ResponseEntity.ok(CustomResponse.success(message, response));
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
@@ -1,0 +1,292 @@
+package com.kakaobase.snsapp.domain.comments.converter;
+
+import com.kakaobase.snsapp.domain.comments.dto.CommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.comments.entity.Recomment;
+import com.kakaobase.snsapp.domain.comments.exception.CommentErrorCode;
+import com.kakaobase.snsapp.domain.comments.exception.CommentException;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 댓글과 대댓글 관련 엔티티와 DTO 간 변환을 담당하는 컨버터 클래스
+ */
+@Component
+public class CommentConverter {
+
+    /**
+     * 댓글 작성 요청 DTO를 댓글 엔티티로 변환
+     *
+     * @param post 댓글이 작성될 게시글
+     * @param member 댓글 작성자
+     * @param request 댓글 작성 요청 DTO
+     * @param parentComment 부모 댓글 (대댓글인 경우)
+     * @return 생성된 댓글 엔티티
+     */
+    public Comment toCommentEntity(Post post, Member member, CommentRequestDto.CreateCommentRequest request, Comment parentComment) {
+        validateContent(request.content());
+
+        if (parentComment == null) {
+            // 일반 댓글
+            return new Comment(post, member, request.content());
+        } else {
+            // 대댓글
+            return new Comment(post, member, request.content(), parentComment);
+        }
+    }
+
+    /**
+     * 대댓글 작성 요청 DTO를 대댓글 엔티티로 변환
+     *
+     * @param comment 대댓글이 작성될 부모 댓글
+     * @param member 대댓글 작성자
+     * @param request 대댓글 작성 요청 DTO
+     * @return 생성된 대댓글 엔티티
+     */
+    public Recomment toRecommentEntity(Comment comment, Member member, CommentRequestDto.CreateCommentRequest request) {
+        validateContent(request.content());
+
+        return new Recomment(comment, member, request.content());
+    }
+
+    /**
+     * 댓글 엔티티를 댓글 생성 응답 DTO로 변환
+     *
+     * @param comment 댓글 엔티티
+     * @return 댓글 생성 응답 DTO
+     */
+    public CommentResponseDto.CreateCommentResponse toCreateCommentResponse(Comment comment) {
+        CommentResponseDto.UserInfo userInfo = createUserInfo(
+                comment.getMember().getId(),
+                comment.getMember().getNickname(),
+                comment.getMember().getProfileImgUrl(),
+                false
+        );
+
+        return new CommentResponseDto.CreateCommentResponse(
+                comment.getId(),
+                userInfo,
+                comment.getContent(),
+                comment.getParentComment() != null ? comment.getParentComment().getId() : null
+        );
+    }
+
+    /**
+     * 대댓글 엔티티를 대댓글 생성 응답 DTO로 변환
+     *
+     * @param recomment 대댓글 엔티티
+     * @return 대댓글 생성 응답 DTO
+     */
+    public CommentResponseDto.CreateCommentResponse toCreateRecommentResponse(Recomment recomment) {
+        CommentResponseDto.UserInfo userInfo = createUserInfo(
+                recomment.getMember().getId(),
+                recomment.getMember().getNickname(),
+                recomment.getMember().getProfileImgUrl(),
+                false
+        );
+
+        return new CommentResponseDto.CreateCommentResponse(
+                recomment.getId(),
+                userInfo,
+                recomment.getContent(),
+                recomment.getComment().getId()
+        );
+    }
+
+    /**
+     * 댓글 엔티티를 댓글 상세 정보 DTO로 변환
+     *
+     * @param comment 댓글 엔티티
+     * @param currentMemberId 현재 로그인한 회원 ID
+     * @param likedCommentIds 좋아요 누른 댓글 ID 목록
+     * @param followedMemberIds 팔로우한 회원 ID 목록
+     * @param recomments 대댓글 목록 (있는 경우)
+     * @param likedRecommentIds 좋아요 누른 대댓글 ID 목록
+     * @return 댓글 상세 정보 DTO
+     */
+    public CommentResponseDto.CommentInfo toCommentInfo(
+            Comment comment,
+            Long currentMemberId,
+            Set<Long> likedCommentIds,
+            Set<Long> followedMemberIds,
+            List<Recomment> recomments,
+            Set<Long> likedRecommentIds
+    ) {
+        CommentResponseDto.UserInfo userInfo = createUserInfo(
+                comment.getMember().getId(),
+                comment.getMember().getNickname(),
+                comment.getMember().getProfileImgUrl(),
+                followedMemberIds != null && followedMemberIds.contains(comment.getMember().getId())
+        );
+
+        // 대댓글 목록 변환 (있는 경우)
+        List<CommentResponseDto.RecommentInfo> recommentInfos = Collections.emptyList();
+        if (recomments != null && !recomments.isEmpty()) {
+            recommentInfos = recomments.stream()
+                    .map(recomment -> toRecommentInfo(
+                            recomment,
+                            currentMemberId,
+                            likedRecommentIds,
+                            followedMemberIds
+                    ))
+                    .collect(Collectors.toList());
+        }
+
+        return new CommentResponseDto.CommentInfo(
+                comment.getId(),
+                userInfo,
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getLikeCount(),
+                comment.getMember().getId().equals(currentMemberId),
+                likedCommentIds != null && likedCommentIds.contains(comment.getId()),
+                recommentInfos
+        );
+    }
+
+    /**
+     * 대댓글 엔티티를 대댓글 상세 정보 DTO로 변환
+     *
+     * @param recomment 대댓글 엔티티
+     * @param currentMemberId 현재 로그인한 회원 ID
+     * @param likedRecommentIds 좋아요 누른 대댓글 ID 목록
+     * @param followedMemberIds 팔로우한 회원 ID 목록
+     * @return 대댓글 상세 정보 DTO
+     */
+    public CommentResponseDto.RecommentInfo toRecommentInfo(
+            Recomment recomment,
+            Long currentMemberId,
+            Set<Long> likedRecommentIds,
+            Set<Long> followedMemberIds
+    ) {
+        CommentResponseDto.UserInfo userInfo = createUserInfo(
+                recomment.getMember().getId(),
+                recomment.getMember().getNickname(),
+                recomment.getMember().getProfileImgUrl(),
+                followedMemberIds != null && followedMemberIds.contains(recomment.getMember().getId())
+        );
+
+        return new CommentResponseDto.RecommentInfo(
+                recomment.getId(),
+                userInfo,
+                recomment.getContent(),
+                recomment.getCreatedAt(),
+                recomment.getLikeCount(),
+                recomment.getMember().getId().equals(currentMemberId),
+                likedRecommentIds != null && likedRecommentIds.contains(recomment.getId())
+        );
+    }
+
+    /**
+     * 댓글 목록을 댓글 목록 응답 DTO로 변환
+     *
+     * @param comments 댓글 목록
+     * @param currentMemberId 현재 로그인한 회원 ID
+     * @param likedCommentIds 좋아요 누른 댓글 ID 목록
+     * @param followedMemberIds 팔로우한 회원 ID 목록
+     * @param recommentsMap 댓글별 대댓글 목록 맵
+     * @param likedRecommentIds 좋아요 누른 대댓글 ID 목록
+     * @param nextCursor 다음 페이지 커서
+     * @return 댓글 목록 응답 DTO
+     */
+    public CommentResponseDto.CommentListResponse toCommentListResponse(
+            List<Comment> comments,
+            Long currentMemberId,
+            Set<Long> likedCommentIds,
+            Set<Long> followedMemberIds,
+            java.util.Map<Long, List<Recomment>> recommentsMap,
+            Set<Long> likedRecommentIds,
+            Long nextCursor
+    ) {
+        List<CommentResponseDto.CommentInfo> commentInfos = comments.stream()
+                .map(comment -> {
+                    List<Recomment> recommentList = recommentsMap.getOrDefault(comment.getId(), Collections.emptyList());
+                    return toCommentInfo(
+                            comment,
+                            currentMemberId,
+                            likedCommentIds,
+                            followedMemberIds,
+                            recommentList,
+                            likedRecommentIds
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new CommentResponseDto.CommentListResponse(
+                commentInfos,
+                nextCursor != null,
+                nextCursor
+        );
+    }
+
+    /**
+     * 대댓글 목록을 대댓글 목록 응답 DTO로 변환
+     *
+     * @param recomments 대댓글 목록
+     * @param currentMemberId 현재 로그인한 회원 ID
+     * @param likedRecommentIds 좋아요 누른 대댓글 ID 목록
+     * @param followedMemberIds 팔로우한 회원 ID 목록
+     * @param nextCursor 다음 페이지 커서
+     * @return 대댓글 목록 응답 DTO
+     */
+    public CommentResponseDto.RecommentListResponse toRecommentListResponse(
+            List<Recomment> recomments,
+            Long currentMemberId,
+            Set<Long> likedRecommentIds,
+            Set<Long> followedMemberIds,
+            Long nextCursor
+    ) {
+        List<CommentResponseDto.RecommentInfo> recommentInfos = recomments.stream()
+                .map(recomment -> toRecommentInfo(
+                        recomment,
+                        currentMemberId,
+                        likedRecommentIds,
+                        followedMemberIds
+                ))
+                .collect(Collectors.toList());
+
+        return new CommentResponseDto.RecommentListResponse(
+                recommentInfos,
+                nextCursor != null,
+                nextCursor
+        );
+    }
+
+    /**
+     * 단순 메시지 응답 DTO 생성
+     *
+     * @param message 메시지
+     * @return 메시지 응답 DTO
+     */
+    public CommentResponseDto.MessageResponse toMessageResponse(String message) {
+        return new CommentResponseDto.MessageResponse(message);
+    }
+
+    /**
+     * 유저 정보 DTO 생성 (중복 코드 제거를 위한 헬퍼 메서드)
+     */
+    private CommentResponseDto.UserInfo createUserInfo(Long id, String nickname, String profileImage, boolean isFollowed) {
+        return new CommentResponseDto.UserInfo(id, nickname, profileImage, isFollowed);
+    }
+
+    /**
+     * 댓글/대댓글 내용 유효성 검증
+     */
+    private void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "content");
+        }
+
+        if (content.length() > 2000) {
+            throw new CommentException(CommentErrorCode.CONTENT_LENGTH_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/LikeConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/LikeConverter.java
@@ -1,0 +1,67 @@
+package com.kakaobase.snsapp.domain.comments.converter;
+
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.comments.entity.CommentLike;
+import com.kakaobase.snsapp.domain.comments.entity.Recomment;
+import com.kakaobase.snsapp.domain.comments.entity.RecommentLike;
+import com.kakaobase.snsapp.domain.comments.exception.CommentException;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import org.springframework.stereotype.Component;
+
+/**
+ * 댓글 및 대댓글 좋아요 관련 변환을 담당하는 컨버터 클래스
+ */
+@Component
+public class LikeConverter {
+
+    /**
+     * 댓글 좋아요 엔티티 생성
+     *
+     * @param memberId 회원 ID
+     * @param commentId 댓글 ID
+     * @return 댓글 좋아요 엔티티
+     */
+    public CommentLike toCommentLikeEntity(Long memberId, Long commentId) {
+        return new CommentLike(memberId, commentId);
+    }
+
+    /**
+     * 대댓글 좋아요 엔티티 생성
+     *
+     * @param memberId 회원 ID
+     * @param recommentId 대댓글 ID
+     * @return 대댓글 좋아요 엔티티
+     */
+    public RecommentLike toRecommentLikeEntity(Long memberId, Long recommentId) {
+        return new RecommentLike(memberId, recommentId);
+    }
+
+    /**
+     * 댓글 좋아요 토글 응답 DTO 생성
+     *
+     * @param comment 댓글 엔티티
+     * @param isLiked 좋아요 상태
+     * @return 댓글 좋아요 토글 응답 DTO
+     */
+    public CommentResponseDto.CommentLikeResponse toCommentLikeResponse(Comment comment, boolean isLiked) {
+        if (comment == null) {
+            throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "존재하지 않는 댓글입니다.");
+        }
+        return new CommentResponseDto.CommentLikeResponse(isLiked, comment.getLikeCount());
+    }
+
+    /**
+     * 대댓글 좋아요 토글 응답 DTO 생성
+     *
+     * @param recomment 대댓글 엔티티
+     * @param isLiked 좋아요 상태
+     * @return 대댓글 좋아요 토글 응답 DTO
+     */
+    public CommentResponseDto.RecommentLikeResponse toRecommentLikeResponse(Recomment recomment, boolean isLiked) {
+        if (recomment == null) {
+            throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId", "존재하지 않는 대댓글입니다.");
+        }
+        return new CommentResponseDto.RecommentLikeResponse(isLiked, recomment.getLikeCount());
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentRequestDto.java
@@ -1,0 +1,97 @@
+package com.kakaobase.snsapp.domain.comments.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 댓글 관련 요청 DTO 클래스
+ * <p>
+ * 댓글 생성, 수정, 조회, 좋아요 등 댓글 관련 API 요청에 사용되는 DTO들을 포함합니다.
+ * </p>
+ */
+@Schema(description = "댓글 관련 요청 DTO 클래스")
+public class CommentRequestDto {
+
+    /**
+     * 댓글 작성 요청 DTO
+     */
+    @Schema(description = "댓글 작성 요청 DTO")
+    public record CreateCommentRequest(
+            @Schema(description = "댓글 내용", example = "이 댓글은 정말 유익하네요!", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "댓글 내용은 공백일 수 없습니다.")
+            @Size(min = 1, max = 2000, message = "댓글은 최대 2000자까지 작성할 수 있습니다.")
+            String content,
+
+            @Schema(description = "대댓글일 경우 부모 댓글 ID, 없으면 일반 댓글", example = "101", nullable = true)
+            Long parent_id
+    ) {}
+
+    /**
+     * 댓글 수정 요청 DTO
+     */
+    @Schema(description = "댓글 수정 요청 DTO")
+    public record UpdateCommentRequest(
+            @Schema(description = "수정할 댓글 내용", example = "수정된 댓글 내용입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "댓글 내용은 공백일 수 없습니다.")
+            @Size(min = 1, max = 2000, message = "댓글은 최대 2000자까지 작성할 수 있습니다.")
+            String content
+    ) {}
+
+    /**
+     * 댓글 목록 조회 요청 DTO
+     */
+    @Schema(description = "댓글 목록 조회 요청 DTO")
+    public record CommentPageRequest(
+            @Schema(description = "한 번에 불러올 댓글 수", example = "12", defaultValue = "12")
+            Integer limit,
+
+            @Schema(description = "페이지네이션 기준 커서 (이전 응답의 마지막 댓글 ID)", example = "123", nullable = true)
+            Long cursor
+    ) {
+        public CommentPageRequest {
+            if (limit == null) {
+                limit = 12;
+            }
+        }
+    }
+
+    /**
+     * 대댓글 목록 조회 요청 DTO
+     */
+    @Schema(description = "대댓글 목록 조회 요청 DTO")
+    public record RecommentPageRequest(
+            @Schema(description = "한 번에 불러올 대댓글 수", example = "12", defaultValue = "12")
+            Integer limit,
+
+            @Schema(description = "페이지네이션 기준 커서 (이전 응답의 마지막 대댓글 ID)", example = "123", nullable = true)
+            Long cursor
+    ) {
+        public RecommentPageRequest {
+            if (limit == null) {
+                limit = 12;
+            }
+        }
+    }
+
+    /**
+     * 댓글 좋아요 요청 DTO
+     */
+    @Schema(description = "댓글 좋아요 요청 DTO")
+    public record CommentLikeRequest(
+            @Schema(description = "좋아요를 누를 댓글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull(message = "댓글 ID는 필수입니다.")
+            Long commentId
+    ) {}
+
+    /**
+     * 대댓글 좋아요 요청 DTO
+     */
+    @Schema(description = "대댓글 좋아요 요청 DTO")
+    public record RecommentLikeRequest(
+            @Schema(description = "좋아요를 누를 대댓글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotNull(message = "대댓글 ID는 필수입니다.")
+            Long recommentId
+    ) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -1,0 +1,187 @@
+package com.kakaobase.snsapp.domain.comments.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 댓글 관련 응답 DTO 클래스
+ * <p>
+ * 댓글 생성, 조회, 삭제, 좋아요 등 댓글 관련 API 응답에 사용되는 DTO들을 포함합니다.
+ * </p>
+ */
+@Schema(description = "댓글 관련 응답 DTO 클래스")
+public class CommentResponseDto {
+
+    /**
+     * 댓글 작성자 정보 DTO
+     */
+    @Schema(description = "댓글 작성자 정보")
+    public record UserInfo(
+            @Schema(description = "회원 ID", example = "10")
+            Long id,
+
+            @Schema(description = "회원 닉네임", example = "댓글러")
+            String nickname,
+
+            @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
+            String profile_image,
+
+            @Schema(description = "팔로우 여부", example = "false")
+            boolean is_followed
+    ) {}
+
+    /**
+     * 대댓글 정보 DTO
+     */
+    @Schema(description = "대댓글 정보")
+    public record RecommentInfo(
+            @Schema(description = "대댓글 ID", example = "201")
+            Long id,
+
+            @Schema(description = "작성자 정보")
+            UserInfo user,
+
+            @Schema(description = "대댓글 내용", example = "저도 그렇게 생각해요!")
+            String content,
+
+            @Schema(description = "작성 시간", example = "2024-04-25T13:15:00Z")
+            LocalDateTime created_at,
+
+            @Schema(description = "좋아요 수", example = "1")
+            int like_count,
+
+            @Schema(description = "본인 작성 여부", example = "false")
+            boolean is_mine,
+
+            @Schema(description = "좋아요 여부", example = "true")
+            boolean is_liked
+    ) {}
+
+    /**
+     * 댓글 정보 DTO
+     */
+    @Schema(description = "댓글 정보")
+    public record CommentInfo(
+            @Schema(description = "댓글 ID", example = "101")
+            Long id,
+
+            @Schema(description = "작성자 정보")
+            UserInfo user,
+
+            @Schema(description = "댓글 내용", example = "이 게시글 정말 유익하네요!")
+            String content,
+
+            @Schema(description = "작성 시간", example = "2024-04-25T13:00:00Z")
+            LocalDateTime created_at,
+
+            @Schema(description = "좋아요 수", example = "3")
+            int like_count,
+
+            @Schema(description = "본인 작성 여부", example = "true")
+            boolean is_mine,
+
+            @Schema(description = "좋아요 여부", example = "false")
+            boolean is_liked,
+
+            @Schema(description = "대댓글 목록", nullable = true)
+            List<RecommentInfo> recomments
+    ) {}
+
+    /**
+     * 댓글 생성 응답 DTO
+     */
+    @Schema(description = "댓글 생성 응답")
+    public record CreateCommentResponse(
+            @Schema(description = "댓글 ID", example = "456")
+            Long id,
+
+            @Schema(description = "작성자 정보")
+            UserInfo user,
+
+            @Schema(description = "댓글 내용", example = "이 댓글은 정말 유익하네요!")
+            String content,
+
+            @Schema(description = "부모 댓글 ID (대댓글인 경우)", example = "101", nullable = true)
+            Long parent_id
+    ) {}
+
+    /**
+     * 댓글 목록 응답 DTO
+     */
+    @Schema(description = "댓글 목록 응답")
+    public record CommentListResponse(
+            @Schema(description = "댓글 목록")
+            List<CommentInfo> comments,
+
+            @Schema(description = "다음 페이지 존재 여부", example = "true")
+            boolean has_next,
+
+            @Schema(description = "다음 페이지 커서", example = "102", nullable = true)
+            Long next_cursor
+    ) {}
+
+    /**
+     * 대댓글 목록 응답 DTO
+     */
+    @Schema(description = "대댓글 목록 응답")
+    public record RecommentListResponse(
+            @Schema(description = "대댓글 목록")
+            List<RecommentInfo> recomments,
+
+            @Schema(description = "다음 페이지 존재 여부", example = "true")
+            boolean has_next,
+
+            @Schema(description = "다음 페이지 커서", example = "202", nullable = true)
+            Long next_cursor
+    ) {}
+
+    /**
+     * 댓글 좋아요 토글 응답 DTO
+     */
+    @Schema(description = "댓글 좋아요 토글 응답")
+    public record CommentLikeResponse(
+            @Schema(description = "좋아요 상태 (true: 좋아요 등록, false: 좋아요 취소)", example = "true")
+            boolean liked,
+
+            @Schema(description = "좋아요 수", example = "4")
+            int like_count
+    ) {}
+
+    /**
+     * 대댓글 좋아요 토글 응답 DTO
+     */
+    @Schema(description = "대댓글 좋아요 토글 응답")
+    public record RecommentLikeResponse(
+            @Schema(description = "좋아요 상태 (true: 좋아요 등록, false: 좋아요 취소)", example = "true")
+            boolean liked,
+
+            @Schema(description = "좋아요 수", example = "2")
+            int like_count
+    ) {}
+
+    /**
+     * 기본 응답 메시지 DTO
+     */
+    @Schema(description = "기본 응답 메시지")
+    public record MessageResponse(
+            @Schema(description = "응답 메시지", example = "댓글이 삭제되었습니다.")
+            String message
+    ) {}
+
+    /**
+     * 에러 응답 DTO
+     */
+    @Schema(description = "에러 응답")
+    public record ErrorResponse(
+            @Schema(description = "에러 코드", example = "resource_not_found")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "해당 댓글을 찾을 수 없습니다.")
+            String message,
+
+            @Schema(description = "에러가 발생한 필드", example = "commentId", nullable = true)
+            String field
+    ) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
@@ -1,0 +1,152 @@
+package com.kakaobase.snsapp.domain.comments.entity;
+
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 댓글 정보를 담는 엔티티
+ * <p>
+ * 게시글에 달린 댓글과 대댓글 정보를 관리합니다.
+ * BaseSoftDeletableEntity를 상속받아 생성/수정/삭제 시간 정보를 관리합니다.
+ * 자기 참조를 통해 댓글-대댓글 관계를 구현합니다.
+ * </p>
+ */
+@Entity
+@Table(
+        name = "comments",
+        indexes = {
+                @Index(name = "idx_post_created_not_deleted", columnList = "post_id, created_at DESC"),
+                @Index(name = "idx_member_created_not_deleted", columnList = "member_id, created_at DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseSoftDeletableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "content", nullable = false, length = 3000)
+    private String content;
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
+    @Column(name = "recomment_count", nullable = false)
+    private int recommentCount = 0;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
+    private List<Comment> childComments = new ArrayList<>();
+
+    /**
+     * 일반 댓글 생성을 위한 생성자
+     *
+     * @param post 댓글이 작성될 게시글
+     * @param member 댓글 작성자
+     * @param content 댓글 내용
+     */
+    public Comment(Post post, Member member, String content) {
+        this.post = post;
+        this.member = member;
+        this.content = content;
+    }
+
+    /**
+     * 대댓글 생성을 위한 생성자
+     *
+     * @param post 댓글이 작성될 게시글
+     * @param member 댓글 작성자
+     * @param content 댓글 내용
+     * @param parentComment 부모 댓글 (대댓글의 대상이 되는 댓글)
+     */
+    public Comment(Post post, Member member, String content, Comment parentComment) {
+        this.post = post;
+        this.member = member;
+        this.content = content;
+        this.parentComment = parentComment;
+        if (parentComment != null) {
+            parentComment.increaseRecommentCount();
+        }
+    }
+
+    /**
+     * 댓글 내용 수정
+     *
+     * @param content 수정할 댓글 내용
+     */
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * 좋아요 수 증가
+     */
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    /**
+     * 좋아요 수 감소
+     */
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    /**
+     * 대댓글 수 증가
+     */
+    public void increaseRecommentCount() {
+        this.recommentCount++;
+    }
+
+    /**
+     * 대댓글 수 감소
+     */
+    public void decreaseRecommentCount() {
+        if (this.recommentCount > 0) {
+            this.recommentCount--;
+        }
+    }
+
+    /**
+     * 대댓글 여부 확인
+     *
+     * @return 대댓글이면 true, 일반 댓글이면 false
+     */
+    public boolean isRecomment() {
+        return this.parentComment != null;
+    }
+
+    /**
+     * 작성자 확인
+     *
+     * @param member 확인할 회원
+     * @return 입력받은 회원이 작성자면 true, 아니면 false
+     */
+    public boolean isWrittenBy(Member member) {
+        return this.member.getId().equals(member.getId());
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/CommentLike.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/CommentLike.java
@@ -1,0 +1,78 @@
+package com.kakaobase.snsapp.domain.comments.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 댓글 좋아요 정보를 담는 엔티티
+ * <p>
+ * 댓글에 좋아요를 누른 회원 정보를 관리합니다.
+ * 복합 기본키를 사용합니다 (회원 ID + 댓글 ID).
+ * </p>
+ */
+@Entity
+@Table(
+        name = "comment_likes",
+        indexes = {
+                @Index(name = "idx_member_id", columnList = "member_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(CommentLike.CommentLikeId.class)
+public class CommentLike {
+
+    @Id
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Id
+    @Column(name = "comment_id", nullable = false)
+    private Long commentId;
+
+    /**
+     * 좋아요 정보 생성을 위한 생성자
+     *
+     * @param memberId 좋아요를 누른 회원 ID
+     * @param commentId 좋아요가 눌린 댓글 ID
+     */
+    public CommentLike(Long memberId, Long commentId) {
+        this.memberId = memberId;
+        this.commentId = commentId;
+    }
+
+    /**
+     * CommentLike 엔티티의 복합 기본키 클래스
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CommentLikeId implements java.io.Serializable {
+        private Long memberId;
+        private Long commentId;
+
+        public CommentLikeId(Long memberId, Long commentId) {
+            this.memberId = memberId;
+            this.commentId = commentId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            CommentLikeId that = (CommentLikeId) o;
+
+            if (!memberId.equals(that.memberId)) return false;
+            return commentId.equals(that.commentId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = memberId.hashCode();
+            result = 31 * result + commentId.hashCode();
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Recomment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Recomment.java
@@ -1,0 +1,103 @@
+package com.kakaobase.snsapp.domain.comments.entity;
+
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 대댓글 정보를 담는 엔티티
+ * <p>
+ * 댓글에 달린 대댓글 정보를 관리합니다.
+ * BaseSoftDeletableEntity를 상속받아 생성/수정/삭제 시간 정보를 관리합니다.
+ * </p>
+ */
+@Entity
+@Table(
+        name = "recomments",
+        indexes = {
+                @Index(name = "idx_comment_created_not_deleted", columnList = "comment_id, created_at DESC"),
+                @Index(name = "idx_member_created_not_deleted", columnList = "member_id, created_at DESC")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recomment extends BaseSoftDeletableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "content", nullable = false, length = 3000)
+    private String content;
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0;
+
+    /**
+     * 대댓글 생성을 위한 생성자
+     *
+     * @param comment 대댓글이 작성될 댓글
+     * @param member 대댓글 작성자
+     * @param content 대댓글 내용
+     */
+    public Recomment(Comment comment, Member member, String content) {
+        this.comment = comment;
+        this.member = member;
+        this.content = content;
+        comment.increaseRecommentCount();
+    }
+
+    /**
+     * 대댓글 내용 수정
+     *
+     * @param content 수정할 대댓글 내용
+     */
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * 좋아요 수 증가
+     */
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    /**
+     * 좋아요 수 감소
+     */
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    /**
+     * 작성자 확인
+     *
+     * @param member 확인할 회원
+     * @return 입력받은 회원이 작성자면 true, 아니면 false
+     */
+    public boolean isWrittenBy(Member member) {
+        return this.member.getId().equals(member.getId());
+    }
+
+    /**
+     * 대댓글 삭제 시 부모 댓글의 대댓글 수 감소
+     */
+    @PreRemove
+    public void onPreRemove() {
+        comment.decreaseRecommentCount();
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/RecommentLike.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/RecommentLike.java
@@ -1,0 +1,78 @@
+package com.kakaobase.snsapp.domain.comments.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 대댓글 좋아요 정보를 담는 엔티티
+ * <p>
+ * 대댓글에 좋아요를 누른 회원 정보를 관리합니다.
+ * 복합 기본키를 사용합니다 (회원 ID + 대댓글 ID).
+ * </p>
+ */
+@Entity
+@Table(
+        name = "recomment_likes",
+        indexes = {
+                @Index(name = "idx_member_id", columnList = "member_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@IdClass(RecommentLike.RecommentLikeId.class)
+public class RecommentLike {
+
+    @Id
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Id
+    @Column(name = "recomment_id", nullable = false)
+    private Long recommentId;
+
+    /**
+     * 좋아요 정보 생성을 위한 생성자
+     *
+     * @param memberId 좋아요를 누른 회원 ID
+     * @param recommentId 좋아요가 눌린 대댓글 ID
+     */
+    public RecommentLike(Long memberId, Long recommentId) {
+        this.memberId = memberId;
+        this.recommentId = recommentId;
+    }
+
+    /**
+     * RecommentLike 엔티티의 복합 기본키 클래스
+     */
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecommentLikeId implements java.io.Serializable {
+        private Long memberId;
+        private Long recommentId;
+
+        public RecommentLikeId(Long memberId, Long recommentId) {
+            this.memberId = memberId;
+            this.recommentId = recommentId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            RecommentLikeId that = (RecommentLikeId) o;
+
+            if (!memberId.equals(that.memberId)) return false;
+            return recommentId.equals(that.recommentId);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = memberId.hashCode();
+            result = 31 * result + recommentId.hashCode();
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/exception/CommentErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/exception/CommentErrorCode.java
@@ -1,0 +1,27 @@
+package com.kakaobase.snsapp.domain.comments.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements BaseErrorCode {
+
+
+    CONTENT_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "content_length_exceeded", "댓글 본문은 최대 2000자까지 작성할 수 있습니다.", "content"),
+
+    // 권한 관련 에러
+    POST_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "forbidden", "본인의 댓글만 삭제할 수 있습니다.", "postId"),
+    POST_TYPE_FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden", "해당 댓글에 접근할 권한이 없습니다.", "postType"),
+
+    // 좋아요 관련 에러
+    ALREADY_LIKED(HttpStatus.CONFLICT, "state_conflict", "이미 좋아요한 댓글입니다.", null),
+    ALREADY_UNLIKED(HttpStatus.CONFLICT, "state_conflict", "이미 좋아요를 취소한 댓글입니다.", null);
+
+    private final HttpStatus status;
+    private final String error;
+    private final String message;
+    private final String field;
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/exception/CommentException.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/exception/CommentException.java
@@ -1,0 +1,63 @@
+package com.kakaobase.snsapp.domain.comments.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import com.kakaobase.snsapp.global.error.exception.CustomException;
+
+/**
+ * 게시글 도메인에서 발생하는 예외를 처리하는 클래스입니다.
+ * CustomException을 상속받아 게시글 관련 예외를 특화하여 처리합니다.
+ */
+public class CommentException extends CustomException {
+
+    /**
+     * 게시글 관련 에러 코드를 받아 PostException을 생성합니다.
+     *
+     * @param errorCode 에러 코드 (PostErrorCode)
+     */
+    public CommentException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    /**
+     * 게시글 관련 에러 코드와 필드를 받아 PostException을 생성합니다.
+     *
+     * @param errorCode 에러 코드 (PostErrorCode)
+     * @param field 에러가 발생한 필드
+     */
+    public CommentException(BaseErrorCode errorCode, String field) {
+        super(errorCode, field);
+    }
+
+    /**
+     * 게시글 관련 에러 코드, 필드, 추가 메시지를 받아 PostException을 생성합니다.
+     *
+     * @param errorCode 에러 코드 (PostErrorCode)
+     * @param field 에러가 발생한 필드
+     * @param additionalMessage 추가 메시지
+     */
+    public CommentException(BaseErrorCode errorCode, String field, String additionalMessage) {
+        super(errorCode, field, additionalMessage);
+    }
+
+    /**
+     * 특정 게시글 ID에 대한 에러를 생성하는 편의 메서드
+     *
+     * @param errorCode 에러 코드
+     * @param postId 게시글 ID
+     * @return 게시글 ID 정보가 포함된 예외
+     */
+    public static CommentException forPostId(BaseErrorCode errorCode, Long postId) {
+        return new CommentException(errorCode, "postId", "게시글 ID: " + postId);
+    }
+
+    /**
+     * 특정 게시판 타입에 대한 에러를 생성하는 편의 메서드
+     *
+     * @param errorCode 에러 코드
+     * @param postType 게시판 타입
+     * @return 게시판 타입 정보가 포함된 예외
+     */
+    public static CommentException forPostType(BaseErrorCode errorCode, String postType) {
+        return new CommentException(errorCode, "postType", "게시판 타입: " + postType);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -1,0 +1,94 @@
+package com.kakaobase.snsapp.domain.comments.repository;
+
+import com.kakaobase.snsapp.domain.comments.entity.CommentLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 댓글 좋아요 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>댓글 좋아요에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface CommentLikeRepository extends JpaRepository<CommentLike, CommentLike.CommentLikeId> {
+
+    /**
+     * 특정 회원이 특정 댓글에 좋아요를 눌렀는지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param commentId 댓글 ID
+     * @return 좋아요 정보 (Optional)
+     */
+    Optional<CommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
+
+    /**
+     * 특정 회원이 특정 댓글에 좋아요를 눌렀는지 여부를 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param commentId 댓글 ID
+     * @return 좋아요를 눌렀으면 true, 아니면 false
+     */
+    boolean existsByMemberIdAndCommentId(Long memberId, Long commentId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 댓글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 좋아요를 누른 댓글 ID 목록
+     */
+    @Query("SELECT cl.commentId FROM CommentLike cl WHERE cl.memberId = :memberId")
+    List<Long> findCommentIdsByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 회원이 주어진 댓글 목록 중 좋아요를 누른 댓글 ID 목록을 조회합니다.
+     * 댓글 목록 조회 시 좋아요 여부를 확인하는 데 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     * @param commentIds 댓글 목록
+     * @return 좋아요를 누른 댓글 ID 목록
+     */
+    @Query("SELECT cl.commentId FROM CommentLike cl WHERE cl.memberId = :memberId AND cl.commentId IN :commentIds")
+    List<Long> findCommentIdsByMemberIdAndCommentIdIn(
+            @Param("memberId") Long memberId,
+            @Param("commentIds") List<Long> commentIds);
+
+    /**
+     * 특정 댓글의 좋아요 수를 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @return 좋아요 수
+     */
+    long countByCommentId(Long commentId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 댓글 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 좋아요를 누른 댓글 ID 목록 (페이지네이션 적용)
+     */
+    Page<CommentLike> findByMemberId(Long memberId, Pageable pageable);
+
+    /**
+     * 특정 댓글의 모든 좋아요를 삭제합니다.
+     * 댓글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param commentId 댓글 ID
+     */
+    void deleteByCommentId(Long commentId);
+
+    /**
+     * 특정 회원의 모든 좋아요를 삭제합니다.
+     * 회원 탈퇴 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     */
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -1,0 +1,146 @@
+package com.kakaobase.snsapp.domain.comments.repository;
+
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 댓글 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>댓글에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    /**
+     * 특정 게시글의 최상위 댓글(대댓글이 아닌 댓글)을 생성 시간 역순으로 조회합니다.
+     * 삭제되지 않은 댓글만 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @param pageable 페이지네이션 정보
+     * @return 댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND c.parentComment IS NULL AND c.deletedAt IS NULL ORDER BY c.createdAt DESC")
+    Page<Comment> findTopLevelCommentsByPostId(@Param("postId") Long postId, Pageable pageable);
+
+    /**
+     * 특정 게시글의 삭제되지 않은 댓글을 커서 기반으로 조회합니다.
+     * 최상위 댓글(대댓글이 아닌 댓글)만 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @param cursor 마지막으로 조회한 댓글 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 댓글 수
+     * @return 댓글 목록
+     */
+    @Query(value = "SELECT c.* FROM comments c " +
+            "WHERE c.post_id = :postId " +
+            "AND c.parent_id IS NULL " +
+            "AND c.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR c.id < :cursor) " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Comment> findTopLevelCommentsByPostIdWithCursor(
+            @Param("postId") Long postId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+    /**
+     * 특정 댓글의 대댓글을 생성 시간 순으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param pageable 페이지네이션 정보
+     * @return 대댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :commentId AND c.deletedAt IS NULL ORDER BY c.createdAt ASC")
+    Page<Comment> findRepliesByCommentId(@Param("commentId") Long commentId, Pageable pageable);
+
+    /**
+     * 특정 댓글의 대댓글을 커서 기반으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 대댓글 수
+     * @return 대댓글 목록
+     */
+    @Query(value = "SELECT c.* FROM comments c " +
+            "WHERE c.parent_id = :commentId " +
+            "AND c.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR c.id < :cursor) " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Comment> findRepliesByCommentIdWithCursor(
+            @Param("commentId") Long commentId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+    /**
+     * 특정 회원이 작성한 댓글을 생성 시간 역순으로 조회합니다.
+     * 삭제되지 않은 댓글만 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.deletedAt IS NULL ORDER BY c.createdAt DESC")
+    Page<Comment> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    /**
+     * 특정 회원이 작성한 댓글을 커서 기반으로 조회합니다.
+     * 삭제되지 않은 댓글만 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param cursor 마지막으로 조회한 댓글 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 댓글 수
+     * @return 댓글 목록
+     */
+    @Query(value = "SELECT c.* FROM comments c " +
+            "WHERE c.member_id = :memberId " +
+            "AND c.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR c.id < :cursor) " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Comment> findByMemberIdWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+    /**
+     * 특정 댓글을 ID로 조회합니다. 삭제된 댓글은 포함하지 않습니다.
+     *
+     * @param id 댓글 ID
+     * @return 댓글 (Optional)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.id = :id AND c.deletedAt IS NULL")
+    Optional<Comment> findByIdAndDeletedAtIsNull(@Param("id") Long id);
+
+    /**
+     * 특정 게시글의 댓글 수를 조회합니다.
+     * 삭제되지 않은 댓글만 계산합니다.
+     *
+     * @param postId 게시글 ID
+     * @return 댓글 수
+     */
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.post.id = :postId AND c.deletedAt IS NULL")
+    long countByPostIdAndDeletedAtIsNull(@Param("postId") Long postId);
+
+    /**
+     * 특정 게시글의 모든 댓글을 찾습니다.
+     * 대댓글도 포함됩니다.
+     *
+     * @param postId 게시글 ID
+     * @return 댓글 목록
+     */
+    List<Comment> findByPostId(Long postId);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -1,0 +1,94 @@
+package com.kakaobase.snsapp.domain.comments.repository;
+
+import com.kakaobase.snsapp.domain.comments.entity.RecommentLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 대댓글 좋아요 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>대댓글 좋아요에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface RecommentLikeRepository extends JpaRepository<RecommentLike, RecommentLike.RecommentLikeId> {
+
+    /**
+     * 특정 회원이 특정 대댓글에 좋아요를 눌렀는지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param recommentId 대댓글 ID
+     * @return 좋아요 정보 (Optional)
+     */
+    Optional<RecommentLike> findByMemberIdAndRecommentId(Long memberId, Long recommentId);
+
+    /**
+     * 특정 회원이 특정 대댓글에 좋아요를 눌렀는지 여부를 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param recommentId 대댓글 ID
+     * @return 좋아요를 눌렀으면 true, 아니면 false
+     */
+    boolean existsByMemberIdAndRecommentId(Long memberId, Long recommentId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 대댓글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 좋아요를 누른 대댓글 ID 목록
+     */
+    @Query("SELECT rl.recommentId FROM RecommentLike rl WHERE rl.memberId = :memberId")
+    List<Long> findRecommentIdsByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 회원이 주어진 대댓글 목록 중 좋아요를 누른 대댓글 ID 목록을 조회합니다.
+     * 대댓글 목록 조회 시 좋아요 여부를 확인하는 데 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     * @param recommentIds 대댓글 목록
+     * @return 좋아요를 누른 대댓글 ID 목록
+     */
+    @Query("SELECT rl.recommentId FROM RecommentLike rl WHERE rl.memberId = :memberId AND rl.recommentId IN :recommentIds")
+    List<Long> findRecommentIdsByMemberIdAndRecommentIdIn(
+            @Param("memberId") Long memberId,
+            @Param("recommentIds") List<Long> recommentIds);
+
+    /**
+     * 특정 대댓글의 좋아요 수를 조회합니다.
+     *
+     * @param recommentId 대댓글 ID
+     * @return 좋아요 수
+     */
+    long countByRecommentId(Long recommentId);
+
+    /**
+     * 특정 회원이 좋아요를 누른 대댓글 목록을 페이지네이션하여 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 좋아요를 누른 대댓글 ID 목록 (페이지네이션 적용)
+     */
+    Page<RecommentLike> findByMemberId(Long memberId, Pageable pageable);
+
+    /**
+     * 특정 대댓글의 모든 좋아요를 삭제합니다.
+     * 대댓글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param recommentId 대댓글 ID
+     */
+    void deleteByRecommentId(Long recommentId);
+
+    /**
+     * 특정 회원의 모든 좋아요를 삭제합니다.
+     * 회원 탈퇴 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param memberId 회원 ID
+     */
+    void deleteByMemberId(Long memberId);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -1,0 +1,131 @@
+package com.kakaobase.snsapp.domain.comments.repository;
+
+import com.kakaobase.snsapp.domain.comments.entity.Recomment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 대댓글 엔티티에 대한 데이터 액세스 객체
+ *
+ * <p>대댓글에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
+ */
+@Repository
+public interface RecommentRepository extends JpaRepository<Recomment, Long> {
+
+    /**
+     * 특정 댓글의 대댓글을 생성 시간 순으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param pageable 페이지네이션 정보
+     * @return 대댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL ORDER BY r.createdAt ASC")
+    Page<Recomment> findByCommentId(@Param("commentId") Long commentId, Pageable pageable);
+
+    /**
+     * 특정 댓글의 대댓글을 커서 기반으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 대댓글 수
+     * @return 대댓글 목록
+     */
+    @Query(value = "SELECT r.* FROM recomments r " +
+            "WHERE r.comment_id = :commentId " +
+            "AND r.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR r.id < :cursor) " +
+            "ORDER BY r.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Recomment> findByCommentIdWithCursor(
+            @Param("commentId") Long commentId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+    /**
+     * 특정 회원이 작성한 대댓글을 생성 시간 역순으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param pageable 페이지네이션 정보
+     * @return 대댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.member.id = :memberId AND r.deletedAt IS NULL ORDER BY r.createdAt DESC")
+    Page<Recomment> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    /**
+     * 특정 회원이 작성한 대댓글을 커서 기반으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null 또는 0)
+     * @param limit 조회할 대댓글 수
+     * @return 대댓글 목록
+     */
+    @Query(value = "SELECT r.* FROM recomments r " +
+            "WHERE r.member_id = :memberId " +
+            "AND r.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR r.id < :cursor) " +
+            "ORDER BY r.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Recomment> findByMemberIdWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+    /**
+     * 특정 대댓글을 ID로 조회합니다. 삭제된 대댓글은 포함하지 않습니다.
+     *
+     * @param id 대댓글 ID
+     * @return 대댓글 (Optional)
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.id = :id AND r.deletedAt IS NULL")
+    Optional<Recomment> findByIdAndDeletedAtIsNull(@Param("id") Long id);
+
+    /**
+     * 특정 댓글의 대댓글 수를 조회합니다.
+     * 삭제되지 않은 대댓글만 계산합니다.
+     *
+     * @param commentId 댓글 ID
+     * @return 대댓글 수
+     */
+    @Query("SELECT COUNT(r) FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL")
+    long countByCommentIdAndDeletedAtIsNull(@Param("commentId") Long commentId);
+
+    /**
+     * 특정 댓글의 모든 대댓글을 조회합니다.
+     * 삭제된 대댓글도 포함됩니다.
+     *
+     * @param commentId 댓글 ID
+     * @return 대댓글 목록
+     */
+    List<Recomment> findByCommentId(Long commentId);
+
+    /**
+     * 특정 댓글에 달린 대댓글 중 최근 몇 개를 조회합니다.
+     * 삭제되지 않은 대댓글만 조회하며, 최신순으로 정렬합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param limit 조회할 대댓글 수
+     * @return 대댓글 목록
+     */
+    @Query(value = "SELECT r.* FROM recomments r " +
+            "WHERE r.comment_id = :commentId " +
+            "AND r.deleted_at IS NULL " +
+            "ORDER BY r.created_at DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Recomment> findRecentByCommentId(
+            @Param("commentId") Long commentId,
+            @Param("limit") int limit);
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #22

## 📌 개요
- CustomUserDetails의 생성자 매개변수를 직렬화 가능한 값만 받도록 변경
- 비즈니스 로직을 제외한 Comment도메인에 필요한 요소 구현
Comment도메인의 Dto, Converter, Exception, Entity, Repository, Controller생성

## 🔁 변경 사항
### CustomDetails 리팩토링
- CustomUserDetails 생성자 매개변수 변경
CustomUserDetails가 member객체를 매개변수를 받는 로직에서
직렬화 가능한 매개변수 email, password, id, role, isEnable만 받도록 수정
- 용도에 따른 CustomUserDetails생성자 분리
CustomUserDetails는 로그인시 사용되는 email, password를 포함한 나머지 필드를 받는 생성자와
JWT를 포함한 요청시 구현되는 id, role, isEnable만 받는 생성자 2개가 존재
- UserAuthenticationService의 login로직을 변경


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.