### PR TITLE
[BE - FEAT] 유튜브 요약 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // Spring WebFlux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     //thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -104,6 +104,10 @@ public class CommentService {
             throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId", "본인이 작성한 댓글만 삭제할 수 있습니다.");
         }
 
+        // 게시글의 댓글 수 1감소
+        Post post = postService.findById(comment.getPost().getId());
+        post.decreaseCommentCount();
+
         // 댓글의 좋아요 삭제
         commentLikeService.deleteAllCommentLikesByCommentId(commentId);
 

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostRequestDto.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -82,4 +83,66 @@ public class PostRequestDto {
             @NotBlank(message = "MIME 타입은 필수입니다")
             String mime_type
     ) {}
+
+    /**
+     * AI 서버 YouTube 요약 요청 DTO
+     *
+     * <p>AI 서버에 YouTube 영상 요약을 요청할 때 사용하는 DTO입니다.</p>
+     *
+     * @param youtubeUrl YouTube 영상 URL
+     */
+    @Schema(description = "AI 서버 YouTube 요약 요청")
+    public record YouTubeAiRequest(
+            @Schema(description = "YouTube 영상 URL", example = "https://www.youtube.com/watch?v=VIDEO_ID", required = true)
+            @JsonProperty("youtube_url")
+            String youtubeUrl
+    ) {
+    }
+
+    /**
+     * AI 서버 YouTube 요약 응답 DTO
+     *
+     * <p>AI 서버로부터 YouTube 영상 요약 결과를 받을 때 사용하는 DTO입니다.</p>
+     *
+     * @param message 응답 메시지
+     * @param data 요약 데이터
+     */
+    @Schema(description = "AI 서버 YouTube 요약 응답")
+    public record YouTubeAiResponse(
+            @Schema(description = "응답 메시지", example = "YouTube 영상이 요약되었습니다.")
+            String message,
+
+            @Schema(description = "요약 데이터")
+            YouTubeAiData data
+    ) {
+        /**
+         * YouTube 요약 데이터
+         *
+         * @param summary 요약 내용
+         */
+        @Schema(description = "YouTube 요약 데이터")
+        public record YouTubeAiData(
+                @Schema(description = "요약 내용", example = "• 서울대 교수회가 중고교 통합과 수능 중복 응시를 포함한 교육 개혁안을 발표했습니다.\\n• 중등학교 6년제로 학재를 통합하고 초등 6년 과정은 소양 교육, 중등 6년 과정은 기초 교육 및 적성 탐색에 중점을 둬야 한다고 제안했습니다.\\n• 학생 선택권을 보장하기 위해 수능 시험을 연간 세 차례 실시하고 최고 점수나 평균 점수를 입시에 반영하는 방안을 제시했습니다.")
+                String summary
+        ) {
+        }
+    }
+
+    /**
+     * AI 서버 에러 응답 DTO
+     *
+     * <p>AI 서버에서 에러가 발생했을 때 받는 응답 DTO입니다.</p>
+     *
+     * @param error 에러 코드
+     * @param message 에러 메시지
+     */
+    @Schema(description = "AI 서버 에러 응답")
+    public record YouTubeAiErrorResponse(
+            @Schema(description = "에러 코드", example = "subtitles_not_found")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "해당 YouTube 영상에 자막이 존재하지 않습니다.")
+            String message
+    ) {
+    }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 게시글 도메인의 응답 DTO를 관리하는 통합 클래스
@@ -181,4 +182,30 @@ public class PostResponseDto {
             @Schema(description = "데이터", example = "null")
             Object data
     ) {}
