### PR TITLE
[BE - FEAT] Comment도메인 서비스 로직 구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
@@ -70,6 +70,29 @@ public class CommentController {
     }
 
     /**
+     * 댓글 상세 조회 API
+     */
+    @GetMapping("/comments/{commentId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "댓글 상세 조회",
+            description = "특정 댓글의 상세 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CommentDetailResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음")
+    })
+    public ResponseEntity<CustomResponse<CommentResponseDto.CommentDetailResponse>> getCommentDetail(
+            @PathVariable Long commentId
+    ) {
+        Long memberId = getCurrentMemberId();
+        CommentResponseDto.CommentDetailResponse response = commentService.getCommentDetail(memberId, commentId);
+        return ResponseEntity.ok(CustomResponse.success("댓글을 성공적으로 불러왔습니다.", response));
+    }
+
+    /**
      * 댓글 삭제 API
      */
     @DeleteMapping("/comments/{commentId}")

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentRequestDto.java
@@ -28,16 +28,6 @@ public class CommentRequestDto {
             Long parent_id
     ) {}
 
-    /**
-     * 댓글 수정 요청 DTO
-     */
-    @Schema(description = "댓글 수정 요청 DTO")
-    public record UpdateCommentRequest(
-            @Schema(description = "수정할 댓글 내용", example = "수정된 댓글 내용입니다.", requiredMode = Schema.RequiredMode.REQUIRED)
-            @NotBlank(message = "댓글 내용은 공백일 수 없습니다.")
-            @Size(min = 1, max = 2000, message = "댓글은 최대 2000자까지 작성할 수 있습니다.")
-            String content
-    ) {}
 
     /**
      * 댓글 목록 조회 요청 DTO

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentRequestDto.java
@@ -76,22 +76,30 @@ public class CommentRequestDto {
     }
 
     /**
-     * 댓글 좋아요 요청 DTO
+     * 댓글 신고 요청 DTO (V2에서 구현 예정)
      */
