### PR TITLE
[FIX] SignUp RequestDto의 오탈자 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.members.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
@@ -34,11 +35,13 @@ public class MemberRequestDto {
 
             @Schema(description = "기수명", example = "PANGYO_1", allowableValues = {"PANGYO_1", "PANGYO_2", "JEJU_1", "JEJU_2", "JEJU_3"})
             @NotNull(message = "기수는 필수 입력값입니다.")
+            @JsonProperty("class_name")
             String className,
 
             @Schema(description = "GitHub 프로필 URL", example = "https://github.com/gildong")
             @Pattern(regexp = "^(https://github\\.com/)[A-Za-z0-9_-]+(/)?.*$",
                     message = "GitHub URL 형식이 올바르지 않습니다. https://github.com/{username} 형식이어야 합니다.")
+            @JsonProperty("github_url")
             String githubUrl
     ) {}
 


### PR DESCRIPTION
className을 class_name으로,
githubUrl을 github_url로 수정

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #54

## 📌 개요
- MemberRequestDto에 SignUp요청의 필드 오탈자 수정

## 🔁 변경 사항
className을 class_name으로,
githubUrl을 github_url로 수정

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.