### PR TITLE
Feature/#48 addrecomment count to response

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
@@ -110,14 +110,12 @@ public class CommentConverter {
      * 댓글 엔티티를 댓글 상세 정보 DTO로 변환
      *
      * @param comment 댓글 엔티티
-     * @param currentMemberId 현재 로그인한 회원 ID
-     * @param likedCommentIds 좋아요 누른 댓글 ID 목록
      * @return 댓글 상세 정보 DTO
      */
     public CommentResponseDto.CommentInfo toCommentInfo(
             Comment comment,
-            Long currentMemberId,
-            Set<Long> likedCommentIds
+            Boolean isMine,
+            Boolean isLiked
             // 팔로우 기능은 V2에서 구현 예정
             // Set<Long> followedMemberIds,
     ) {
@@ -134,41 +132,13 @@ public class CommentConverter {
                 userInfo,
                 comment.getContent(),
                 comment.getCreatedAt(),
+                comment.getRecommentCount(),
                 comment.getLikeCount(),
-                comment.getMember().getId().equals(currentMemberId),
-                likedCommentIds != null && likedCommentIds.contains(comment.getId())
+                isMine,
+                isLiked
         );
     }
 
-    /**
-     * 댓글 목록을 댓글 목록 응답 DTO로 변환
-     *
-     * @param comments 댓글 목록
-     * @param currentMemberId 현재 로그인한 회원 ID
-     * @param likedCommentIds 좋아요 누른 댓글 ID 목록
-     * @param nextCursor 다음 페이지 커서
-     * @return 댓글 목록 응답 DTO
-     */
-    public CommentResponseDto.CommentListResponse toCommentListResponse(
-            List<Comment> comments,
-            Long currentMemberId,
-            Set<Long> likedCommentIds,
-            Long nextCursor
-    ) {
-        List<CommentResponseDto.CommentInfo> commentInfos = comments.stream()
-                .map(comment -> toCommentInfo(
-                        comment,
-                        currentMemberId,
-                        likedCommentIds
-                ))
-                .collect(Collectors.toList());
-
-        return new CommentResponseDto.CommentListResponse(
-                commentInfos,
-                nextCursor != null,
-                nextCursor
-        );
-    }
 
     /**
      * 대댓글 목록을 대댓글 목록 응답 DTO로 변환

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -84,6 +84,9 @@ public class CommentResponseDto {
             @Schema(description = "좋아요 수", example = "3")
             int like_count,
 
+            @Schema(description = "대댓글 수", example = "3")
+            int recomment_count,
+
             @Schema(description = "본인 작성 여부", example = "true")
             boolean is_mine,
 
@@ -182,18 +185,4 @@ public class CommentResponseDto {
             String message
     ) {}
 
-    /**
-     * 에러 응답 DTO
-     */
-    @Schema(description = "에러 응답")
-    public record ErrorResponse(
-            @Schema(description = "에러 코드", example = "resource_not_found")
-            String error,
-
-            @Schema(description = "에러 메시지", example = "해당 댓글을 찾을 수 없습니다.")
-            String message,
-
-            @Schema(description = "에러가 발생한 필드", example = "commentId", nullable = true)
-            String field
-    ) {}
 }


### PR DESCRIPTION
# PR템플릿

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #48

## 📌 개요
- 댓글 서비스 관련 리팩토링 및 버그 수정
- 댓글 정보 DTO에 대댓글 수 필드 추가
- 서비스 레이어와 컨버터 간 책임 분리
- 코드 재사용성 개선을 위한 메서드 추출

## 🔁 변경 사항
1. `CommentInfo` DTO에 `recomment_count` 필드 추가
2. `Converter`에서 비즈니스 로직 부분을 `Service`로 이동
   - 댓글이 본인 작성 여부(`isMine`) 판별 로직 이동
   - 필요없는 매개변수(`likedCommentIds`) 제거
3. 댓글 정보 조회 로직 재사용성 개선
   - 개별 댓글 정보를 반환하는 `getCommentInfo` 메서드 추출
   - `getCommentsByPostId`와 `getCommentDetail` 메서드에서 해당 메서드 활용하도록 수정

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.