### PR TITLE
[BE - FEAT] 소셜봇 대댓글 기능 구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/BotRecommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/BotRecommentConverter.java
@@ -1,0 +1,209 @@
+package com.kakaobase.snsapp.domain.comments.converter;
+
+import com.kakaobase.snsapp.domain.comments.dto.BotRecommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 봇 대댓글 관련 엔티티와 DTO 간 변환을 담당하는 컨버터 클래스
+ */
+public class BotRecommentConverter {
+
+    /**
+     * AI 서버 요청 DTO 생성 (RecommentInfo 사용)
+     *
+     * @param post 게시글 엔티티
+     * @param postAuthorInfo 게시글 작성자 봇 정보
+     * @param comment 댓글 엔티티
+     * @param recomments 기존 대댓글 목록 (RecommentInfo)
+     * @return AI 서버 요청 DTO
+     */
+    public static BotRecommentRequestDto.CreateRecommentRequest toCreateRecommentRequest(
+            Post post,
+            BotRecommentRequestDto.UserInfo postAuthorInfo,
+            Comment comment,
+            List<CommentResponseDto.RecommentInfo> recomments) {
+
+        String boardType = post.getBoardType().name();
+
+        // 게시글 정보 생성
+        BotRecommentRequestDto.BotPost botPost = new BotRecommentRequestDto.BotPost(
+                post.getId(),
+                postAuthorInfo,
+                formatDateTime(post.getCreatedAt()),
+                post.getContent()
+        );
+
+        // 댓글 정보 생성
+        BotRecommentRequestDto.BotComment botComment = new BotRecommentRequestDto.BotComment(
+                comment.getId(),
+                new BotRecommentRequestDto.UserInfo(
+                        comment.getMember().getNickname(),
+                        comment.getMember().getClassName()
+                ),
+                formatDateTime(comment.getCreatedAt()),
+                comment.getContent(),
+                toRecommentListFromDto(recomments)
+        );
+
+        return new BotRecommentRequestDto.CreateRecommentRequest(
+                boardType,
+                botPost,
+                botComment
+        );
+    }
+
+    /**
+     * RecommentInfo DTO 리스트를 BotRecomment DTO 리스트로 변환
+     *
+     * @param recomments 대댓글 정보 리스트
+     * @return BotRecomment DTO 리스트
+     */
+    private static List<BotRecommentRequestDto.BotRecomment> toRecommentListFromDto(
+            List<CommentResponseDto.RecommentInfo> recomments) {
+
+        if (recomments == null || recomments.isEmpty()) {
+            return List.of();
+        }
+
+        return recomments.stream()
+                .map(recomment -> new BotRecommentRequestDto.BotRecomment(
+                        new BotRecommentRequestDto.UserInfo(
+                                recomment.user().nickname(),
+                                "PANGYO_2"  // TODO: RecommentInfo에 className 추가 필요
+                        ),
+                        recomment.created_at().format(DateTimeFormatter.ISO_INSTANT),
+                        recomment.content()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * AI 응답 DTO를 대댓글 생성 요청 DTO로 변환
+     *
+     * @param response AI 서버 응답
+     * @param commentId 부모 댓글 ID (parent_id로 사용)
+     * @return 대댓글 생성 요청 DTO
+     */
+    public static CommentRequestDto.CreateCommentRequest toCreateCommentRequest(
+            BotRecommentRequestDto.AiRecommentResponse response,
+            Long commentId) {
+
+        return new CommentRequestDto.CreateCommentRequest(
+                response.data().content(),
+                commentId  // parent_id로 사용됨
+        );
+    }
+
+    /**
+     * LocalDateTime을 ISO_INSTANT 형식 문자열로 변환
+     *
+     * @param dateTime 변환할 시간
+     * @return ISO_INSTANT 형식 문자열 (예: 2025-04-27T13:41:32.311141Z)
+     */
+    private static String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.atZone(ZoneId.of("UTC"))
+                .format(DateTimeFormatter.ISO_INSTANT);
+    }
+
+    /**
+     * AI 응답이 유효한지 검증
+     *
+     * @param response AI 서버 응답
+     * @return 유효하면 true, 아니면 false
+     */
+    public static boolean isValidResponse(BotRecommentRequestDto.AiRecommentResponse response) {
+        if (response == null || response.data() == null) {
+            return false;
+        }
+
+        String content = response.data().content();
+        return content != null && !content.trim().isEmpty() && content.length() <= 2000;
+    }
+
+    /**
+     * 에러 응답 메시지 생성
+     *
+     * @param errorResponse AI 서버 에러 응답
+     * @return 에러 메시지
+     */
+    public static String getErrorMessage(BotRecommentRequestDto.ErrorResponse errorResponse) {
+        if (errorResponse == null) {
+            return "알 수 없는 오류가 발생했습니다.";
+        }
+
+        StringBuilder message = new StringBuilder(errorResponse.message());
+
+        if (errorResponse.field() != null && !errorResponse.field().isEmpty()) {
+            message.append(" (필드: ")
+                    .append(String.join(", ", errorResponse.field()))
+                    .append(")");
+        }
+
+        return message.toString();
+    }
+
+    /**
+     * AI 응답에서 봇 정보가 유효한지 검증
+     *
+     * @param response AI 서버 응답
+     * @return 유효하면 true, 아니면 false
+     */
+    public static boolean isBotResponseValid(BotRecommentRequestDto.AiRecommentResponse response) {
+        if (response == null || response.data() == null || response.data().user() == null) {
+            return false;
+        }
+
+        // AI 응답의 user 정보 검증
+        BotRecommentRequestDto.UserInfo botUser = response.data().user();
+        return botUser.nickname() != null && !botUser.nickname().trim().isEmpty();
+    }
+
+    /**
+     * AI 요청 데이터 로깅용 문자열 생성
+     *
+     * @param request AI 서버 요청 DTO
+     * @return 로깅용 문자열
+     */
+    public static String toLogString(BotRecommentRequestDto.CreateRecommentRequest request) {
+        if (request == null) {
+            return "null request";
+        }
+
+        return String.format("boardType: %s, postId: %d, commentId: %d, recomments: %d개",
+                request.boardType(),
+                request.post() != null ? request.post().id() : null,
+                request.comment() != null ? request.comment().id() : null,
+                request.comment() != null && request.comment().recomments() != null
+                        ? request.comment().recomments().size() : 0
+        );
+    }
+
+    /**
+     * AI 응답 데이터 로깅용 문자열 생성
+     *
+     * @param response AI 서버 응답 DTO
+     * @return 로깅용 문자열
+     */
+    public static String toLogString(BotRecommentRequestDto.AiRecommentResponse response) {
+        if (response == null || response.data() == null) {
+            return "null response";
+        }
+
+        return String.format("postId: %d, commentId: %d, content: %s...",
+                response.data().postId(),
+                response.data().commentId(),
+                response.data().content() != null && response.data().content().length() > 20
+                        ? response.data().content().substring(0, 20)
+                        : response.data().content()
+        );
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/BotRecommentRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/BotRecommentRequestDto.java
@@ -1,0 +1,203 @@
+package com.kakaobase.snsapp.domain.comments.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+/**
+ * AI 봇 대댓글 관련 요청/응답 DTO 모음
+ *
+ * <p>AI 서버와의 대댓글 생성 통신에 사용되는 DTO record들을 포함합니다.</p>
+ */
+@Schema(description = "봇 대댓글 관련 요청/응답 DTO 클래스")
+public class BotRecommentRequestDto {
+
+    /**
+     * 사용자 정보 DTO (API 스펙에 맞춤)
+     * 게시글 작성자, 댓글 작성자, 대댓글 작성자 모두에 사용
+     *
+     * @param nickname 사용자 닉네임
+     * @param className 사용자 기수
+     */
+    @Schema(description = "사용자 정보")
+    public record UserInfo(
+            @Schema(description = "사용자 닉네임", example = "roro.bot", required = true)
+            String nickname,
+
+            @Schema(description = "사용자 기수", example = "PANGYO_2", required = true)
+            @JsonProperty("class_name")
+            String className
+    ) {}
+
+    /**
+     * AI 서버에 대댓글 생성 요청 DTO
+     *
+     * @param boardType 게시판 타입 (PANGYO_2 등)
+     * @param post 원본 게시글 정보
+     * @param comment 댓글 정보
+     */
+    @Schema(description = "AI 서버 대댓글 생성 요청")
+    public record CreateRecommentRequest(
+            @Schema(description = "게시판 타입", example = "PANGYO_2", required = true)
+            @JsonProperty("board_type")
+            String boardType,
+
+            @Schema(description = "원본 게시글 정보", required = true)
+            BotPost post,
+
+            @Schema(description = "댓글 정보", required = true)
+            BotComment comment
+    ) {
+        /**
+         * 유효성 검사를 포함한 생성자
+         */
+        public CreateRecommentRequest {
+            if (boardType == null || boardType.trim().isEmpty()) {
+                throw new IllegalArgumentException("게시판 타입은 필수입니다.");
+            }
+            if (post == null) {
+                throw new IllegalArgumentException("게시글 정보는 필수입니다.");
+            }
+            if (comment == null) {
+                throw new IllegalArgumentException("댓글 정보는 필수입니다.");
+            }
+        }
+    }
+
+    /**
+     * 게시글 정보 DTO
+     *
+     * @param id 게시글 ID
+     * @param user 작성자 정보
+     * @param createdAt 작성 시각 (ISO 8601 형식)
+     * @param content 게시글 내용
+     */
+    @Schema(description = "게시글 정보")
+    public record BotPost(
+            @Schema(description = "게시글 ID", example = "4040", required = true)
+            Long id,
+
+            @Schema(description = "작성자 정보", required = true)
+            UserInfo user,
+
+            @Schema(description = "작성 시각", example = "2025-04-27T11:41:32.311141Z", required = true)
+            @JsonProperty("created_at")
+            String createdAt,
+
+            @Schema(description = "게시글 내용", example = "이번에 해태제과에서 후렌치파이...", required = true)
+            String content
+    ) {}
+
+    /**
+     * 댓글 정보 DTO
+     *
+     * @param id 댓글 ID
+     * @param user 작성자 정보
+     * @param createdAt 작성 시각 (ISO 8601 형식)
+     * @param content 댓글 내용
+     * @param recomments 기존 대댓글 목록
+     */
+    @Schema(description = "댓글 정보")
+    public record BotComment(
+            @Schema(description = "댓글 ID", example = "1234", required = true)
+            Long id,
+
+            @Schema(description = "작성자 정보", required = true)
+            UserInfo user,
+
+            @Schema(description = "작성 시각", example = "2025-04-27T13:40:32.311141Z", required = true)
+            @JsonProperty("created_at")
+            String createdAt,
+
+            @Schema(description = "댓글 내용", example = "블루베리맛 후렌치파이? 맛있겠다!", required = true)
+            String content,
+
+            @Schema(description = "기존 대댓글 목록", nullable = true)
+            List<BotRecomment> recomments
+    ) {}
+
+    /**
+     * 대댓글 정보 DTO
+     *
+     * @param user 작성자 정보
+     * @param createdAt 작성 시각 (ISO 8601 형식)
+     * @param content 대댓글 내용
+     */
+    @Schema(description = "대댓글 정보")
+    public record BotRecomment(
+            @Schema(description = "작성자 정보", required = true)
+            UserInfo user,
+
+            @Schema(description = "작성 시각", example = "2025-04-27T13:41:32.311141Z", required = true)
+            @JsonProperty("created_at")
+            String createdAt,
+
+            @Schema(description = "대댓글 내용", example = "네 맛있더라구요!><", required = true)
+            String content
+    ) {}
+
+
+    /**
+     * AI 서버로부터의 대댓글 생성 응답 DTO
+     *
+     * @param message 응답 메시지
+     * @param data 응답 데이터
+     */
+    @Schema(description = "AI 서버로부터의 대댓글 생성 응답")
+    public record AiRecommentResponse(
+            @Schema(description = "응답 메시지", example = "소셜봇이 대댓글을 작성했습니다.")
+            String message,
+
+            @Schema(description = "응답 데이터")
+            AiResponseData data
+    ) {}
+
+    /**
+     * AI 서버 응답 데이터 DTO
+     *
+     * @param boardType 게시판 타입
+     * @param postId 게시글 ID
+     * @param commentId 댓글 ID
+     * @param user 봇 사용자 정보
+     * @param content 생성된 대댓글 내용
+     */
+    @Schema(description = "AI 서버 응답 데이터")
+    public record AiResponseData(
+            @Schema(description = "게시판 타입", example = "PANGYO_2")
+            @JsonProperty("board_type")
+            String boardType,
+
+            @Schema(description = "게시글 ID", example = "4040")
+            @JsonProperty("post_id")
+            Long postId,
+
+            @Schema(description = "댓글 ID", example = "1234")
+            @JsonProperty("comment_id")
+            Long commentId,
+
+            @Schema(description = "봇 사용자 정보")
+            UserInfo user,
+
+            @Schema(description = "생성된 대댓글 내용", example = "ㅎㅎ 맞아요! 저는 입은 없지만...")
+            String content
+    ) {}
+
+    /**
+     * AI 서버 에러 응답 DTO
+     *
+     * @param error 에러 코드
+     * @param message 에러 메시지
+     * @param field 에러 필드 (optional)
+     */
+    @Schema(description = "AI 서버 에러 응답")
+    public record ErrorResponse(
+            @Schema(description = "에러 코드", example = "missing_required_field")
+            String error,
+
+            @Schema(description = "에러 메시지", example = "필수 필드가 누락되었습니다.")
+            String message,
+
+            @Schema(description = "에러 필드 목록", example = "[\"body\", \"board_type\"]", required = false)
+            List<String> field
+    ) {}
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/event/CommentCreatedEvent.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/event/CommentCreatedEvent.java
@@ -1,0 +1,76 @@
+package com.kakaobase.snsapp.domain.comments.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import com.kakaobase.snsapp.global.common.constant.BotConstants;
+
+import java.time.LocalDateTime;
+
+/**
+ * 댓글 생성 시 발행되는 이벤트
+ *
+ * <p>댓글이 생성되었을 때 발행되며, 봇 대댓글 생성 등의 후속 처리에 사용됩니다.</p>
+ */
+@Getter
+@AllArgsConstructor
+public class CommentCreatedEvent {
+
+    /**
+     * 생성된 댓글 ID
+     */
+    private final Long commentId;
+
+    /**
+     * 댓글이 달린 게시글 ID
+     */
+    private final Long postId;
+
+    /**
+     * 게시글 작성자 ID
+     */
+    private final Long postAuthorId;
+
+    /**
+     * 댓글 작성자 ID
+     */
+    private final Long commentAuthorId;
+
+    /**
+     * 댓글 내용
+     */
+    private final String content;
+
+    /**
+     * 이벤트 생성 시각
+     */
+    private final LocalDateTime createdAt;
+
+    /**
+     * 봇이 작성한 게시글에 달린 댓글인지 확인
+     *
+     * @return 봇 게시글 여부 (true: 봇 게시글, false: 일반 게시글)
+     */
+    public boolean isCommentOnBotPost() {
+        return postAuthorId != null && postAuthorId.equals(BotConstants.BOT_MEMBER_ID);
+    }
+
+    /**
+     * 봇이 작성한 댓글인지 확인
+     *
+     * @return 봇 댓글 여부 (true: 봇이 작성, false: 일반 사용자 작성)
+     */
+    public boolean isCommentByBot() {
+        return commentAuthorId != null && commentAuthorId.equals(BotConstants.BOT_MEMBER_ID);
+    }
+
+    /**
+     * 이벤트 정보를 로깅용 문자열로 변환
+     *
+     * @return 로깅용 문자열
+     */
+    @Override
+    public String toString() {
+        return String.format("CommentCreatedEvent[commentId=%d, postId=%d, postAuthorId=%d, commentAuthorId=%d]",
+                commentId, postId, postAuthorId, commentAuthorId);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/event/CommentEventListener.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/event/CommentEventListener.java
@@ -1,0 +1,75 @@
+package com.kakaobase.snsapp.domain.comments.event;
+
+import com.kakaobase.snsapp.domain.comments.service.BotRecommentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * 댓글 이벤트 리스너
+ *
+ * <p>댓글 관련 이벤트를 처리하여 봇 대댓글 생성 등의 후속 작업을 수행합니다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CommentEventListener {
+
+    private final BotRecommentService botRecommentService;
+
+    /**
+     * 댓글 생성 이벤트 처리
+     *
+     * <p>봇이 작성한 게시글에 일반 사용자가 댓글을 달았을 때 AI 대댓글을 생성합니다.</p>
+     *
+     * @param event 댓글 생성 이벤트
+     */
+    @EventListener
+    @Async("taskExecutor")  // AsyncConfig에서 정의한 빈 이름 명시
+    public void handleCommentCreated(CommentCreatedEvent event) {
+        log.debug("댓글 생성 이벤트 수신: {}", event);
+
+        try {
+            // 1. 봇 게시글에 달린 댓글인지 확인
+            if (!event.isCommentOnBotPost()) {
+                log.debug("봇 게시글이 아니므로 대댓글 생성 스킵 - postAuthorId: {}", event.getPostAuthorId());
+                return;
+            }
+
+            // 2. 봇이 작성한 댓글 제외 (무한 루프 방지)
+            if (event.isCommentByBot()) {
+                log.debug("봇이 작성한 댓글이므로 대댓글 생성 스킵 - commentAuthorId: {}", event.getCommentAuthorId());
+                return;
+            }
+
+            log.info("봇 대댓글 생성 시작 - commentId: {}, postId: {}",
+                    event.getCommentId(), event.getPostId());
+
+            // 3. 봇 대댓글 생성 서비스 호출
+            botRecommentService.createBotRecomment(event);
+
+            log.info("봇 대댓글 생성 이벤트 처리 완료 - commentId: {}", event.getCommentId());
+
+        } catch (Exception e) {
+            // 에러가 발생해도 메인 플로우에 영향 없도록 처리
+            log.error("봇 대댓글 생성 실패 - commentId: {}, error: {}",
+                    event.getCommentId(), e.getMessage(), e);
+
+            // 모니터링을 위해 추가적인 처리 필요시 여기에 구현
+            // 예: 메트릭 수집, 알림 발송 등
+        }
+    }
+
+    /**
+     * 댓글 삭제 이벤트 처리 (향후 구현 예정)
+     *
+     * @param event 댓글 삭제 이벤트
+     */
+    // @EventListener
+    // @Async("taskExecutor")
+    // public void handleCommentDeleted(CommentDeletedEvent event) {
+    //     // 향후 댓글 삭제 시 봇 대댓글도 처리하는 로직 구현
+    // }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
@@ -1,0 +1,228 @@
+package com.kakaobase.snsapp.domain.comments.service;
+
+import com.kakaobase.snsapp.domain.comments.converter.BotRecommentConverter;
+import com.kakaobase.snsapp.domain.comments.dto.BotRecommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentRequestDto;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.comments.entity.Recomment;
+import com.kakaobase.snsapp.domain.comments.event.CommentCreatedEvent;
+import com.kakaobase.snsapp.domain.comments.exception.CommentErrorCode;
+import com.kakaobase.snsapp.domain.comments.exception.CommentException;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.service.MemberService;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.global.common.constant.BotConstants;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * 봇 대댓글 서비스
+ *
+ * <p>AI 서버와 통신하여 봇 게시글에 달린 댓글에 대한 대댓글을 생성합니다.</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class BotRecommentService {
+
+    private final CommentService commentService;
+    private final MemberService memberService;
+    private final WebClient webClient;
+
+    // 대댓글 조회 시 사용할 최대 limit 값
+    private static final int MAX_RECOMMENT_LIMIT = 100;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    @Value("${ai.server.timeout:30}")
+    private int timeoutSeconds;
+
+    @Value("${ai.server.retry.attempts:3}")
+    private long retryAttempts;
+
+    @Value("${ai.server.retry.delay:1}")
+    private long retryDelaySeconds;
+
+    /**
+     * 봇 대댓글 생성
+     *
+     * @param event 댓글 생성 이벤트
+     */
+    @Transactional
+    public void createBotRecomment(CommentCreatedEvent event) {
+        log.info("봇 대댓글 생성 시작 - commentId: {}", event.getCommentId());
+
+        try {
+            // 1. 댓글 정보 조회
+            Comment comment = commentService.findById(event.getCommentId());
+            Post post = comment.getPost();
+
+            // 2. 게시글 작성자 정보 조회
+            BotRecommentRequestDto.UserInfo postAuthorInfo = memberService.getMemberBotInfo(post.getMemberId());
+
+            // 3. 대댓글 목록 조회 (큰 limit 사용)
+            CommentRequestDto.RecommentPageRequest pageRequest =
+                    new CommentRequestDto.RecommentPageRequest(MAX_RECOMMENT_LIMIT, null);
+
+            CommentResponseDto.RecommentListResponse recommentResponse =
+                    commentService.getRecommentsByCommentId(
+                            BotConstants.BOT_MEMBER_ID,
+                            comment.getId(),
+                            pageRequest
+                    );
+
+            // 4. AI 요청 DTO 생성 (RecommentInfo 직접 사용)
+            BotRecommentRequestDto.CreateRecommentRequest aiRequest =
+                    BotRecommentConverter.toCreateRecommentRequest(
+                            post,
+                            postAuthorInfo,
+                            comment,
+                            recommentResponse.recomments()  // RecommentInfo 리스트 전달
+                    );
+
+            // 5. AI 서버 호출
+            BotRecommentRequestDto.AiRecommentResponse aiResponse = callAiServerForRecommend(aiRequest);
+
+            log.debug("AI 응답 수신: {}", BotRecommentConverter.toLogString(aiResponse));
+
+            // 6. 응답 검증
+            validateAiResponse(aiResponse);
+
+            // 7. 대댓글 저장 (CommentService의 createComment 활용)
+            Comment savedRecomment = saveRecomment(post.getId(), comment.getId(), aiResponse);
+
+            log.info("봇 대댓글 생성 완료 - commentId: {}, content: {}...",
+                    comment.getId(),
+                    savedRecomment.getContent().substring(0, Math.min(20, savedRecomment.getContent().length())));
+
+        } catch (CommentException e) {
+            log.error("댓글 관련 오류 발생 - commentId: {}, error: {}",
+                    event.getCommentId(), e.getMessage());
+            throw e;
+        } catch (WebClientResponseException e) {
+            log.error("AI 서버 통신 오류 - commentId: {}, status: {}, body: {}",
+                    event.getCommentId(), e.getStatusCode(), e.getResponseBodyAsString());
+            throw new CommentException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "AI 서버 통신 오류");
+        } catch (Exception e) {
+            log.error("봇 대댓글 생성 중 예상치 못한 오류 발생 - commentId: {}", event.getCommentId(), e);
+            throw new CommentException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "봇 대댓글 생성 실패");
+        }
+    }
+
+    /**
+     * 댓글의 대댓글 목록 조회
+     *
+     * @param commentId 댓글 ID
+     * @return 대댓글 목록
+     */
+    private List<Recomment> getRecommentsByCommentId(Long commentId) {
+        // CommentService의 getRecommentsByCommentId 메서드를 활용
+        // 하지만 해당 메서드는 페이징을 사용하므로 리포지토리 직접 호출이 더 효율적
+        // CommentService에 전체 대댓글 조회 메서드가 없으므로 새로 만들어야 할 수도 있음
+
+        // 임시로 빈 리스트 반환 (실제 구현 시 수정 필요)
+        return List.of();
+    }
+
+    /**
+     * AI 서버 호출
+     *
+     * @param request AI 요청 DTO
+     * @return AI 응답 DTO
+     */
+    private BotRecommentRequestDto.AiRecommentResponse callAiServerForRecommend(
+            BotRecommentRequestDto.CreateRecommentRequest request) {
+
+        String url = aiServerUrl + "/recomments/bot";
+
+        return webClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError(),
+                        response -> response.bodyToMono(BotRecommentRequestDto.ErrorResponse.class)
+                                .flatMap(errorResponse -> {
+                                    String errorMessage = BotRecommentConverter.getErrorMessage(errorResponse);
+                                    log.error("AI 서버 클라이언트 오류: {}", errorMessage);
+                                    return Mono.error(new CommentException(
+                                            GeneralErrorCode.INTERNAL_SERVER_ERROR,
+                                            errorMessage
+                                    ));
+                                })
+                )
+                .bodyToMono(BotRecommentRequestDto.AiRecommentResponse.class)
+                .timeout(Duration.ofSeconds(timeoutSeconds))
+                .retryWhen(Retry.backoff(retryAttempts, Duration.ofSeconds(retryDelaySeconds))
+                        .filter(throwable -> throwable instanceof WebClientResponseException &&
+                                ((WebClientResponseException) throwable).getStatusCode().is5xxServerError())
+                        .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                            log.error("AI 서버 재시도 횟수 초과");
+                            return new CommentException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "AI 서버 응답 없음");
+                        })
+                )
+                .block();
+    }
+
+    /**
+     * AI 응답 검증
+     *
+     * @param response AI 응답
+     * @throws CommentException 응답이 유효하지 않은 경우
+     */
+    private void validateAiResponse(BotRecommentRequestDto.AiRecommentResponse response) {
+        if (!BotRecommentConverter.isValidResponse(response)) {
+            log.error("유효하지 않은 AI 응답: {}", response);
+            throw new CommentException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "유효하지 않은 AI 응답");
+        }
+
+        // 대댓글 내용 길이 검증
+        String content = response.data().content();
+        if (content.length() > 2000) {
+            log.error("AI 응답 내용이 너무 깁니다: {} 자", content.length());
+            throw new CommentException(CommentErrorCode.CONTENT_LENGTH_EXCEEDED);
+        }
+    }
+
+    /**
+     * 대댓글 저장
+     *
+     * @param postId 게시글 ID
+     * @param commentId 댓글 ID
+     * @param response AI 응답
+     * @return 저장된 댓글(실제로는 대댓글) 엔티티
+     */
+    @Transactional
+    protected Comment saveRecomment(Long postId, Long commentId,
+                                    BotRecommentRequestDto.AiRecommentResponse response) {
+
+        // AI 응답을 대댓글 생성 요청 DTO로 변환
+        CommentRequestDto.CreateCommentRequest recommentRequest =
+                BotRecommentConverter.toCreateCommentRequest(response, commentId);
+
+        // CommentService의 createComment 메서드를 사용하여 대댓글 생성
+        // parent_id가 있으므로 자동으로 대댓글로 처리됨
+        CommentResponseDto.CreateCommentResponse recommentResponse =
+                commentService.createComment(BotConstants.BOT_MEMBER_ID, postId, recommentRequest);
+
+        // 생성된 대댓글 반환을 위해 조회
+        // CreateCommentResponse에는 id가 있지만 content 전체를 위해 다시 조회
+        return commentService.findById(recommentResponse.id());
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.members.service;
 
+import com.kakaobase.snsapp.domain.comments.dto.BotRecommentRequestDto;
 import com.kakaobase.snsapp.domain.members.converter.MemberConverter;
 import com.kakaobase.snsapp.domain.members.dto.MemberRequestDto;
 import com.kakaobase.snsapp.domain.members.entity.Member;
@@ -166,5 +167,23 @@ public class MemberService {
     @Transactional(readOnly = true)
     public boolean existsById(Long memberId) {
         return memberRepository.existsById(memberId);
+    }
+
+    /**
+     * 회원의 닉네임과 기수 정보만 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return BotUser DTO (닉네임, 기수)
+     * @throws MemberException 회원을 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public BotRecommentRequestDto.UserInfo getMemberBotInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND, "memberId"));
+
+        return new BotRecommentRequestDto.UserInfo(
+                member.getNickname(),
+                member.getClassName()
+        );
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #30

## 📌 개요
- AI 소셜봇이 게시글에 달린 댓글에 자동으로 대댓글을 작성하는 기능을 추가했습니다.
- 봇 게시글에 일반 사용자가 댓글을 작성하면, 이벤트 기반으로 AI 서버와 통신하여 자연스러운 대댓글을 생성합니다.

## 🔁 변경 사항

### 1. 이벤트 관련 코드 추가
- `CommentCreatedEvent`: 댓글 생성 이벤트 클래스 구현 (댓글 ID, 게시글 ID, 작성자 정보 포함)
- `CommentEventListener`: 이벤트 리스너 구현 (봇 게시글 여부 확인 후 봇 대댓글 서비스 호출)

### 2. 봇 대댓글 서비스 구현
- `BotRecommentService`: AI 서버와 통신하여 봇 대댓글을 생성하는 핵심 서비스
  - AI 서버 호출 (WebClient 사용, 타임아웃 및 재시도 로직 포함)
  - 응답 검증 및 대댓글 저장
  - 에러 처리 및 로깅

### 3. DTO 및 컨버터 추가
- `BotRecommentRequestDto`: AI 서버 요청/응답용 DTO (게시글 정보, 댓글 정보, 대댓글 정보 포함)
- `BotRecommentConverter`: 엔티티-DTO 간 변환 로직 구현

### 4. 상수 정의
- `BotConstants`: 봇 관련 상수 정의 (봇 ID, 닉네임, 기수, 타임아웃 설정 등)

### 5. CommentService 수정
- `ApplicationEventPublisher` 주입 추가
- `createComment()` 메서드에서 `CommentCreatedEvent` 발행
- 게시글 작성자 ID 조회하여 이벤트에 포함

### 6. MemberService 수정
- `getMemberBotInfo()` 메서드 추가 (닉네임, 기수 정보만 조회) 

## 👀 기타 더 이야기해볼 점

### 성능 고려사항
- 대댓글 조회 시 페이징 크기를 100개로 설정하여 대부분의 케이스 커버
- className 정보는 임시로 하드코딩 처리 (추후 개선 필요)

### 추가 개선 가능 사항
1. 대댓글의 className 조회 로직 구현
2. AI 서버 응답 시간이 긴 경우 비동기 처리 고려
3. 봇 대댓글에 대한 통계 및 모니터링 추가

### 테스트
- AI 서버가 실제로 구현되어 있지 않아 통합 테스트는 제한적
- 컨버터, 이벤트 리스너, 서비스 로직에 대한 단위 테스트 작성 예정

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요