-    @Schema(description = "댓글 좋아요 요청 DTO")
-    public record CommentLikeRequest(
-            @Schema(description = "좋아요를 누를 댓글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "댓글 신고 요청 DTO")
+    public record CommentReportRequest(
+            @Schema(description = "신고할 댓글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "댓글 ID는 필수입니다.")
-            Long commentId
+            Long commentId,
+
+            @Schema(description = "신고 사유", example = "스팸 또는 광고 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "신고 사유는 필수입니다.")
+            String reason
     ) {}
 
     /**
-     * 대댓글 좋아요 요청 DTO
+     * 대댓글 신고 요청 DTO (V2에서 구현 예정)
      */
-    @Schema(description = "대댓글 좋아요 요청 DTO")
-    public record RecommentLikeRequest(
-            @Schema(description = "좋아요를 누를 대댓글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(description = "대댓글 신고 요청 DTO")
+    public record RecommentReportRequest(
+            @Schema(description = "신고할 대댓글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
             @NotNull(message = "대댓글 ID는 필수입니다.")
-            Long recommentId
+            Long recommentId,
+
+            @Schema(description = "신고 사유", example = "스팸 또는 광고 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "신고 사유는 필수입니다.")
+            String reason
     ) {}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -164,6 +164,16 @@ public class CommentResponseDto {
     ) {}
 
     /**
+     * 댓글 상세 조회 응답 DTO
+     */
+    @Schema(description = "댓글 상세 조회 응답")
+    public record CommentDetailResponse(
+            @Schema(description = "댓글 상세 정보")
+            CommentInfo data
+    ) {
+    }
+
+    /**
      * 기본 응답 메시지 DTO
      */
     @Schema(description = "기본 응답 메시지")

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -28,9 +28,14 @@ public class CommentResponseDto {
             @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
             String profile_image,
 
-            @Schema(description = "팔로우 여부", example = "false")
+            @Schema(description = "팔로우 여부 (V2에서 구현)", example = "false")
             boolean is_followed
-    ) {}
+    ) {
+        // 팔로우 정보 없이 생성하는 생성자 추가 (V2 전까지 임시로 사용)
+        public UserInfo(Long id, String nickname, String profile_image) {
+            this(id, nickname, profile_image, false);  // 팔로우 여부는 항상 false로 설정
+        }
+    }
 
     /**
      * 대댓글 정보 DTO
@@ -83,10 +88,7 @@ public class CommentResponseDto {
             boolean is_mine,
 
             @Schema(description = "좋아요 여부", example = "false")
-            boolean is_liked,
-
-            @Schema(description = "대댓글 목록", nullable = true)
-            List<RecommentInfo> recomments
+            boolean is_liked
     ) {}
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
@@ -1,3 +1,4 @@
+// Comment.java
 package com.kakaobase.snsapp.domain.comments.entity;
 
 import com.kakaobase.snsapp.domain.members.entity.Member;
@@ -14,9 +15,9 @@ import java.util.List;
 /**
  * 댓글 정보를 담는 엔티티
  * <p>
- * 게시글에 달린 댓글과 대댓글 정보를 관리합니다.
+ * 게시글에 달린 댓글 정보를 관리합니다.
+ * 대댓글은 별도의 Recomment 엔티티에서 관리됩니다.
  * BaseSoftDeletableEntity를 상속받아 생성/수정/삭제 시간 정보를 관리합니다.
- * 자기 참조를 통해 댓글-대댓글 관계를 구현합니다.
  * </p>
  */
 @Entity
@@ -52,15 +53,11 @@ public class Comment extends BaseSoftDeletableEntity {
     @Column(name = "recomment_count", nullable = false)
     private int recommentCount = 0;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "parent_id")
-    private Comment parentComment;
-
-    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
-    private List<Comment> childComments = new ArrayList<>();
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
+    private List<Recomment> recomments = new ArrayList<>();
 
     /**
-     * 일반 댓글 생성을 위한 생성자
+     * 댓글 생성을 위한 생성자
      *
      * @param post 댓글이 작성될 게시글
      * @param member 댓글 작성자
@@ -70,24 +67,6 @@ public class Comment extends BaseSoftDeletableEntity {
         this.post = post;
         this.member = member;
         this.content = content;
-    }
-
-    /**
-     * 대댓글 생성을 위한 생성자
-     *
-     * @param post 댓글이 작성될 게시글
-     * @param member 댓글 작성자
-     * @param content 댓글 내용
-     * @param parentComment 부모 댓글 (대댓글의 대상이 되는 댓글)
-     */
-    public Comment(Post post, Member member, String content, Comment parentComment) {
-        this.post = post;
-        this.member = member;
-        this.content = content;
-        this.parentComment = parentComment;
-        if (parentComment != null) {
-            parentComment.increaseRecommentCount();
-        }
     }
 
     /**
@@ -129,15 +108,6 @@ public class Comment extends BaseSoftDeletableEntity {
         if (this.recommentCount > 0) {
             this.recommentCount--;
         }
-    }
-
-    /**
-     * 대댓글 여부 확인
-     *
-     * @return 대댓글이면 true, 일반 댓글이면 false
-     */
-    public boolean isRecomment() {
-        return this.parentComment != null;
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/exception/CommentErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/exception/CommentErrorCode.java
@@ -11,7 +11,7 @@ public enum CommentErrorCode implements BaseErrorCode {
 
 
     CONTENT_LENGTH_EXCEEDED(HttpStatus.BAD_REQUEST, "content_length_exceeded", "댓글 본문은 최대 2000자까지 작성할 수 있습니다.", "content"),
-
+    INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, "invalid_parent_comment", "유효하지 않은 부모 댓글입니다. 대댓글에는 댓글을 작성할 수 없습니다.", null),
     // 권한 관련 에러
     POST_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "forbidden", "본인의 댓글만 삭제할 수 있습니다.", "postId"),
     POST_TYPE_FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden", "해당 댓글에 접근할 권한이 없습니다.", "postType"),

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -81,8 +81,9 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Commen
      * 댓글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
      *
      * @param commentId 댓글 ID
+     * @return 삭제된 좋아요 수
      */
-    void deleteByCommentId(Long commentId);
+    int deleteByCommentId(Long commentId);
 
     /**
      * 특정 회원의 모든 좋아요를 삭제합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -136,11 +136,35 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     long countByPostIdAndDeletedAtIsNull(@Param("postId") Long postId);
 
     /**
-     * 특정 게시글의 모든 댓글을 찾습니다.
-     * 대댓글도 포함됩니다.
+     * 특정 게시글의 댓글을 페이지네이션하여 조회합니다.
+     * 삭제되지 않은 댓글만 조회합니다.
      *
      * @param postId 게시글 ID
+     * @param pageable 페이지네이션 정보
+     * @return 댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND c.deletedAt IS NULL")
+    Page<Comment> findByPostId(@Param("postId") Long postId, Pageable pageable);
+
+    /**
+     * 특정 게시글의 댓글을 커서 기반으로 조회합니다.
+     * ID가 특정 값보다 작은 댓글들을 ID 내림차순으로 조회합니다.
+     * 삭제되지 않은 댓글만 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @param commentId 커서(특정 댓글 ID)
+     * @param limit 조회할 최대 댓글 수
      * @return 댓글 목록
      */
-    List<Comment> findByPostId(Long postId);
+    @Query(value = "SELECT c.* FROM comments c " +
+            "WHERE c.post_id = :postId " +
+            "AND c.id < :commentId " +
+            "AND c.deleted_at IS NULL " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Comment> findByPostIdAndIdLessThanOrderByIdDesc(
+            @Param("postId") Long postId,
+            @Param("commentId") Long commentId,
+            @Param("limit") int limit);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -1,8 +1,7 @@
+// CommentRepository.java
 package com.kakaobase.snsapp.domain.comments.repository;
 
 import com.kakaobase.snsapp.domain.comments.entity.Comment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,108 +12,9 @@ import java.util.Optional;
 
 /**
  * 댓글 엔티티에 대한 데이터 액세스 객체
- *
- * <p>댓글에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
  */
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-    /**
-     * 특정 게시글의 최상위 댓글(대댓글이 아닌 댓글)을 생성 시간 역순으로 조회합니다.
-     * 삭제되지 않은 댓글만 조회합니다.
-     *
-     * @param postId 게시글 ID
-     * @param pageable 페이지네이션 정보
-     * @return 댓글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND c.parentComment IS NULL AND c.deletedAt IS NULL ORDER BY c.createdAt DESC")
-    Page<Comment> findTopLevelCommentsByPostId(@Param("postId") Long postId, Pageable pageable);
-
-    /**
-     * 특정 게시글의 삭제되지 않은 댓글을 커서 기반으로 조회합니다.
-     * 최상위 댓글(대댓글이 아닌 댓글)만 조회합니다.
-     *
-     * @param postId 게시글 ID
-     * @param cursor 마지막으로 조회한 댓글 ID (첫 페이지에서는 null 또는 0)
-     * @param limit 조회할 댓글 수
-     * @return 댓글 목록
-     */
-    @Query(value = "SELECT c.* FROM comments c " +
-            "WHERE c.post_id = :postId " +
-            "AND c.parent_id IS NULL " +
-            "AND c.deleted_at IS NULL " +
-            "AND (:cursor IS NULL OR c.id < :cursor) " +
-            "ORDER BY c.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
-    List<Comment> findTopLevelCommentsByPostIdWithCursor(
-            @Param("postId") Long postId,
-            @Param("cursor") Long cursor,
-            @Param("limit") int limit);
-
-    /**
-     * 특정 댓글의 대댓글을 생성 시간 순으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param commentId 댓글 ID
-     * @param pageable 페이지네이션 정보
-     * @return 대댓글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT c FROM Comment c WHERE c.parentComment.id = :commentId AND c.deletedAt IS NULL ORDER BY c.createdAt ASC")
-    Page<Comment> findRepliesByCommentId(@Param("commentId") Long commentId, Pageable pageable);
-
-    /**
-     * 특정 댓글의 대댓글을 커서 기반으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param commentId 댓글 ID
-     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null 또는 0)
-     * @param limit 조회할 대댓글 수
-     * @return 대댓글 목록
-     */
-    @Query(value = "SELECT c.* FROM comments c " +
-            "WHERE c.parent_id = :commentId " +
-            "AND c.deleted_at IS NULL " +
-            "AND (:cursor IS NULL OR c.id < :cursor) " +
-            "ORDER BY c.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
-    List<Comment> findRepliesByCommentIdWithCursor(
-            @Param("commentId") Long commentId,
-            @Param("cursor") Long cursor,
-            @Param("limit") int limit);
-
-    /**
-     * 특정 회원이 작성한 댓글을 생성 시간 역순으로 조회합니다.
-     * 삭제되지 않은 댓글만 조회합니다.
-     *
-     * @param memberId 회원 ID
-     * @param pageable 페이지네이션 정보
-     * @return 댓글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT c FROM Comment c WHERE c.member.id = :memberId AND c.deletedAt IS NULL ORDER BY c.createdAt DESC")
-    Page<Comment> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
-
-    /**
-     * 특정 회원이 작성한 댓글을 커서 기반으로 조회합니다.
-     * 삭제되지 않은 댓글만 조회합니다.
-     *
-     * @param memberId 회원 ID
-     * @param cursor 마지막으로 조회한 댓글 ID (첫 페이지에서는 null 또는 0)
-     * @param limit 조회할 댓글 수
-     * @return 댓글 목록
-     */
-    @Query(value = "SELECT c.* FROM comments c " +
-            "WHERE c.member_id = :memberId " +
-            "AND c.deleted_at IS NULL " +
-            "AND (:cursor IS NULL OR c.id < :cursor) " +
-            "ORDER BY c.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
-    List<Comment> findByMemberIdWithCursor(
-            @Param("memberId") Long memberId,
-            @Param("cursor") Long cursor,
-            @Param("limit") int limit);
 
     /**
      * 특정 댓글을 ID로 조회합니다. 삭제된 댓글은 포함하지 않습니다.
@@ -124,6 +24,38 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
      */
     @Query("SELECT c FROM Comment c WHERE c.id = :id AND c.deletedAt IS NULL")
     Optional<Comment> findByIdAndDeletedAtIsNull(@Param("id") Long id);
+
+    /**
+     * 특정 댓글을 ID와 회원 ID로 조회합니다.
+     * 댓글의 소유자 확인에 사용됩니다.
+     *
+     * @param id 댓글 ID
+     * @param memberId 회원 ID
+     * @return 댓글 (Optional)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.id = :id AND c.member.id = :memberId AND c.deletedAt IS NULL")
+    Optional<Comment> findByIdAndMemberId(@Param("id") Long id, @Param("memberId") Long memberId);
+
+    /**
+     * 특정 게시글의 댓글을 커서 기반으로 조회합니다.
+     * 삭제되지 않은 댓글만 조회합니다.
+     *
+     * @param postId 게시글 ID
+     * @param cursor 마지막으로 조회한 댓글 ID (첫 페이지에서는 null)
+     * @param limit 조회할 댓글 수
+     * @return 댓글 목록
+     */
+    @Query(value = "SELECT c.* FROM comments c " +
+            "WHERE c.post_id = :postId " +
+            "AND c.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR c.id < :cursor) " +
+            "ORDER BY c.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Comment> findByPostIdWithCursor(
+            @Param("postId") Long postId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
 
     /**
      * 특정 게시글의 댓글 수를 조회합니다.
@@ -136,35 +68,33 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     long countByPostIdAndDeletedAtIsNull(@Param("postId") Long postId);
 
     /**
-     * 특정 게시글의 댓글을 페이지네이션하여 조회합니다.
-     * 삭제되지 않은 댓글만 조회합니다.
+     * 특정 댓글들의 좋아요 상태를 한번에 조회합니다.
+     * 댓글 좋아요 테이블을 기반으로 좋아요 여부를 확인합니다.
      *
-     * @param postId 게시글 ID
-     * @param pageable 페이지네이션 정보
-     * @return 댓글 목록 (페이지네이션 적용)
+     * @param commentIds 댓글 ID 목록
+     * @param memberId 회원 ID
+     * @return 회원이 좋아요 한 댓글 ID 목록
      */
-    @Query("SELECT c FROM Comment c WHERE c.post.id = :postId AND c.deletedAt IS NULL")
-    Page<Comment> findByPostId(@Param("postId") Long postId, Pageable pageable);
+    @Query(value = "SELECT cl.comment_id FROM comment_likes cl " +
+            "WHERE cl.comment_id IN :commentIds " +
+            "AND cl.member_id = :memberId",
+            nativeQuery = true)
+    List<Long> findLikedCommentIds(
+            @Param("commentIds") List<Long> commentIds,
+            @Param("memberId") Long memberId);
 
     /**
-     * 특정 게시글의 댓글을 커서 기반으로 조회합니다.
-     * ID가 특정 값보다 작은 댓글들을 ID 내림차순으로 조회합니다.
-     * 삭제되지 않은 댓글만 조회합니다.
+     * 특정 회원이 특정 댓글에 좋아요를 했는지 확인합니다.
      *
-     * @param postId 게시글 ID
-     * @param commentId 커서(특정 댓글 ID)
-     * @param limit 조회할 최대 댓글 수
-     * @return 댓글 목록
+     * @param commentId 댓글 ID
+     * @param memberId 회원 ID
+     * @return 좋아요 여부
      */
-    @Query(value = "SELECT c.* FROM comments c " +
-            "WHERE c.post_id = :postId " +
-            "AND c.id < :commentId " +
-            "AND c.deleted_at IS NULL " +
-            "ORDER BY c.id DESC " +
-            "LIMIT :limit",
+    @Query(value = "SELECT COUNT(*) > 0 FROM comment_likes cl " +
+            "WHERE cl.comment_id = :commentId " +
+            "AND cl.member_id = :memberId",
             nativeQuery = true)
-    List<Comment> findByPostIdAndIdLessThanOrderByIdDesc(
-            @Param("postId") Long postId,
+    boolean existsCommentLike(
             @Param("commentId") Long commentId,
-            @Param("limit") int limit);
+            @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -81,8 +81,19 @@ public interface RecommentLikeRepository extends JpaRepository<RecommentLike, Re
      * 대댓글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
      *
      * @param recommentId 대댓글 ID
+     * @return 삭제된 좋아요 수
      */
-    void deleteByRecommentId(Long recommentId);
+    int deleteByRecommentId(Long recommentId);
+
+    /**
+     * 특정 대댓글 목록의 모든 좋아요를 삭제합니다.
+     * 여러 대댓글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
+     *
+     * @param recommentIds 대댓글 ID 목록
+     * @return 삭제된 좋아요 수
+     */
+    @Query("DELETE FROM RecommentLike rl WHERE rl.recommentId IN :recommentIds")
+    int deleteByRecommentIdIn(@Param("recommentIds") List<Long> recommentIds);
 
     /**
      * 특정 회원의 모든 좋아요를 삭제합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -1,8 +1,7 @@
+// RecommentRepository.java
 package com.kakaobase.snsapp.domain.comments.repository;
 
 import com.kakaobase.snsapp.domain.comments.entity.Recomment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,75 +12,9 @@ import java.util.Optional;
 
 /**
  * 대댓글 엔티티에 대한 데이터 액세스 객체
- *
- * <p>대댓글에 대한 CRUD 및 다양한 조회 작업을 처리합니다.</p>
  */
 @Repository
 public interface RecommentRepository extends JpaRepository<Recomment, Long> {
-
-    /**
-     * 특정 댓글의 대댓글을 생성 시간 순으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param commentId 댓글 ID
-     * @param pageable 페이지네이션 정보
-     * @return 대댓글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT r FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL ORDER BY r.createdAt ASC")
-    Page<Recomment> findByCommentId(@Param("commentId") Long commentId, Pageable pageable);
-
-    /**
-     * 특정 댓글의 대댓글을 커서 기반으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param commentId 댓글 ID
-     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null 또는 0)
-     * @param limit 조회할 대댓글 수
-     * @return 대댓글 목록
-     */
-    @Query(value = "SELECT r.* FROM recomments r " +
-            "WHERE r.comment_id = :commentId " +
-            "AND r.deleted_at IS NULL " +
-            "AND (:cursor IS NULL OR r.id < :cursor) " +
-            "ORDER BY r.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
-    List<Recomment> findByCommentIdWithCursor(
-            @Param("commentId") Long commentId,
-            @Param("cursor") Long cursor,
-            @Param("limit") int limit);
-
-    /**
-     * 특정 회원이 작성한 대댓글을 생성 시간 역순으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param memberId 회원 ID
-     * @param pageable 페이지네이션 정보
-     * @return 대댓글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT r FROM Recomment r WHERE r.member.id = :memberId AND r.deletedAt IS NULL ORDER BY r.createdAt DESC")
-    Page<Recomment> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
-
-    /**
-     * 특정 회원이 작성한 대댓글을 커서 기반으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param memberId 회원 ID
-     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null 또는 0)
-     * @param limit 조회할 대댓글 수
-     * @return 대댓글 목록
-     */
-    @Query(value = "SELECT r.* FROM recomments r " +
-            "WHERE r.member_id = :memberId " +
-            "AND r.deleted_at IS NULL " +
-            "AND (:cursor IS NULL OR r.id < :cursor) " +
-            "ORDER BY r.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
-    List<Recomment> findByMemberIdWithCursor(
-            @Param("memberId") Long memberId,
-            @Param("cursor") Long cursor,
-            @Param("limit") int limit);
 
     /**
      * 특정 대댓글을 ID로 조회합니다. 삭제된 대댓글은 포함하지 않습니다.
@@ -91,6 +24,58 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
      */
     @Query("SELECT r FROM Recomment r WHERE r.id = :id AND r.deletedAt IS NULL")
     Optional<Recomment> findByIdAndDeletedAtIsNull(@Param("id") Long id);
+
+    /**
+     * 특정 대댓글을 ID와 회원 ID로 조회합니다.
+     * 대댓글의 소유자 확인에 사용됩니다.
+     *
+     * @param id 대댓글 ID
+     * @param memberId 회원 ID
+     * @return 대댓글 (Optional)
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.id = :id AND r.member.id = :memberId AND r.deletedAt IS NULL")
+    Optional<Recomment> findByIdAndMemberId(@Param("id") Long id, @Param("memberId") Long memberId);
+
+    /**
+     * 특정 댓글의 대댓글을 모두 조회합니다. (댓글 목록 조회 시 사용)
+     * 삭제되지 않은 대댓글만 조회하며, 생성 시간 오름차순으로 정렬합니다.
+     *
+     * @param commentId 댓글 ID
+     * @return 대댓글 목록
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL ORDER BY r.createdAt ASC")
+    List<Recomment> findByCommentId(@Param("commentId") Long commentId);
+
+    /**
+     * 특정 댓글의 모든 대댓글을 조회합니다. (삭제된 것 포함)
+     * 댓글 삭제 시 연관된 대댓글 삭제를 위해 사용됩니다.
+     *
+     * @param commentId 댓글 ID
+     * @return 대댓글 목록
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.comment.id = :commentId")
+    List<Recomment> findAllByCommentId(@Param("commentId") Long commentId);
+
+    /**
+     * 특정 댓글의 대댓글을 커서 기반으로 조회합니다. (대댓글 목록 API용)
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param cursor 마지막으로 조회한 대댓글 ID (첫 페이지에서는 null)
+     * @param limit 조회할 대댓글 수
+     * @return 대댓글 목록
+     */
+    @Query(value = "SELECT r.* FROM recomments r " +
+            "WHERE r.comment_id = :commentId " +
+            "AND r.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR r.id > :cursor) " +
+            "ORDER BY r.id ASC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Recomment> findByCommentIdWithCursor(
+            @Param("commentId") Long commentId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
 
     /**
      * 특정 댓글의 대댓글 수를 조회합니다.
@@ -103,62 +88,33 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
     long countByCommentIdAndDeletedAtIsNull(@Param("commentId") Long commentId);
 
     /**
-     * 특정 댓글의 모든 대댓글을 조회합니다.
-     * 삭제된 대댓글도 포함됩니다.
+     * 특정 대댓글들의 좋아요 상태를 한번에 조회합니다.
+     * 대댓글 좋아요 테이블을 기반으로 좋아요 여부를 확인합니다.
      *
-     * @param commentId 댓글 ID
-     * @return 대댓글 목록
+     * @param recommentIds 대댓글 ID 목록
+     * @param memberId 회원 ID
+     * @return 회원이 좋아요 한 대댓글 ID 목록
      */
-    List<Recomment> findByCommentId(Long commentId);
-
-    /**
-     * 특정 댓글에 달린 대댓글 중 최근 몇 개를 조회합니다.
-     * 삭제되지 않은 대댓글만 조회하며, 최신순으로 정렬합니다.
-     *
-     * @param commentId 댓글 ID
-     * @param limit 조회할 대댓글 수
-     * @return 대댓글 목록
-     */
-    @Query(value = "SELECT r.* FROM recomments r " +
-            "WHERE r.comment_id = :commentId " +
-            "AND r.deleted_at IS NULL " +
-            "ORDER BY r.created_at DESC " +
-            "LIMIT :limit",
+    @Query(value = "SELECT rl.recomment_id FROM recomment_likes rl " +
+            "WHERE rl.recomment_id IN :recommentIds " +
+            "AND rl.member_id = :memberId",
             nativeQuery = true)
-    List<Recomment> findRecentByCommentId(
-            @Param("commentId") Long commentId,
-            @Param("limit") int limit);
+    List<Long> findLikedRecommentIds(
+            @Param("recommentIds") List<Long> recommentIds,
+            @Param("memberId") Long memberId);
 
     /**
-     * 특정 댓글의 대댓글을 생성 시간 오름차순으로 조회합니다.
-     * 삭제되지 않은 대댓글만 조회합니다.
+     * 특정 회원이 특정 대댓글에 좋아요를 했는지 확인합니다.
      *
-     * @param commentId 댓글 ID
-     * @param pageable 페이지네이션 정보
-     * @return 대댓글 목록 (페이지네이션 적용)
+     * @param recommentId 대댓글 ID
+     * @param memberId 회원 ID
+     * @return 좋아요 여부
      */
-    @Query("SELECT r FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL ORDER BY r.createdAt ASC")
-    Page<Recomment> findByCommentIdOrderByCreatedAtAsc(@Param("commentId") Long commentId, Pageable pageable);
-
-    /**
-     * 특정 댓글의 대댓글을 생성 시간 오름차순으로 조회합니다.
-     * ID가 특정 값보다 큰 대댓글들을 조회합니다(커서 기반 페이징).
-     * 삭제되지 않은 대댓글만 조회합니다.
-     *
-     * @param commentId 댓글 ID
-     * @param recommentId 커서(특정 대댓글 ID)
-     * @param limit 조회할 최대 대댓글 수
-     * @return 대댓글 목록
-     */
-    @Query(value = "SELECT r.* FROM recomments r " +
-            "WHERE r.comment_id = :commentId " +
-            "AND r.id > :recommentId " +
-            "AND r.deleted_at IS NULL " +
-            "ORDER BY r.created_at ASC " +
-            "LIMIT :limit",
+    @Query(value = "SELECT COUNT(*) > 0 FROM recomment_likes rl " +
+            "WHERE rl.recomment_id = :recommentId " +
+            "AND rl.member_id = :memberId",
             nativeQuery = true)
-    List<Recomment> findByCommentIdAndIdGreaterThanOrderByCreatedAtAsc(
-            @Param("commentId") Long commentId,
+    boolean existsRecommentLike(
             @Param("recommentId") Long recommentId,
-            @Param("limit") int limit);
+            @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -128,4 +128,37 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
     List<Recomment> findRecentByCommentId(
             @Param("commentId") Long commentId,
             @Param("limit") int limit);
+
+    /**
+     * 특정 댓글의 대댓글을 생성 시간 오름차순으로 조회합니다.
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param pageable 페이지네이션 정보
+     * @return 대댓글 목록 (페이지네이션 적용)
+     */
+    @Query("SELECT r FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL ORDER BY r.createdAt ASC")
+    Page<Recomment> findByCommentIdOrderByCreatedAtAsc(@Param("commentId") Long commentId, Pageable pageable);
+
+    /**
+     * 특정 댓글의 대댓글을 생성 시간 오름차순으로 조회합니다.
+     * ID가 특정 값보다 큰 대댓글들을 조회합니다(커서 기반 페이징).
+     * 삭제되지 않은 대댓글만 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @param recommentId 커서(특정 대댓글 ID)
+     * @param limit 조회할 최대 대댓글 수
+     * @return 대댓글 목록
+     */
+    @Query(value = "SELECT r.* FROM recomments r " +
+            "WHERE r.comment_id = :commentId " +
+            "AND r.id > :recommentId " +
+            "AND r.deleted_at IS NULL " +
+            "ORDER BY r.created_at ASC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Recomment> findByCommentIdAndIdGreaterThanOrderByCreatedAtAsc(
+            @Param("commentId") Long commentId,
+            @Param("recommentId") Long recommentId,
+            @Param("limit") int limit);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentLikeService.java
@@ -1,0 +1,210 @@
+package com.kakaobase.snsapp.domain.comments.service;
+
+import com.kakaobase.snsapp.domain.comments.converter.CommentConverter;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.comments.entity.CommentLike;
+import com.kakaobase.snsapp.domain.comments.entity.Recomment;
+import com.kakaobase.snsapp.domain.comments.entity.RecommentLike;
+import com.kakaobase.snsapp.domain.comments.exception.CommentErrorCode;
+import com.kakaobase.snsapp.domain.comments.exception.CommentException;
+import com.kakaobase.snsapp.domain.comments.repository.CommentLikeRepository;
+import com.kakaobase.snsapp.domain.comments.repository.CommentRepository;
+import com.kakaobase.snsapp.domain.comments.repository.RecommentLikeRepository;
+import com.kakaobase.snsapp.domain.comments.repository.RecommentRepository;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 댓글 및 대댓글 좋아요 관련 비즈니스 로직을 처리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentLikeService {
+
+    private final CommentRepository commentRepository;
+    private final RecommentRepository recommentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final RecommentLikeRepository recommentLikeRepository;
+    private final CommentConverter commentConverter;
+
+    /**
+     * 댓글 좋아요 토글 처리
+     * 이미 좋아요가 있으면 취소, 없으면 추가합니다.
+     *
+     * @param memberId 회원 ID
+     * @param commentId 댓글 ID
+     * @return 좋아요 토글 결과 응답 DTO
+     */
+    @Transactional
+    public CommentResponseDto.CommentLikeResponse toggleCommentLike(Long memberId, Long commentId) {
+        // 댓글 존재 여부 확인
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+
+        boolean isLiked = commentLikeRepository.existsByMemberIdAndCommentId(memberId, commentId);
+
+        if (isLiked) {
+            // 좋아요 취소
+            Optional<CommentLike> commentLikeOpt = commentLikeRepository.findByMemberIdAndCommentId(memberId, commentId);
+            if (commentLikeOpt.isPresent()) {
+                commentLikeRepository.delete(commentLikeOpt.get());
+                comment.decreaseLikeCount();
+                log.info("댓글 좋아요 취소: 댓글 ID={}, 회원 ID={}", commentId, memberId);
+            }
+        } else {
+            // 좋아요 추가
+            CommentLike commentLike = new CommentLike(memberId, commentId);
+            commentLikeRepository.save(commentLike);
+            comment.increaseLikeCount();
+            log.info("댓글 좋아요 추가: 댓글 ID={}, 회원 ID={}", commentId, memberId);
+        }
+
+        // 업데이트된 상태 반환
+        return new CommentResponseDto.CommentLikeResponse(
+                !isLiked,
+                comment.getLikeCount()
+        );
+    }
+
+    /**
+     * 대댓글 좋아요 토글 처리
+     * 이미 좋아요가 있으면 취소, 없으면 추가합니다.
+     *
+     * @param memberId 회원 ID
+     * @param recommentId 대댓글 ID
+     * @return 좋아요 토글 결과 응답 DTO
+     */
+    @Transactional
+    public CommentResponseDto.RecommentLikeResponse toggleRecommentLike(Long memberId, Long recommentId) {
+        // 대댓글 존재 여부 확인
+        Recomment recomment = recommentRepository.findById(recommentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId", "대댓글을 찾을 수 없습니다."));
+
+        boolean isLiked = recommentLikeRepository.existsByMemberIdAndRecommentId(memberId, recommentId);
+
+        if (isLiked) {
+            // 좋아요 취소
+            Optional<RecommentLike> recommentLikeOpt = recommentLikeRepository.findByMemberIdAndRecommentId(memberId, recommentId);
+            if (recommentLikeOpt.isPresent()) {
+                recommentLikeRepository.delete(recommentLikeOpt.get());
+                recomment.decreaseLikeCount();
+                log.info("대댓글 좋아요 취소: 대댓글 ID={}, 회원 ID={}", recommentId, memberId);
+            }
+        } else {
+            // 좋아요 추가
+            RecommentLike recommentLike = new RecommentLike(memberId, recommentId);
+            recommentLikeRepository.save(recommentLike);
+            recomment.increaseLikeCount();
+            log.info("대댓글 좋아요 추가: 대댓글 ID={}, 회원 ID={}", recommentId, memberId);
+        }
+
+        // 업데이트된 상태 반환
+        return new CommentResponseDto.RecommentLikeResponse(
+                !isLiked,
+                recomment.getLikeCount()
+        );
+    }
+
+    /**
+     * 회원이 특정 댓글 목록 중 좋아요한 댓글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param commentIds 댓글 ID 목록
+     * @return 좋아요한 댓글 ID 목록
+     */
+    public List<Long> getLikedCommentIdsByMember(Long memberId, List<Long> commentIds) {
+        if (commentIds == null || commentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return commentLikeRepository.findCommentIdsByMemberIdAndCommentIdIn(memberId, commentIds);
+    }
+
+    /**
+     * 회원이 특정 대댓글 목록 중 좋아요한 대댓글 ID 목록을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param recommentIds 대댓글 ID 목록
+     * @return 좋아요한 대댓글 ID 목록
+     */
+    public List<Long> getLikedRecommentIdsByMember(Long memberId, List<Long> recommentIds) {
+        if (recommentIds == null || recommentIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return recommentLikeRepository.findRecommentIdsByMemberIdAndRecommentIdIn(memberId, recommentIds);
+    }
+
+    /**
+     * 회원이 댓글을 좋아요했는지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param commentId 댓글 ID
+     * @return 좋아요 여부
+     */
+    public boolean isCommentLikedByMember(Long memberId, Long commentId) {
+        return commentLikeRepository.existsByMemberIdAndCommentId(memberId, commentId);
+    }
+
+    /**
+     * 회원이 대댓글을 좋아요했는지 확인합니다.
+     *
+     * @param memberId 회원 ID
+     * @param recommentId 대댓글 ID
+     * @return 좋아요 여부
+     */
+    public boolean isRecommentLikedByMember(Long memberId, Long recommentId) {
+        return recommentLikeRepository.existsByMemberIdAndRecommentId(memberId, recommentId);
+    }
+
+    /**
+     * 댓글 삭제 시 연관된 좋아요를 일괄 삭제합니다.
+     *
+     * @param commentId 댓글 ID
+     */
+    @Transactional
+    public void deleteAllCommentLikesByCommentId(Long commentId) {
+        int deletedCount = commentLikeRepository.deleteByCommentId(commentId);
+        log.info("댓글 관련 좋아요 일괄 삭제 완료: 댓글 ID={}, 삭제된 좋아요 수={}", commentId, deletedCount);
+    }
+
+    /**
+     * 대댓글 삭제 시 연관된 좋아요를 일괄 삭제합니다.
+     *
+     * @param recommentId 대댓글 ID
+     */
+    @Transactional
+    public void deleteAllRecommentLikesByRecommentId(Long recommentId) {
+        int deletedCount = recommentLikeRepository.deleteByRecommentId(recommentId);
+        log.info("대댓글 관련 좋아요 일괄 삭제 완료: 대댓글 ID={}, 삭제된 좋아요 수={}", recommentId, deletedCount);
+    }
+
+    /**
+     * 댓글이 삭제될 때 해당 댓글에 달린 모든 대댓글의 좋아요를 일괄 삭제합니다.
+     *
+     * @param commentId 댓글 ID
+     */
+    @Transactional
+    public void deleteAllRecommentLikesByParentCommentId(Long commentId) {
+        // 대댓글 ID 목록 조회
+        List<Long> recommentIds = recommentRepository.findByCommentId(commentId)
+                .stream()
+                .map(Recomment::getId)
+                .toList();
+
+        if (!recommentIds.isEmpty()) {
+            int deletedCount = recommentLikeRepository.deleteByRecommentIdIn(recommentIds);
+            log.info("댓글 관련 대댓글 좋아요 일괄 삭제 완료: 댓글 ID={}, 삭제된 좋아요 수={}", commentId, deletedCount);
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -1,0 +1,299 @@
+package com.kakaobase.snsapp.domain.comments.service;
+
+import com.kakaobase.snsapp.domain.comments.converter.CommentConverter;
+import com.kakaobase.snsapp.domain.comments.dto.CommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.comments.entity.Recomment;
+import com.kakaobase.snsapp.domain.comments.exception.CommentErrorCode;
+import com.kakaobase.snsapp.domain.comments.exception.CommentException;
+import com.kakaobase.snsapp.domain.comments.repository.CommentRepository;
+import com.kakaobase.snsapp.domain.comments.repository.RecommentRepository;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.service.PostService;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 댓글 관련 비즈니스 로직을 처리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final RecommentRepository recommentRepository;
+    private final MemberRepository memberRepository;
+    private final CommentConverter commentConverter;
+    private final PostService postService;
+    private final CommentLikeService commentLikeService;
+
+    private static final int DEFAULT_PAGE_SIZE = 12;
+
+    /**
+     * 댓글을 생성합니다.
+     *
+     * @param memberId 회원 ID
+     * @param postId 게시글 ID
+     * @param request 댓글 생성 요청 DTO
+     * @return 생성된 댓글 응답 DTO
+     */
+    @Transactional
+    public CommentResponseDto.CreateCommentResponse createComment(Long memberId, Long postId, CommentRequestDto.CreateCommentRequest request) {
+        // 게시글 존재 확인
+        Post post = postService.findById(postId);
+
+        // 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "memberId", "회원을 찾을 수 없습니다."));
+
+        // 부모 댓글 확인 (대댓글인 경우)
+        Comment parentComment = null;
+        if (request.parent_id() != null) {
+            parentComment = commentRepository.findById(request.parent_id())
+                    .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "parent_id", "부모 댓글을 찾을 수 없습니다."));
+
+            // 부모 댓글에 대댓글 추가는 1단계만 허용 (대댓글의 대댓글은 불가)
+            if (parentComment.getParentComment() != null) {
+                throw new CommentException(CommentErrorCode.INVALID_PARENT_COMMENT, "parent_id", "대댓글에는 댓글을 작성할 수 없습니다.");
+            }
+        }
+
+        // 댓글 엔티티 생성
+        Comment comment = commentConverter.toCommentEntity(post, member, request, parentComment);
+        Comment savedComment = commentRepository.save(comment);
+
+        log.info("댓글 생성 완료: 댓글 ID={}, 작성자 ID={}, 게시글 ID={}, 부모 댓글 ID={}",
+                savedComment.getId(), memberId, postId,
+                parentComment != null ? parentComment.getId() : null);
+
+        return commentConverter.toCreateCommentResponse(savedComment);
+    }
+
+    /**
+     * 댓글을 수정합니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param commentId 수정할 댓글 ID
+     * @param request 댓글 수정 요청 DTO
+     */
+    @Transactional
+    public void updateComment(Long memberId, Long commentId, CommentRequestDto.UpdateCommentRequest request) {
+        // 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+
+        // 댓글 작성자 확인
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId");
+        }
+
+        // 내용 길이 검증
+        if (request.content().length() > 2000) {
+            throw new CommentException(CommentErrorCode.CONTENT_LENGTH_EXCEEDED);
+        }
+
+        // 댓글 내용 업데이트
+        comment.updateContent(request.content());
+
+        log.info("댓글 수정 완료: 댓글 ID={}, 작성자 ID={}", commentId, memberId);
+    }
+
+    /**
+     * 댓글을 삭제합니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param commentId 삭제할 댓글 ID
+     */
+    @Transactional
+    public void deleteComment(Long memberId, Long commentId) {
+        // 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+
+        // 댓글 작성자 확인
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId");
+        }
+
+        // 댓글의 좋아요 삭제
+        commentLikeService.deleteAllCommentLikesByCommentId(commentId);
+
+        // 대댓글이 있는 경우, 대댓글도 함께 삭제
+        if (comment.getParentComment() == null) {
+            // 일반 댓글인 경우, 연관된 대댓글도 삭제
+            List<Recomment> recomments = recommentRepository.findByCommentId(commentId);
+            if (!recomments.isEmpty()) {
+                // 대댓글 좋아요도 함께 삭제
+                commentLikeService.deleteAllRecommentLikesByParentCommentId(commentId);
+
+                // 대댓글 삭제
+                recommentRepository.deleteAll(recomments);
+                log.info("댓글 삭제 시 연관된 대댓글 {} 개도 함께 삭제: 댓글 ID={}", recomments.size(), commentId);
+            }
+        }
+
+        // 댓글 삭제
+        commentRepository.delete(comment);
+
+        log.info("댓글 삭제 완료: 댓글 ID={}, 삭제자 ID={}", commentId, memberId);
+    }
+
+    /**
+     * 게시글의 댓글 목록을 조회합니다.
+     * API 명세서에 맞게 대댓글은 포함하지 않습니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param postId 게시글 ID
+     * @param pageRequest 페이지 요청 DTO
+     * @return 댓글 목록 응답 DTO
+     */
+    public CommentResponseDto.CommentListResponse getCommentsByPostId(Long memberId, Long postId, CommentRequestDto.CommentPageRequest pageRequest) {
+        // 게시글 존재 확인
+        Post post = postService.findById(postId);
+
+        // 페이지 설정
+        int limit = pageRequest.limit() != null ? pageRequest.limit() : DEFAULT_PAGE_SIZE;
+
+        // 댓글 목록 조회
+        List<Comment> comments;
+        if (pageRequest.cursor() == null) {
+            // 첫 페이지 조회
+            PageRequest pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
+            comments = commentRepository.findByPostId(postId, pageable).getContent();
+        } else {
+            // 커서 기반 페이징
+            comments = commentRepository.findByPostIdAndIdLessThanOrderByIdDesc(
+                    postId, pageRequest.cursor(), limit);
+        }
+
+        if (comments.isEmpty()) {
+            return new CommentResponseDto.CommentListResponse(
+                    Collections.emptyList(),
+                    false,
+                    null
+            );
+        }
+
+        // 다음 페이지 커서 설정
+        Long nextCursor = comments.size() >= limit ? comments.get(comments.size() - 1).getId() : null;
+
+        // 댓글 ID 목록 추출
+        List<Long> commentIds = comments.stream()
+                .map(Comment::getId)
+                .collect(Collectors.toList());
+
+        // 좋아요 정보 조회
+        List<Long> likedCommentIds = commentLikeService.getLikedCommentIdsByMember(memberId, commentIds);
+        Set<Long> likedCommentIdsSet = new HashSet<>(likedCommentIds);
+
+        // 응답 DTO 생성 (대댓글 정보 없이)
+        List<CommentResponseDto.CommentInfo> commentInfos = comments.stream()
+                .map(comment -> commentConverter.toCommentInfo(
+                        comment,
+                        memberId,
+                        likedCommentIdsSet
+                ))
+                .collect(Collectors.toList());
+
+        return new CommentResponseDto.CommentListResponse(
+                commentInfos,
+                nextCursor != null,
+                nextCursor
+        );
+    }
+
+    /**
+     * 댓글의 대댓글 목록을 조회합니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param commentId 댓글 ID
+     * @param pageRequest 페이지 요청 DTO
+     * @return 대댓글 목록 응답 DTO
+     */
+    /**
+     * 댓글의 대댓글 목록을 조회합니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param commentId 댓글 ID
+     * @param pageRequest 페이지 요청 DTO
+     * @return 대댓글 목록 응답 DTO
+     */
+    public CommentResponseDto.RecommentListResponse getRecommentsByCommentId(Long memberId, Long commentId, CommentRequestDto.RecommentPageRequest pageRequest) {
+        // 댓글 존재 확인
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+
+        // 페이지 설정
+        int limit = pageRequest.limit() != null ? pageRequest.limit() : DEFAULT_PAGE_SIZE;
+
+        // 대댓글 목록 조회
+        List<Recomment> recomments;
+        if (pageRequest.cursor() == null) {
+            // 첫 페이지 조회 - 생성 시간 오름차순으로 조회
+            recomments = recommentRepository.findByCommentIdOrderByCreatedAtAsc(commentId, PageRequest.of(0, limit));
+        } else {
+            // 커서 기반 페이징 - 커서(ID) 이후부터 생성 시간 오름차순으로 조회
+            recomments = recommentRepository.findByCommentIdAndIdGreaterThanOrderByCreatedAtAsc(
+                    commentId, pageRequest.cursor(), limit);
+        }
+
+        if (recomments.isEmpty()) {
+            return new CommentResponseDto.RecommentListResponse(
+                    Collections.emptyList(),
+                    false,
+                    null
+            );
+        }
+
+        // 다음 페이지 커서 설정
+        Long nextCursor = recomments.size() >= limit ? recomments.get(recomments.size() - 1).getId() : null;
+
+        // 대댓글 ID 목록 추출
+        List<Long> recommentIds = recomments.stream()
+                .map(Recomment::getId)
+                .collect(Collectors.toList());
+
+        // 대댓글 좋아요 정보 조회
+        List<Long> likedRecommentIds = commentLikeService.getLikedRecommentIdsByMember(memberId, recommentIds);
+        Set<Long> likedRecommentIdsSet = new HashSet<>(likedRecommentIds);
+
+        // 응답 DTO 생성
+        List<CommentResponseDto.RecommentInfo> recommentInfos = recomments.stream()
+                .map(recomment -> commentConverter.toRecommentInfo(
+                        recomment,
+                        memberId,
+                        likedRecommentIdsSet
+                ))
+                .collect(Collectors.toList());
+
+        return new CommentResponseDto.RecommentListResponse(
+                recommentInfos,
+                nextCursor != null,
+                nextCursor
+        );
+    }
+
+    /**
+     * 댓글 ID로 댓글을 조회합니다.
+     *
+     * @param commentId 댓글 ID
+     * @return 댓글 엔티티
+     */
+    public Comment findById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -250,6 +250,47 @@ public class CommentService {
     }
 
     /**
+     * 댓글 상세 정보를 조회합니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param commentId 조회할 댓글 ID
+     * @return 댓글 상세 응답 DTO
+     */
+    public CommentResponseDto.CommentDetailResponse getCommentDetail(Long memberId, Long commentId) {
+        // 댓글 조회
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+
+        // 댓글 좋아요 여부 확인
+        boolean isLiked = commentRepository.existsCommentLike(commentId, memberId);
+
+        // 댓글 작성자 확인 (본인 작성 여부)
+        boolean isMine = comment.getMember().getId().equals(memberId);
+
+        // UserInfo 생성
+        Member commentAuthor = comment.getMember();
+        CommentResponseDto.UserInfo userInfo = new CommentResponseDto.UserInfo(
+                commentAuthor.getId(),
+                commentAuthor.getNickname(),
+                commentAuthor.getProfileImgUrl(),
+                false  // is_followed는 일단 false로 설정 (팔로우 서비스와 연동 필요)
+        );
+
+        // CommentInfo 생성
+        CommentResponseDto.CommentInfo commentInfo = new CommentResponseDto.CommentInfo(
+                comment.getId(),
+                userInfo,
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getLikeCount(),
+                isMine,
+                isLiked
+        );
+
+        return new CommentResponseDto.CommentDetailResponse(commentInfo);
+    }
+
+    /**
      * 댓글 ID로 댓글을 조회합니다.
      *
      * @param commentId 댓글 ID

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -16,8 +16,6 @@ import com.kakaobase.snsapp.domain.posts.service.PostService;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,56 +57,34 @@ public class CommentService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "memberId", "회원을 찾을 수 없습니다."));
 
-        // 부모 댓글 확인 (대댓글인 경우)
-        Comment parentComment = null;
+        // 대댓글인 경우
         if (request.parent_id() != null) {
-            parentComment = commentRepository.findById(request.parent_id())
+            Comment parentComment = commentRepository.findByIdAndDeletedAtIsNull(request.parent_id())
                     .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "parent_id", "부모 댓글을 찾을 수 없습니다."));
 
-            // 부모 댓글에 대댓글 추가는 1단계만 허용 (대댓글의 대댓글은 불가)
-            if (parentComment.getParentComment() != null) {
-                throw new CommentException(CommentErrorCode.INVALID_PARENT_COMMENT, "parent_id", "대댓글에는 댓글을 작성할 수 없습니다.");
+            // 부모 댓글이 같은 게시글에 속하는지 확인
+            if (!parentComment.getPost().getId().equals(postId)) {
+                throw new CommentException(CommentErrorCode.INVALID_PARENT_COMMENT, "parent_id", "부모 댓글이 다른 게시글에 속합니다.");
             }
+
+            // 대댓글 엔티티 생성 및 저장
+            Recomment recomment = commentConverter.toRecommentEntity(parentComment, member, request);
+            Recomment savedRecomment = recommentRepository.save(recomment);
+
+            log.info("대댓글 생성 완료: 대댓글 ID={}, 작성자 ID={}, 부모 댓글 ID={}",
+                    savedRecomment.getId(), memberId, parentComment.getId());
+
+            return commentConverter.toCreateRecommentResponse(savedRecomment);
         }
 
-        // 댓글 엔티티 생성
-        Comment comment = commentConverter.toCommentEntity(post, member, request, parentComment);
+        // 일반 댓글인 경우
+        Comment comment = commentConverter.toCommentEntity(post, member, request);
         Comment savedComment = commentRepository.save(comment);
 
-        log.info("댓글 생성 완료: 댓글 ID={}, 작성자 ID={}, 게시글 ID={}, 부모 댓글 ID={}",
-                savedComment.getId(), memberId, postId,
-                parentComment != null ? parentComment.getId() : null);
+        log.info("댓글 생성 완료: 댓글 ID={}, 작성자 ID={}, 게시글 ID={}",
+                savedComment.getId(), memberId, postId);
 
         return commentConverter.toCreateCommentResponse(savedComment);
-    }
-
-    /**
-     * 댓글을 수정합니다.
-     *
-     * @param memberId 현재 로그인한 회원 ID
-     * @param commentId 수정할 댓글 ID
-     * @param request 댓글 수정 요청 DTO
-     */
-    @Transactional
-    public void updateComment(Long memberId, Long commentId, CommentRequestDto.UpdateCommentRequest request) {
-        // 댓글 조회
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
-
-        // 댓글 작성자 확인
-        if (!comment.getMember().getId().equals(memberId)) {
-            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId");
-        }
-
-        // 내용 길이 검증
-        if (request.content().length() > 2000) {
-            throw new CommentException(CommentErrorCode.CONTENT_LENGTH_EXCEEDED);
-        }
-
-        // 댓글 내용 업데이트
-        comment.updateContent(request.content());
-
-        log.info("댓글 수정 완료: 댓글 ID={}, 작성자 ID={}", commentId, memberId);
     }
 
     /**
@@ -120,46 +96,69 @@ public class CommentService {
     @Transactional
     public void deleteComment(Long memberId, Long commentId) {
         // 댓글 조회
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "삭제할 댓글을 찾을 수 없습니다."));
 
         // 댓글 작성자 확인
         if (!comment.getMember().getId().equals(memberId)) {
-            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId");
+            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId", "본인이 작성한 댓글만 삭제할 수 있습니다.");
         }
 
         // 댓글의 좋아요 삭제
         commentLikeService.deleteAllCommentLikesByCommentId(commentId);
 
-        // 대댓글이 있는 경우, 대댓글도 함께 삭제
-        if (comment.getParentComment() == null) {
-            // 일반 댓글인 경우, 연관된 대댓글도 삭제
-            List<Recomment> recomments = recommentRepository.findByCommentId(commentId);
-            if (!recomments.isEmpty()) {
-                // 대댓글 좋아요도 함께 삭제
-                commentLikeService.deleteAllRecommentLikesByParentCommentId(commentId);
-
-                // 대댓글 삭제
-                recommentRepository.deleteAll(recomments);
-                log.info("댓글 삭제 시 연관된 대댓글 {} 개도 함께 삭제: 댓글 ID={}", recomments.size(), commentId);
-            }
+        // 댓글에 달린 모든 대댓글 삭제 (삭제된 것 포함)
+        List<Recomment> recomments = recommentRepository.findAllByCommentId(commentId);
+        for (Recomment recomment : recomments) {
+            commentLikeService.deleteAllRecommentLikesByRecommentId(recomment.getId());
+            recommentRepository.delete(recomment);
         }
 
-        // 댓글 삭제
-        commentRepository.delete(comment);
+        // 댓글 삭제 (Soft Delete)
+        comment.softDelete();
+        commentRepository.save(comment);
 
         log.info("댓글 삭제 완료: 댓글 ID={}, 삭제자 ID={}", commentId, memberId);
     }
 
     /**
-     * 게시글의 댓글 목록을 조회합니다.
-     * API 명세서에 맞게 대댓글은 포함하지 않습니다.
+     * 대댓글을 삭제합니다.
+     *
+     * @param memberId 현재 로그인한 회원 ID
+     * @param recommentId 삭제할 대댓글 ID
+     */
+    @Transactional
+    public void deleteRecomment(Long memberId, Long recommentId) {
+        // 대댓글 조회
+        Recomment recomment = recommentRepository.findByIdAndDeletedAtIsNull(recommentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId", "해당 대댓글을 찾을 수 없습니다."));
+
+        // 대댓글 작성자 확인
+        if (!recomment.getMember().getId().equals(memberId)) {
+            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "recommentId", "본인이 작성한 대댓글만 삭제할 수 있습니다.");
+        }
+
+        // 대댓글의 좋아요 삭제
+        commentLikeService.deleteAllRecommentLikesByRecommentId(recommentId);
+
+        recomment.onPreRemove();
+
+        // 대댓글 삭제 (Soft Delete)
+        recomment.softDelete();
+        recommentRepository.save(recomment);
+
+        log.info("대댓글 삭제 완료: 대댓글 ID={}, 삭제자 ID={}", recommentId, memberId);
+    }
+
+    /**
+     * 게시글의 댓글 목록을 조회합니다. (대댓글 포함)
      *
      * @param memberId 현재 로그인한 회원 ID
      * @param postId 게시글 ID
      * @param pageRequest 페이지 요청 DTO
      * @return 댓글 목록 응답 DTO
      */
+    // CommentService.java
     public CommentResponseDto.CommentListResponse getCommentsByPostId(Long memberId, Long postId, CommentRequestDto.CommentPageRequest pageRequest) {
         // 게시글 존재 확인
         Post post = postService.findById(postId);
@@ -168,16 +167,7 @@ public class CommentService {
         int limit = pageRequest.limit() != null ? pageRequest.limit() : DEFAULT_PAGE_SIZE;
 
         // 댓글 목록 조회
-        List<Comment> comments;
-        if (pageRequest.cursor() == null) {
-            // 첫 페이지 조회
-            PageRequest pageable = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "createdAt"));
-            comments = commentRepository.findByPostId(postId, pageable).getContent();
-        } else {
-            // 커서 기반 페이징
-            comments = commentRepository.findByPostIdAndIdLessThanOrderByIdDesc(
-                    postId, pageRequest.cursor(), limit);
-        }
+        List<Comment> comments = commentRepository.findByPostIdWithCursor(postId, pageRequest.cursor(), limit);
 
         if (comments.isEmpty()) {
             return new CommentResponseDto.CommentListResponse(
@@ -187,42 +177,29 @@ public class CommentService {
             );
         }
 
-        // 다음 페이지 커서 설정
-        Long nextCursor = comments.size() >= limit ? comments.get(comments.size() - 1).getId() : null;
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = comments.size() >= limit;
+        Long nextCursor = hasNext ? comments.get(comments.size() - 1).getId() : null;
 
-        // 댓글 ID 목록 추출
+        // 댓글 ID 추출
         List<Long> commentIds = comments.stream()
                 .map(Comment::getId)
                 .collect(Collectors.toList());
 
-        // 좋아요 정보 조회
-        List<Long> likedCommentIds = commentLikeService.getLikedCommentIdsByMember(memberId, commentIds);
+        // 댓글 좋아요 정보 조회
+        List<Long> likedCommentIds = commentRepository.findLikedCommentIds(commentIds, memberId);
         Set<Long> likedCommentIdsSet = new HashSet<>(likedCommentIds);
 
-        // 응답 DTO 생성 (대댓글 정보 없이)
-        List<CommentResponseDto.CommentInfo> commentInfos = comments.stream()
-                .map(comment -> commentConverter.toCommentInfo(
-                        comment,
-                        memberId,
-                        likedCommentIdsSet
-                ))
-                .collect(Collectors.toList());
-
-        return new CommentResponseDto.CommentListResponse(
-                commentInfos,
-                nextCursor != null,
+        // 응답 DTO 생성
+        return commentConverter.toCommentListResponse(
+                comments,
+                memberId,
+                likedCommentIdsSet,
                 nextCursor
         );
     }
 
-    /**
-     * 댓글의 대댓글 목록을 조회합니다.
-     *
-     * @param memberId 현재 로그인한 회원 ID
-     * @param commentId 댓글 ID
-     * @param pageRequest 페이지 요청 DTO
-     * @return 대댓글 목록 응답 DTO
-     */
+
     /**
      * 댓글의 대댓글 목록을 조회합니다.
      *
@@ -233,22 +210,14 @@ public class CommentService {
      */
     public CommentResponseDto.RecommentListResponse getRecommentsByCommentId(Long memberId, Long commentId, CommentRequestDto.RecommentPageRequest pageRequest) {
         // 댓글 존재 확인
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "해당 댓글을 찾을 수 없습니다."));
 
         // 페이지 설정
         int limit = pageRequest.limit() != null ? pageRequest.limit() : DEFAULT_PAGE_SIZE;
 
         // 대댓글 목록 조회
-        List<Recomment> recomments;
-        if (pageRequest.cursor() == null) {
-            // 첫 페이지 조회 - 생성 시간 오름차순으로 조회
-            recomments = recommentRepository.findByCommentIdOrderByCreatedAtAsc(commentId, PageRequest.of(0, limit));
-        } else {
-            // 커서 기반 페이징 - 커서(ID) 이후부터 생성 시간 오름차순으로 조회
-            recomments = recommentRepository.findByCommentIdAndIdGreaterThanOrderByCreatedAtAsc(
-                    commentId, pageRequest.cursor(), limit);
-        }
+        List<Recomment> recomments = recommentRepository.findByCommentIdWithCursor(commentId, pageRequest.cursor(), limit);
 
         if (recomments.isEmpty()) {
             return new CommentResponseDto.RecommentListResponse(
@@ -258,30 +227,24 @@ public class CommentService {
             );
         }
 
-        // 다음 페이지 커서 설정
-        Long nextCursor = recomments.size() >= limit ? recomments.get(recomments.size() - 1).getId() : null;
+        // 다음 페이지 존재 여부 확인
+        boolean hasNext = recomments.size() >= limit;
+        Long nextCursor = hasNext ? recomments.get(recomments.size() - 1).getId() : null;
 
-        // 대댓글 ID 목록 추출
+        // 대댓글 ID 추출
         List<Long> recommentIds = recomments.stream()
                 .map(Recomment::getId)
                 .collect(Collectors.toList());
 
         // 대댓글 좋아요 정보 조회
-        List<Long> likedRecommentIds = commentLikeService.getLikedRecommentIdsByMember(memberId, recommentIds);
+        List<Long> likedRecommentIds = recommentRepository.findLikedRecommentIds(recommentIds, memberId);
         Set<Long> likedRecommentIdsSet = new HashSet<>(likedRecommentIds);
 
         // 응답 DTO 생성
-        List<CommentResponseDto.RecommentInfo> recommentInfos = recomments.stream()
-                .map(recomment -> commentConverter.toRecommentInfo(
-                        recomment,
-                        memberId,
-                        likedRecommentIdsSet
-                ))
-                .collect(Collectors.toList());
-
-        return new CommentResponseDto.RecommentListResponse(
-                recommentInfos,
-                nextCursor != null,
+        return commentConverter.toRecommentListResponse(
+                recomments,
+                memberId,
+                likedRecommentIdsSet,
                 nextCursor
         );
     }
@@ -293,7 +256,18 @@ public class CommentService {
      * @return 댓글 엔티티
      */
     public Comment findById(Long commentId) {
-        return commentRepository.findById(commentId)
+        return commentRepository.findByIdAndDeletedAtIsNull(commentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "댓글을 찾을 수 없습니다."));
+    }
+
+    /**
+     * 대댓글 ID로 대댓글을 조회합니다.
+     *
+     * @param recommentId 대댓글 ID
+     * @return 대댓글 엔티티
+     */
+    public Recomment findRecommentById(Long recommentId) {
+        return recommentRepository.findByIdAndDeletedAtIsNull(recommentId)
+                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId", "대댓글을 찾을 수 없습니다."));
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #24

## 📌 개요
- 댓글에 관한 비즈니스 로직 구현

## 🔁 변경 사항

### CommentService
댓글 생성, 삭제 메서드 추가
댓글 목록조회 메서드 추가
댓글 상세 조회 메서드 추가

### CommentLikeService
댓글 좋아요 등록 메서드 추가
댓글 좋아요 취소 메서드 추가
대댓글 좋아요 등록 메서드 추가
대댓글 좋아요 취소 메서드 추가

### Comment Entity
통합형 댓글로 자기참조형으로 대댓글을 구현하던걸
분리형 Entity로 변경

### Comment, Recomment Repository
Pase 객체로 반환하던 목록값을
List형을 반환하도록 수정

## 👀 기타 더 이야기해볼 점
현재 댓글 삭제시 관련된 대댓글이 전부 삭제되는데,
이를 에타처럼 (알수 없음)으로 표기하고 대댓글을 살려둘지,
아니면 전부 삭제할지 논의 필요



## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.