+
+
+    /**
+     * YouTube 영상 요약 응답 DTO
+     *
+     * <p>클라이언트에게 YouTube 영상 요약 결과를 반환할 때 사용하는 DTO입니다.</p>
+     * API 명세에 따라 message는 CustomResponse에서 처리하고,
+     * data 부분만 이 DTO에서 담당합니다.
+     *
+     * @param summary 요약 내용
+     */
+    @Schema(description = "YouTube 영상 요약 데이터")
+    public record YouTubeSummaryResponse(
+            @Schema(description = "요약 내용", example = "• 서울대 교수회가 중고교 통합과 수능 중복 응시를 포함한 교육 개혁안을 발표했습니다.")
+            String summary
+    ) {
+        /**
+         * YouTube 요약 응답 생성
+         *
+         * @param summary 요약 내용
+         * @return YouTube 요약 응답 DTO
+         */
+        public static YouTubeSummaryResponse of(String summary) {
+            return new YouTubeSummaryResponse(summary);
+        }
+    }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.posts.service;
 
 import com.kakaobase.snsapp.domain.members.service.MemberService;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
+import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.entity.PostImage;
 import com.kakaobase.snsapp.domain.posts.exception.PostErrorCode;
@@ -32,7 +33,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final S3Service s3Service;
     private final MemberService memberService;
-    private final PostLikeService postLikeService;
+    private final YouTubeSummaryService youtubeSummaryService;  // 생성자 주입 필요
 
     /**
      * 게시글을 생성합니다.
@@ -145,6 +146,48 @@ public class PostService {
 
         // MemberService를 통해 회원 정보 조회
         return memberService.getMemberInfoMapByIds(memberIds);
+    }
+
+
+    /**
+     * YouTube 영상 요약
+     *
+     * <p>게시글에 포함된 YouTube URL의 영상을 요약하고 결과를 저장합니다.</p>
+     *
+     * @param postId 요약할 게시글의 ID
+     * @param memberId 요청한 사용자의 ID
+     * @return YouTube 요약 응답 DTO
+     * @throws PostException 게시글을 찾을 수 없거나, 권한이 없거나, YouTube URL이 없는 경우
+     */
+    @Transactional
+    public PostResponseDto.YouTubeSummaryResponse summarizeYoutube(Long postId, Long memberId) {
+        log.info("YouTube 요약 요청 - postId: {}, memberId: {}", postId, memberId);
+
+        // 1. 게시글 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> {
+                    log.error("게시글을 찾을 수 없음 - postId: {}", postId);
+                    return new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postId");
+                });
+
+
+        // 3. YouTube URL 존재 확인
+        String youtubeUrl = post.getYoutubeUrl();
+        if (youtubeUrl == null || youtubeUrl.isBlank()) {
+            log.error("YouTube URL이 없음 - postId: {}", postId);
+            throw new PostException(GeneralErrorCode.INVALID_FORMAT, "youtubeUrl");
+        }
+
+        // 4. AI 서버에 요약 요청
+        log.info("AI 서버에 YouTube 요약 요청 - postId: {}, url: {}", postId, youtubeUrl);
+        String summary = youtubeSummaryService.getSummary(youtubeUrl);
+
+        // 5. 요약 내용 저장
+        post.setYoutubeSummary(summary);
+        log.info("YouTube 요약 저장 완료 - postId: {}", postId);
+
+        // 6. 응답 생성
+        return PostResponseDto.YouTubeSummaryResponse.of(summary);
     }
 
 //    /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/YouTubeSummaryService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/YouTubeSummaryService.java
