### PR TITLE
[BE - FEAT] 소셜봇 구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -70,6 +70,9 @@ public class CommentService {
             // 대댓글 엔티티 생성 및 저장
             Recomment recomment = commentConverter.toRecommentEntity(parentComment, member, request);
             Recomment savedRecomment = recommentRepository.save(recomment);
+            
+            //부모 댓글 대댓글 카운트 증가
+            parentComment.increaseRecommentCount();
 
             log.info("대댓글 생성 완료: 대댓글 ID={}, 작성자 ID={}, 부모 댓글 ID={}",
                     savedRecomment.getId(), memberId, parentComment.getId());
@@ -80,6 +83,9 @@ public class CommentService {
         // 일반 댓글인 경우
         Comment comment = commentConverter.toCommentEntity(post, member, request);
         Comment savedComment = commentRepository.save(comment);
+        
+        //게시글의 댓글 수 추가
+        post.increaseCommentCount();
 
         log.info("댓글 생성 완료: 댓글 ID={}, 작성자 ID={}, 게시글 ID={}",
                 savedComment.getId(), memberId, postId);

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.converter;
 
+import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.entity.PostImage;
@@ -11,6 +12,27 @@ import java.util.stream.Collectors;
  * Post 도메인의 Entity와 DTO 간 변환을 담당하는 Converter 클래스
  */
 public class PostConverter {
+
+    /**
+     * 게시글 생성 요청 DTO를 Post 엔티티로 변환합니다.
+     *
+     * @param requestDto 게시글 생성 요청 DTO
+     * @param memberId 작성자 ID
+     * @param boardType 게시판 타입
+     * @return 생성된 Post 엔티티
+     */
+    public static Post toPost(
+            PostRequestDto.PostCreateRequestDto requestDto,
+            Long memberId,
+            Post.BoardType boardType) {
+
+        return Post.builder()
+                .memberId(memberId)
+                .boardType(boardType)
+                .content(requestDto.content())
+                .youtubeUrl(requestDto.youtube_url())
+                .build();
+    }
 
     /**
      * Post 엔티티를 상세 응답 DTO로 변환합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/BotRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/BotRequestDto.java
@@ -76,30 +76,30 @@ public class BotRequestDto {
     }
 
     /**
-     * AI 서버 게시글 생성 응답 DTO
+     * AI 서버로부터의 게시글 생성 응답 DTO
      *
      * @param message 응답 메시지
      * @param data 응답 데이터
      */
-    @Schema(description = "AI 서버 게시글 생성 응답")
-    public record CreatePostResponse(
+    @Schema(description = "AI 서버로부터의 게시글 생성 응답")
+    public record AiPostResponse(
             @Schema(description = "응답 메시지", example = "소셜봇이 게시물을 작성했습니다.")
             String message,
 
             @Schema(description = "응답 데이터")
-            ResponseData data
+            AiResponseData data
     ) {
     }
 
     /**
-     * 응답 데이터 DTO
+     * AI 서버 응답 데이터 DTO
      *
      * @param boardType 게시판 타입
      * @param user 봇 사용자 정보
      * @param content 생성된 게시글 내용
      */
-    @Schema(description = "응답 데이터")
-    public record ResponseData(
+    @Schema(description = "AI 서버 응답 데이터")
+    public record AiResponseData(
             @Schema(description = "게시판 타입", example = "PANGYO_2")
             @JsonProperty("board_type")
             String boardType,

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/BotRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/BotRequestDto.java
@@ -1,0 +1,134 @@
+package com.kakaobase.snsapp.domain.posts.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * AI 봇 관련 요청/응답 DTO 모음
+ *
+ * <p>AI 서버와의 통신에 사용되는 DTO record들을 포함합니다.</p>
+ */
+public class BotRequestDto {
+
+    /**
+     * AI 서버에 게시글 생성 요청 DTO
+     *
+     * @param boardType 게시판 타입 (PANGYO_2 등)
+     * @param posts 최근 5개 게시글 정보
+     */
+    @Schema(description = "AI 서버 게시글 생성 요청")
+    public record CreatePostRequest(
+            @Schema(description = "게시판 타입", example = "PANGYO_2", required = true)
+            @JsonProperty("board_type")
+            String boardType,
+
+            @Schema(description = "최근 5개 게시글 목록", required = true)
+            List<BotPost> posts
+    ) {
+        /**
+         * 유효성 검사를 포함한 생성자
+         */
+        public CreatePostRequest {
+            if (posts == null || posts.size() != 5) {
+                throw new IllegalArgumentException("정확히 5개의 게시글이 필요합니다.");
+            }
+        }
+    }
+
+    /**
+     * 게시글 정보 DTO
+     *
+     * @param user 작성자 정보
+     * @param createdAt 게시글 작성 시각 (ISO 8601 형식)
+     * @param content 게시글 내용
+     */
+    @Schema(description = "게시글 정보")
+    public record BotPost(
+            @Schema(description = "게시글 작성자 정보", required = true)
+            BotUser user,
+
+            @Schema(description = "게시글 작성 시각", example = "2025-04-27T10:30:32.311141Z", required = true)
+            @JsonProperty("created_at")
+            String createdAt,
+
+            @Schema(description = "게시글 내용", example = "좋은아침입니당", required = true)
+            String content
+    ) {
+    }
+
+    /**
+     * 사용자 정보 DTO
+     *
+     * @param nickname 사용자 닉네임
+     * @param className 사용자 기수
+     */
+    @Schema(description = "사용자 정보")
+    public record BotUser(
+            @Schema(description = "사용자 닉네임", example = "hazel.kim", required = true)
+            String nickname,
+
+            @Schema(description = "사용자 기수", example = "PANGYO_2", required = true)
+            @JsonProperty("class_name")
+            String className
+    ) {
+    }
+
+    /**
+     * AI 서버 게시글 생성 응답 DTO
+     *
+     * @param message 응답 메시지
+     * @param data 응답 데이터
+     */
+    @Schema(description = "AI 서버 게시글 생성 응답")
+    public record CreatePostResponse(
+            @Schema(description = "응답 메시지", example = "소셜봇이 게시물을 작성했습니다.")
+            String message,
+
+            @Schema(description = "응답 데이터")
+            ResponseData data
+    ) {
+    }
+
+    /**
+     * 응답 데이터 DTO
+     *
+     * @param boardType 게시판 타입
+     * @param user 봇 사용자 정보
+     * @param content 생성된 게시글 내용
+     */
+    @Schema(description = "응답 데이터")
+    public record ResponseData(
+            @Schema(description = "게시판 타입", example = "PANGYO_2")
+            @JsonProperty("board_type")
+            String boardType,
+
+            @Schema(description = "봇 사용자 정보")
+            BotUser user,
+
+            @Schema(description = "생성된 게시글 내용", example = "ㅎㅎ 다들 아침 인사도 해주시고...")
+            String content
+    ) {
+    }
+
+    /**
+     * AI 서버 에러 응답 DTO
+     *
+     * @param error 에러 코드
+     * @param message 에러 메시지
+     * @param field 에러 필드 (optional)
+     */
+    @Schema(description = "AI 서버 에러 응답")
+    public record ErrorResponse(
+            @Schema(description = "에러 코드", example = "invalid_query_parameter")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "전달받은 게시글이 5개 미만입니다.")
+            String message,
+
+            @Schema(description = "에러 필드 목록", example = "[\"body\", \"board_type\"]", required = false)
+            List<String> field
+    ) {
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -27,7 +27,6 @@ import java.util.List;
         }
 )
 @Getter
-@RequiredArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
@@ -79,6 +78,7 @@ public class Post extends BaseSoftDeletableEntity {
     private Integer commentCount = 0;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
     private List<PostImage> images = new ArrayList<>();
 
     public Post(Long memberId, BoardType boardType, String content) {

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -2,9 +2,7 @@ package com.kakaobase.snsapp.domain.posts.entity;
 
 import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -29,7 +27,10 @@ import java.util.List;
         }
 )
 @Getter
+@RequiredArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @SQLDelete(sql = "UPDATE posts SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class Post extends BaseSoftDeletableEntity {
@@ -70,30 +71,22 @@ public class Post extends BaseSoftDeletableEntity {
     private String youtubeSummary;
 
     @Column(name = "like_count", nullable = false)
-    private Integer likeCount;
+    @Builder.Default
+    private Integer likeCount = 0;
 
     @Column(name = "comment_count", nullable = false)
-    private Integer commentCount;
+    @Builder.Default
+    private Integer commentCount = 0;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImage> images = new ArrayList<>();
 
-    /**
-     * 게시글 생성을 위한 생성자
-     *
-     * @param memberId 작성자 ID
-     * @param boardType 게시판 유형
-     * @param content 내용
-     * @param youtubeUrl 유튜브 URL
-     */
-    public Post(Long memberId, BoardType boardType, String content, String youtubeUrl) {
+    public Post(Long memberId, BoardType boardType, String content) {
         this.memberId = memberId;
         this.boardType = boardType;
         this.content = content;
-        this.youtubeUrl = youtubeUrl;
-        this.likeCount = 0;
-        this.commentCount = 0;
     }
+
 
     /**
      * 유튜브 요약 내용을 설정합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCounter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCounter.java
@@ -1,0 +1,94 @@
+package com.kakaobase.snsapp.domain.posts.event;
+
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 게시글 카운터 관리
+ *
+ * <p>게시판별로 게시글 수를 카운트하여 봇 게시글 생성 조건을 관리합니다.</p>
+ */
+@Slf4j
+@Component
+public class PostCounter {
+
+    /**
+     * 게시판별 카운터 맵
+     *
+     * <p>스레드 안전성을 위해 ConcurrentHashMap과 AtomicInteger를 사용합니다.</p>
+     */
+    private final Map<Post.BoardType, AtomicInteger> counters = new ConcurrentHashMap<>();
+
+    /**
+     * 게시글 카운터 증가
+     *
+     * <p>지정된 게시판의 카운터를 1 증가시키고 현재 값을 반환합니다.</p>
+     *
+     * @param boardType 게시판 타입
+     * @return 증가 후 카운터 값
+     */
+    public int increment(Post.BoardType boardType) {
+        AtomicInteger counter = counters.computeIfAbsent(boardType, k -> new AtomicInteger(0));
+        int newValue = counter.incrementAndGet();
+        log.debug("카운터 증가 - boardType: {}, count: {}", boardType, newValue);
+        return newValue;
+    }
+
+    /**
+     * 게시글 카운터 리셋
+     *
+     * <p>지정된 게시판의 카운터를 0으로 초기화합니다.</p>
+     *
+     * @param boardType 게시판 타입
+     */
+    public void reset(Post.BoardType boardType) {
+        counters.computeIfAbsent(boardType, k -> new AtomicInteger(0)).set(0);
+        log.debug("카운터 리셋 - boardType: {}", boardType);
+    }
+
+    /**
+     * 현재 카운터 값 조회
+     *
+     * <p>지정된 게시판의 현재 카운터 값을 반환합니다.</p>
+     *
+     * @param boardType 게시판 타입
+     * @return 현재 카운터 값
+     */
+    public int getCount(Post.BoardType boardType) {
+        AtomicInteger counter = counters.get(boardType);
+        int count = (counter != null) ? counter.get() : 0;
+        log.debug("카운터 조회 - boardType: {}, count: {}", boardType, count);
+        return count;
+    }
+
+    /**
+     * 모든 카운터 리셋
+     *
+     * <p>모든 게시판의 카운터를 0으로 초기화합니다.
+     * 주로 테스트나 초기화 작업에 사용됩니다.</p>
+     */
+    public void resetAll() {
+        counters.forEach((boardType, counter) -> counter.set(0));
+        log.info("모든 카운터 리셋 완료");
+    }
+
+    /**
+     * 카운터 상태 정보 반환
+     *
+     * <p>디버깅용으로 모든 게시판의 카운터 상태를 문자열로 반환합니다.</p>
+     *
+     * @return 카운터 상태 문자열
+     */
+    public String getStatus() {
+        StringBuilder status = new StringBuilder("PostCounter Status: ");
+        counters.forEach((boardType, counter) ->
+                status.append(String.format("[%s: %d] ", boardType, counter.get()))
+        );
+        return status.toString();
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCreatedEvent.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCreatedEvent.java
@@ -1,0 +1,75 @@
+package com.kakaobase.snsapp.domain.posts.event;
+
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.time.LocalDateTime;
+
+/**
+ * 게시글 생성 이벤트
+ *
+ * <p>게시글이 생성될 때 발행되는 이벤트입니다.
+ * 모든 게시글(봇 포함)이 5개 생성될 때마다 봇 게시글을 추가로 생성합니다.</p>
+ */
+@Getter
+public class PostCreatedEvent extends ApplicationEvent {
+
+    /**
+     * 생성된 게시글 ID
+     */
+    private final Long postId;
+
+    /**
+     * 게시판 타입
+     */
+    private final Post.BoardType boardType;
+
+    /**
+     * 게시글 작성자 ID
+     */
+    private final Long memberId;
+
+    /**
+     * 이벤트 발생 시각
+     */
+    private final LocalDateTime createdAt;
+
+    /**
+     * PostCreatedEvent 생성자
+     *
+     * @param source 이벤트 소스 (일반적으로 이벤트를 발행하는 객체)
+     * @param postId 생성된 게시글 ID
+     * @param boardType 게시판 타입
+     * @param memberId 작성자 ID
+     */
+    public PostCreatedEvent(Object source, Long postId, Post.BoardType boardType, Long memberId) {
+        super(source);
+        this.postId = postId;
+        this.boardType = boardType;
+        this.memberId = memberId;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    /**
+     * 간편 생성자 (source를 postId로 사용)
+     *
+     * @param postId 생성된 게시글 ID
+     * @param boardType 게시판 타입
+     * @param memberId 작성자 ID
+     */
+    public PostCreatedEvent(Long postId, Post.BoardType boardType, Long memberId) {
+        this(postId, postId, boardType, memberId);
+    }
+
+    /**
+     * 이벤트 정보를 문자열로 반환
+     *
+     * @return 이벤트 정보 문자열
+     */
+    @Override
+    public String toString() {
+        return String.format("PostCreatedEvent{postId=%d, boardType=%s, memberId=%d, createdAt=%s}",
+                postId, boardType, memberId, createdAt);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostEventListener.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostEventListener.java
@@ -1,0 +1,63 @@
+package com.kakaobase.snsapp.domain.posts.event;
+
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.service.BotPostService;
+import com.kakaobase.snsapp.global.common.constant.BotConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * 게시글 생성 이벤트 리스너
+ *
+ * <p>모든 게시글(봇 포함) 생성 이벤트를 처리하여 5개마다 봇 게시글을 생성합니다.</p>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEventListener {
+
+    private final PostCounter postCounter;
+    private final BotPostService botPostService;
+
+    /**
+     * 게시글 생성 이벤트 처리
+     *
+     * <p>모든 게시글(봇 포함)이 생성될 때마다 카운터를 증가시키고,
+     * 5개가 되면 봇 게시글을 생성합니다.</p>
+     *
+     * @param event 게시글 생성 이벤트
+     */
+    @EventListener
+    @Async
+    public void handlePostCreated(PostCreatedEvent event) {
+        log.info("게시글 생성 이벤트 처리 시작 - postId: {}, boardType: {}, memberId: {}",
+                event.getPostId(), event.getBoardType(), event.getMemberId());
+
+        try {
+            Post.BoardType boardType = event.getBoardType();
+
+            // 모든 게시글에 대해 카운터 증가
+            int currentCount = postCounter.increment(boardType);
+            log.info("게시글 카운터 증가 - boardType: {}, currentCount: {}", boardType, currentCount);
+
+            // 카운터가 5에 도달한 경우
+            if (currentCount >= BotConstants.POST_COUNT_THRESHOLD) {
+                log.info("게시글 5개 도달 - 봇 게시글 생성 시작. boardType: {}", boardType);
+
+                // 카운터 먼저 리셋 (봇 게시글 생성 실패해도 리셋은 보장)
+                postCounter.reset(boardType);
+                log.info("카운터 리셋 완료 - boardType: {}", boardType);
+
+                // 봇 게시글 생성
+                botPostService.createBotPost(boardType);
+            }
+
+        } catch (Exception e) {
+            log.error("게시글 생성 이벤트 처리 중 오류 발생", e);
+            // 이벤트 처리 실패가 게시글 생성에 영향을 주지 않도록 예외 처리
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -1,0 +1,153 @@
+package com.kakaobase.snsapp.domain.posts.service;
+
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
+import com.kakaobase.snsapp.domain.posts.dto.BotRequestDto;
+import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
+import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * AI 봇의 게시글 관련 서비스
+ *
+ * <p>게시글이 5개 생성될 때마다 AI 서버에 요청하여 자동으로 봇 게시글을 생성합니다.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BotPostService {
+
+    private final PostService postService;
+    private final MemberRepository memberRepository;
+    private final WebClient webClient;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    /**
+     * AI 봇 게시글 생성
+     *
+     * <p>최근 5개 게시글을 기반으로 AI 서버에 요청하여 봇 게시글을 생성합니다.</p>
+     *
+     * @param boardType 게시판 타입
+     * @return 생성된 봇 게시글 응답 (null일 수 있음)
+     */
+    @Transactional
+    public PostResponseDto.PostCreateResponse createBotPost(Post.BoardType boardType) {
+        try {
+            log.info("봇 게시글 생성 시작 - boardType: {}", boardType);
+
+            // 1. 최근 5개 게시글 조회
+            List<Post> recentPosts = postService.findByCursor(boardType, 5, null);
+            if (recentPosts.size() < 5) {
+                log.warn("게시글이 5개 미만입니다. 봇 게시글 생성을 건너뜁니다. - count: {}", recentPosts.size());
+                return null;
+            }
+
+            // 2. AI 서버 요청 DTO 생성
+            BotRequestDto.CreatePostRequest request = createBotRequest(boardType, recentPosts);
+
+            // 3. AI 서버 호출
+            BotRequestDto.CreatePostResponse response = callAiServer(request);
+
+            // 4. 봇 게시글 저장
+            PostResponseDto.PostCreateResponse createResponse = saveBotPost(response);
+
+            log.info("봇 게시글 생성 완료 - boardType: {}", boardType);
+            return createResponse;
+
+        } catch (Exception e) {
+            log.error("봇 게시글 생성 실패 - boardType: {}", boardType, e);
+            // 실패해도 카운터는 리셋되어야 하므로 예외를 전파하지 않음
+            return null;
+        }
+    }
+
+    /**
+     * AI 서버 요청 DTO 생성
+     *
+     * @param boardType 게시판 타입
+     * @param posts 최근 게시글 목록
+     * @return AI 서버 요청 DTO
+     */
+    private BotRequestDto.CreatePostRequest createBotRequest(Post.BoardType boardType, List<Post> posts) {
+        List<BotRequestDto.BotPost> botPosts = posts.stream()
+                .map(post -> {
+                    Member member = memberRepository.findById(post.getMemberId())
+                            .orElseThrow(() -> new IllegalStateException("회원을 찾을 수 없습니다. memberId: " + post.getMemberId()));
+
+                    return new BotRequestDto.BotPost(
+                            new BotRequestDto.BotUser(
+                                    member.getNickname(),
+                                    member.getClassName()
+                            ),
+                            post.getCreatedAt().atZone(java.time.ZoneId.systemDefault()).toInstant().toString(),
+                            post.getContent()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new BotRequestDto.CreatePostRequest(boardType.name(), botPosts);
+    }
+
+    /**
+     * AI 서버 호출
+     *
+     * @param request AI 서버 요청 DTO
+     * @return AI 서버 응답 DTO
+     */
+    private BotRequestDto.CreatePostResponse callAiServer(BotRequestDto.CreatePostRequest request) {
+        try {
+            return webClient.post()
+                    .uri(aiServerUrl + "/posts/bot")
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(BotRequestDto.CreatePostResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("AI 서버 요청 실패 - Status: {}, Body: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new RuntimeException("AI 서버 통신 오류", e);
+        }
+    }
+
+    /**
+     * 봇 게시글 저장
+     *
+     * @param response AI 서버 응답
+     * @return 게시글 생성 응답 DTO
+     */
+    private PostResponseDto.PostCreateResponse saveBotPost(BotRequestDto.CreatePostResponse response) {
+        BotRequestDto.ResponseData data = response.data();
+
+        // 게시판 타입 변환
+        Post.BoardType boardType;
+        try {
+            boardType = Post.BoardType.valueOf(data.boardType());
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 게시판 타입: {}", data.boardType());
+            throw new RuntimeException("잘못된 게시판 타입", e);
+        }
+
+        // PostService의 createPost 메서드에 전달할 DTO 생성
+        // PostCreateRequestDto는 snake_case 필드명 사용
+        PostRequestDto.PostCreateRequestDto createRequest = new PostRequestDto.PostCreateRequestDto(
+                data.content(),
+                null, // 봇은 이미지 없음
+                null                     // 봇은 YouTube URL 없음
+        );
+
+        // PostService의 createPost 메서드 재사용
+        // postType (소문자)로 전달
+        return postService.createPost(createRequest, BotConstants.BOT_MEMBER_ID, boardType.name().toLowerCase());
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/global/common/constant/BotConstants.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/constant/BotConstants.java
@@ -1,0 +1,58 @@
+package com.kakaobase.snsapp.global.common.constant;
+
+/**
+ * 봇 관련 상수 정의
+ *
+ * <p>AI 소셜봇 기능에 사용되는 상수들을 중앙 관리합니다.</p>
+ */
+public final class BotConstants {
+
+    /**
+     * 인스턴스화 방지를 위한 private 생성자
+     */
+    private BotConstants() {
+        throw new AssertionError("BotConstants는 인스턴스화할 수 없습니다.");
+    }
+
+    /**
+     * 봇 멤버 ID
+     *
+     * <p>AI 소셜봇의 고정 멤버 ID입니다.</p>
+     */
+    public static final Long BOT_MEMBER_ID = 1213L;
+
+    /**
+     * 봇 닉네임
+     *
+     * <p>AI 소셜봇의 기본 닉네임입니다.</p>
+     */
+    public static final String BOT_NICKNAME = "roro.bot";
+
+    /**
+     * 봇 기수
+     *
+     * <p>AI 소셜봇이 속한 기본 기수입니다.</p>
+     */
+    public static final String BOT_CLASS_NAME = "PANGYO_2";
+
+    /**
+     * 봇 게시글 생성 임계값
+     *
+     * <p>일반 사용자 게시글이 이 수만큼 누적되면 봇이 게시글을 작성합니다.</p>
+     */
+    public static final int POST_COUNT_THRESHOLD = 5;
+
+    /**
+     * AI 서버 요청 타임아웃 (초)
+     *
+     * <p>AI 서버 응답을 기다리는 최대 시간입니다.</p>
+     */
+    public static final int AI_SERVER_TIMEOUT_SECONDS = 30;
+
+    /**
+     * 봇 게시글 최대 길이
+     *
+     * <p>AI가 생성하는 게시글의 최대 문자 수입니다.</p>
+     */
+    public static final int BOT_POST_MAX_LENGTH = 2000;
+}

--- a/src/main/java/com/kakaobase/snsapp/global/config/AsyncConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/AsyncConfig.java
@@ -1,0 +1,45 @@
+package com.kakaobase.snsapp.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * 비동기 처리 설정
+ *
+ * <p>Spring의 @Async 어노테이션을 위한 설정입니다.</p>
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /**
+     * 비동기 작업을 위한 ThreadPoolTaskExecutor 빈 생성
+     *
+     * @return 설정된 TaskExecutor
+     */
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        // 코어 스레드 개수
+        executor.setCorePoolSize(2);
+
+        // 최대 스레드 개수
+        executor.setMaxPoolSize(10);
+
+        // 큐 용량
+        executor.setQueueCapacity(500);
+
+        // 스레드 이름 prefix
+        executor.setThreadNamePrefix("sns-async-");
+
+        // 초기화
+        executor.initialize();
+
+        return executor;
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #28

## 📌 개요
- 게시글이 5개 생성될 때마다 AI 서버와 통신하여 자동으로 봇 게시글을 생성하는 기능 구현
- 이벤트 기반 아키텍처를 사용하여 게시글 생성과 봇 로직을 분리

## 🔁 변경 사항

### 새로 추가된 파일
- `BotRequestDto`: AI 서버와의 통신을 위한 요청/응답 DTO
  - `CreatePostRequest`: AI 서버에 전송할 게시글 생성 요청
  - `AiPostResponse`: AI 서버로부터의 응답
- `BotPostService`: AI 봇 게시글 생성 비즈니스 로직
  - 최근 5개 게시글 조회 및 AI 서버 요청 처리
  - WebClient를 사용한 비동기 통신
- `PostCreatedEvent`: 게시글 생성 이벤트
  - ApplicationEvent를 상속하여 Spring 이벤트 시스템과 통합
- `PostEventListener`: 게시글 생성 이벤트 처리
  - `@Async`를 통한 비동기 처리로 메인 플로우에 영향 없음
- `PostCounter`: 게시판별 게시글 카운터 관리
  - Thread-safe한 구현 (ConcurrentHashMap, AtomicInteger)
- `BotConstants`: 봇 관련 상수 정의
  - 봇 ID(1213L), 닉네임, 기수 등 중앙 관리
- `AsyncConfig`: 비동기 처리 설정
  - ThreadPoolTaskExecutor 커스텀 설정

### 수정된 파일
- `PostService`: 게시글 생성 시 이벤트 발행 기능 추가
  - `ApplicationEventPublisher`를 사용하여 `PostCreatedEvent` 발행
- `Post`, `PostConverter` : 엔티티가  @Builer를 통해 구현되도록 변경

### 주요 구현 내용
1. **이벤트 기반 아키텍처**
   - 게시글 생성 → 이벤트 발행 → 리스너가 카운터 관리 → 5개 도달 시 봇 게시글 생성
   - 메인 비즈니스 로직과 봇 처리 로직 분리

2. **AI 서버 통신**
   - WebClient를 사용한 HTTP 통신
   - 요청: boardType + 최근 5개 게시글 정보
   - 응답: AI가 생성한 게시글 내용

3. **카운터 관리**
   - 게시판별 독립적인 카운터
   - 모든 게시글(봇 포함) 5개마다 봇 게시글 생성
   - Thread-safe한 구현

## 👀 기타 더 이야기해볼 점
1. **에러 처리**
   - AI 서버 통신 실패 시에도 카운터는 리셋되도록 설계
   - 봇 게시글 생성 실패가 일반 게시글 생성에 영향 없음

2. **확장성**
   - 게시판별 다른 임계값 설정 가능
   - AI 모델 변경 시 DTO만 수정하면 됨

3. **모니터링**
   - 각 단계별 상세 로깅으로 문제 추적 용이
   - PostCounter에 getStatus() 메서드로 상태 확인 가능

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.