### PR TITLE
[BE - FEAT] 로그아웃시 revoked_refresh_tokens토큰값을 갱신하도록 수정 

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
@@ -112,16 +112,8 @@ public class AuthController {
 
         log.info("액세스 토큰 재발급 요청");
 
-        // 쿠키에서 리프레시 토큰 추출
-        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(httpRequest);
 
-        // 리프레시 토큰이 없으면 예외 발생
-        if (refreshToken == null || refreshToken.isEmpty()) {
-            throw new AuthException(AuthErrorCode.REFRESH_TOKEN_MISSING);
-        }
-
-        // 액세스 토큰 재발급
-        String newAccessToken = userAuthenticationService.refreshAuthentication(refreshToken);
+        String newAccessToken = userAuthenticationService.refreshAuthentication(httpRequest);
 
         log.info("액세스 토큰 재발급 성공");
 
@@ -153,21 +145,10 @@ public class AuthController {
             HttpServletRequest httpRequest,
             HttpServletResponse httpResponse) {
 
-        log.info("로그아웃 요청");
+        log.info("로그아웃 요청 수신");
 
-        // 쿠키에서 리프레시 토큰 추출
-        String refreshToken = cookieUtil.extractRefreshTokenFromCookie(httpRequest);
-
-        // 토큰 무효화 처리
-        if (refreshToken != null) {
-            userAuthenticationService.logout(refreshToken);
-            log.info("리프레시 토큰 무효화 완료");
-        }
-
-        // 쿠키에서 리프레시 토큰 제거
-        httpResponse.addCookie(cookieUtil.clearRefreshTokenCookie());
-
-        log.info("로그아웃 성공");
+        // Service에 전체 로그아웃 처리 위임
+        userAuthenticationService.logout(httpRequest, httpResponse);
 
         return CustomResponse.success("정상적으로 로그아웃되었습니다.");
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
@@ -57,7 +57,6 @@ public class AuthConverter {
         return RevokedRefreshToken.builder()
                 .refreshTokenHash(refreshTokenHash)
                 .memberId(memberId)
-                .revokedAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/entity/RevokedRefreshToken.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/entity/RevokedRefreshToken.java
@@ -4,6 +4,7 @@ import com.kakaobase.snsapp.global.common.entity.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +15,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "revoked_refresh_tokens")
 @Getter
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
@@ -39,6 +39,7 @@ public class RevokedRefreshToken extends BaseCreatedTimeEntity {
      * BaseCreatedTimeEntity의 createdAt 필드가 이 역할을 합니다.
      * revoked_at 컬럼에 매핑됩니다.
      */
+    @CreatedDate
     @Column(name = "revoked_at", insertable = false, updatable = false)
     private LocalDateTime revokedAt;
 
@@ -52,14 +53,11 @@ public class RevokedRefreshToken extends BaseCreatedTimeEntity {
         return this.memberId.equals(memberId);
     }
 
-    /**
-     * 해시된 토큰과 사용자 정보를 기반으로 취소 토큰 객체를 생성합니다.
-     */
-    public static RevokedRefreshToken from(String refreshTokenHash, Long memberId) {
-        return RevokedRefreshToken.builder()
-                .refreshTokenHash(refreshTokenHash)
-                .memberId(memberId)
-                .build();
+    @Builder
+    RevokedRefreshToken(String refreshTokenHash, Long memberId) {
+        this.refreshTokenHash = refreshTokenHash;
+        this.memberId = memberId;
     }
+
 
 }

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/CorsConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5500", "http://localhost:8081", "http://172.16.24.221:8081"));
+        config.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5500", "http://localhost:8081","http://localhost:8080", "http://172.16.24.221:8081"));
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ app:
     refresh:
       expiration-time: 604800000 # 7일
       token-name: kakaobase_refresh_token
-      path: /auth/tokens/refresh
+      path: /auth/tokens
 
 cloud:
   aws:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 로그아웃 시 refresh token이 서버로 전송되지 않는 문제 수정
- 쿠키의 path 설정 문제로 인해 브라우저에서 쿠키가 필터링되어 전송되지 않았음
- 로그아웃 API 호출 시 refresh token 쿠키를 정상적으로 추출하여 토큰 무효화 처리가 가능하도록 수정

## 🔁 변경 사항

### 1. 쿠키 Path 설정 변경
```diff
# application.yml
cookie:
- refresh-token-path: /auth/tokens/refresh
+ refresh-token-path: /auth
```

### 2. 개발 환경 쿠키 Secure 설정 변경
```diff
# application-dev.yml
cookie:
+ secure: false  # 개발 환경에서는 HTTP 사용을 위해 false로 설정
```

### 3. 로그아웃 서비스 로직 구현
- 기존 Controller에서 처리하던 토큰 무효화 로직을 Service 레이어로 이동
- refresh token을 revoked_refresh_tokens 테이블로 이동하는 기능 구현
- RevokedRefreshToken 엔티티 및 Repository 추가

## 👀 기타 더 이야기해볼 점

### 문제 원인 분석
- 기존 쿠키 Path: `/auth/tokens/refresh`
- 로그아웃 API 경로: `/auth/tokens`
- 쿠키의 Path가 `/auth/tokens/refresh`로 제한되어 있어서, `/auth/tokens` 경로로의 요청에서는 해당 쿠키가 전송되지 않음

### 보안 고려사항
- refresh token 무효화 시 revoked_refresh_tokens 테이블로 이동하여 재사용 방지
- 개발 환경과 운영 환경의 쿠키 Secure 설정 분리
- HttpOnly 속성 유지로 XSS 공격 방지

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.