### PR TITLE
[FIX] 로그인이 회원의 닉네임 기수를 반환하도록 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
@@ -8,14 +8,32 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class AuthResponseDto {
 
     /**
-     * 액세스 토큰 응답 DTO
+     * 로그인 Dto
      * - RefreshToken은 쿠키로 전달됨
+     */
+    @Schema(description = "로그인 또는 토큰 재발급 성공 응답 DTO")
+    public record LoginResponse(
+
+            @Schema(description = "AccessToken (JWT 형식)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
+            String access_token,
+
+            @Schema(description = "로그인 유저의 닉네임", example = "rick.lee")
+            String nickname,
+
+            @Schema(description = "사용자의 기수명", example = "PANGYO_2")
+            String class_name
+
+    ) {}
+
+    /**
+     * 액세스 토큰 응답 DTO
+     *
      */
     @Schema(description = "로그인 또는 토큰 재발급 성공 응답 DTO")
     public record TokenResponse(
 
             @Schema(description = "AccessToken (JWT 형식)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
-            String accessToken
+            String access_token
 
     ) {}
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #32

## 📌 개요
- 로그인시 회원의 기수명과 닉네임을 반환하도록 수정

## 🔁 변경 사항
- AuthResponseDto: 기존의 TokenResponse로 되어있는 응답dto를 TokenResponse, LoginResponse로 분리
- AuthController: 로그인 메서드가 LoginResponse를 반환하도록 수정

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.