### PR TITLE
Feature/#43 fix get summay to post

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -153,6 +153,7 @@ public class PostConverter {
                 post.getContent(),
                 imageUrl,
                 post.getYoutubeUrl(),
+                post.getYoutubeSummary(),
                 post.getCreatedAt(),
                 post.getLikeCount(),
                 post.getCommentCount(),

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -101,6 +101,10 @@ public class PostResponseDto {
             @JsonProperty("youtube_url")
             String youtubeUrl,
 
+            @Schema(description = "유튜브 요약본", example = "안녕하세요 침착맨입니다~")
+            @JsonProperty("youtube_summary")
+            String youtubeSummary,
+
             @Schema(description = "생성 시간", example = "2024-04-23T10:00:00Z")
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
             @JsonProperty("created_at")

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -338,6 +338,12 @@ public class PostService {
             throw new PostException(GeneralErrorCode.INVALID_FORMAT, "youtubeUrl");
         }
 
+        //4. YouTube Summary가 이미 존재하는 지 확인
+        String youtubeSummary = post.getYoutubeSummary();
+        if(youtubeSummary != null) {
+            return new PostResponseDto.YouTubeSummaryResponse(youtubeSummary);
+        }
+
         // 4. AI 서버에 요약 요청
         log.info("AI 서버에 YouTube 요약 요청 - postId: {}, url: {}", postId, youtubeUrl);
         String summary = youtubeSummaryService.getSummary(youtubeUrl);
@@ -349,56 +355,4 @@ public class PostService {
         // 6. 응답 생성
         return PostResponseDto.YouTubeSummaryResponse.of(summary);
     }
-
-//    /**
-//     * 게시글에 좋아요한 사용자 목록을 조회합니다.
-//     *
-//     * @param posts 게시글 목록
-//     * @param limit 조회할 사용자 수 제한
-//     * @return 게시글 ID를 키로 하고 좋아요한 사용자 닉네임 목록을 값으로 하는 맵
-//     */
-//    public Map<Long, List<String>> getWhoLikedPosts(List<Post> posts, int limit) {
-//        Map<Long, List<String>> result = new HashMap<>();
-//
-//        for (Post post : posts) {
-//            List<String> whoLiked = postLikeService.findWhoLikedPost(post.getId(), limit);
-//            result.put(post.getId(), whoLiked);
-//        }
-//
-//        return result;
-//    }
-
-//    /**
-//     * 사용자가 팔로우하는 회원 ID 목록을 조회합니다.
-//     *
-//     * @param memberId 사용자 ID
-//     * @return 팔로우하는 회원 ID 목록
-//     */
-//    public List<Long> getFollowingIds(Long memberId) {
-//        return followService.getFollowingIds(memberId);
-//    }
-//
-//    /**
-//     * 사용자가 특정 회원을 팔로우하는지 확인합니다.
-//     *
-//     * @param memberId 사용자 ID
-//     * @param targetId 대상 회원 ID
-//     * @return 팔로우 여부
-//     */
-//    public boolean isFollowing(Long memberId, Long targetId) {
-//        return followService.isFollowing(memberId, targetId);
-//    }
-//
-//    /**
-//     * 유튜브 요약 내용을 업데이트합니다.`
-//     *
-//     * @param postId 게시글 ID
-//     * @param summary 요약 내용
-//     */
-//    @Transactional
-//    public void updateYoutubeSummary(Long postId, String summary) {
-//        Post post = findById(postId);
-//        post.updateYoutubeSummary(summary);
-//        log.info("유튜브 요약 업데이트 완료: 게시글 ID={}", postId);
-//    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #43

## 📌 개요
- 게시글 목록조회 및 상세 조회 시 유튜브 요약본이 응답에 포함되지 않는 버그 수정
- DTO 및 Service 로직을 수정하여 응답에 youtube_summary 필드가 정상적으로 포함되도록 구현
- 유튜브 요약 요청 시 이미 요약이 존재하는 경우 기존 데이터를 재활용하도록 최적화

## 🔁 변경 사항

### 1. DTO에 youtubeSummary 필드 추가
- PostListResponse DTO에 youtubeSummary 필드 추가
- PostDetailResponse DTO에 youtubeSummary 필드 추가

### 2. Service 로직 수정
- 게시글 목록 조회 서비스에서 youtubeSummary 반환하도록 수정
- 게시글 상세 조회 서비스에서 youtubeSummary 반환하도록 수정

### 3. 유튜브 요약 최적화
- 게시글에 이미 youtube_summary가 존재하면 재사용하도록 로직 추가
- 중복 요약 생성 방지 및 성능 향상 효과

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.