@@ -1,0 +1,68 @@
+package com.kakaobase.snsapp.domain.posts.service;
+
+import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * YouTube 영상 요약 서비스
+ *
+ * <p>AI 서버와 통신하여 YouTube 영상의 요약을 처리하는 서비스입니다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class YouTubeSummaryService {
+
+    private final WebClient webClient;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    /**
+     * YouTube 영상 요약 요청
+     *
+     * <p>AI 서버에 YouTube URL을 전송하여 영상의 요약본을 받아옵니다.</p>
+     *
+     * @param youtubeUrl YouTube 영상 URL
+     * @return 요약된 내용
+     * @throws PostException AI 서버 통신 실패 또는 요약 실패 시
+     */
+    public String getSummary(String youtubeUrl) {
+        log.info("YouTube 요약 요청 시작 - URL: {}", youtubeUrl);
+
+        try {
+            // AI 서버 요청 DTO 생성
+            PostRequestDto.YouTubeAiRequest request = new PostRequestDto.YouTubeAiRequest(youtubeUrl);
+
+            // AI 서버에 요약 요청
+            PostRequestDto.YouTubeAiResponse response = webClient.post()
+                    .uri(aiServerUrl + "/posts/youtube/summary")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(PostRequestDto.YouTubeAiResponse.class)
+                    .block(); // 동기식 처리를 위해 block() 사용
+
+            // 응답에서 요약 내용 추출
+            String summary = response.data().summary();
+            log.info("YouTube 요약 요청 성공");
+
+            return summary;
+
+        } catch (WebClientResponseException e) {
+            log.error("AI 서버 통신 실패 - Status: {}, Body: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new PostException(GeneralErrorCode.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error("YouTube 요약 중 예외 발생", e);
+            throw new PostException(GeneralErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/global/config/WebClientConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/WebClientConfig.java
@@ -1,0 +1,90 @@
+package com.kakaobase.snsapp.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.LoggingCodecSupport;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * WebClient 설정
+ *
+ * <p>외부 API 통신을 위한 WebClient 빈을 설정합니다.</p>
+ */
+@Slf4j
+@Configuration
+public class WebClientConfig {
+
+    /**
+     * WebClient 빈 생성
+     *
+     * <p>AI 서버와의 통신을 위한 WebClient를 설정합니다.</p>
+     *
+     * @return 설정된 WebClient 인스턴스
+     */
+    @Bean
+    public WebClient webClient() {
+        // Exchange 전략 설정 (최대 메모리 사이즈 등)
+        ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+                .codecs(configurer -> {
+                    configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024); // 10MB
+                    configurer.defaultCodecs().enableLoggingRequestDetails(true);
+                })
+                .build();
+
+        // HttpClient 설정
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // 연결 타임아웃 5초
+                .responseTimeout(Duration.ofSeconds(30)) // 응답 타임아웃 30초
+                .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(30, TimeUnit.SECONDS))
+                                .addHandlerLast(new WriteTimeoutHandler(30, TimeUnit.SECONDS))
+                );
+
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .exchangeStrategies(exchangeStrategies)
+                .filter(logRequest())
+                .filter(logResponse())
+                .build();
+    }
+
+    /**
+     * 요청 로깅 필터
+     *
+     * @return 요청 로깅을 위한 ExchangeFilterFunction
+     */
+    private ExchangeFilterFunction logRequest() {
+        return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+            log.info("=== Request: {} {}", clientRequest.method(), clientRequest.url());
+            clientRequest.headers().forEach((name, values) -> values.forEach(value ->
+                    log.debug("Request Header: {}={}", name, value)));
+            return Mono.just(clientRequest);
+        });
+    }
+
+    /**
+     * 응답 로깅 필터
+     *
+     * @return 응답 로깅을 위한 ExchangeFilterFunction
+     */
+    private ExchangeFilterFunction logResponse() {
+        return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
+            log.info("=== Response Status: {}", clientResponse.statusCode());
+            clientResponse.headers().asHttpHeaders().forEach((name, values) -> values.forEach(value ->
+                    log.debug("Response Header: {}={}", name, value)));
+            return Mono.just(clientResponse);
+        });
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,3 +72,7 @@ springdoc:
   swagger-ui:
     path: /swagger-ui/index.html
     url: /v3/api-docs
+
+ai:
+  server:
+    url: ${AI_SERVER_URL}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #26

## 📌 개요
- PostDomain에 youtube요약 기능 추가

## 🔁 변경 사항
- PostController에 youtube요약 api추가
- Post 요청, 응답dto에 youtube api관련 record추가
- PostService에 유튜브 요약 내용을 Entity에 저장하는 기능 추가 
- YouTubeSummaryService로 Ai서버에 유투브 요약 요청을 보내고, 값을 받아오는 로직 구현
- WebClientConfig를 통해, Ai서버와 통신시 필요한 설정값 구현
- yml파일에 Ai서버 url추가


## 👀 기타 더 이야기해볼 점
원래 비동기로 구현할 예정이었으나, 비동기 구현시
call-back url이 필요하며 백엔드와 ai간 api명세가 대거 바뀔거거 같아
동기로 구현

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.