### PR TITLE
Fix/#58 fix cookie util

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
@@ -2,14 +2,8 @@ package com.kakaobase.snsapp.domain.auth.controller;
 
 import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
 import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
-import com.kakaobase.snsapp.domain.auth.exception.AuthErrorCode;
-import com.kakaobase.snsapp.domain.auth.exception.AuthException;
 import com.kakaobase.snsapp.domain.auth.service.UserAuthenticationService;
-import com.kakaobase.snsapp.domain.auth.util.CookieUtil;
-import com.kakaobase.snsapp.domain.members.entity.Member;
-import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
-import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -36,8 +30,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final UserAuthenticationService userAuthenticationService;
-    private final CookieUtil cookieUtil;
-    private final MemberRepository memberRepository;
 
     /**
      * 로그인 API
@@ -68,25 +60,17 @@ public class AuthController {
         log.info("로그인 요청: {}", request.email());
 
         // 로그인 처리 및 토큰 발급
-        UserAuthenticationService.TokenWithCookie result = userAuthenticationService.login(
+        AuthResponseDto.LoginResponse result = userAuthenticationService.login(
                 request.email(),
                 request.password(),
-                httpRequest.getHeader("User-Agent")
+                httpRequest.getHeader("User-Agent"),
+                httpResponse
         );
-
-        // 리프레시 토큰을 쿠키에 설정
-        httpResponse.addCookie(result.refreshTokenCookie());
 
         log.info("로그인 성공: {}", request.email());
 
-        Member member = memberRepository.findByEmail(request.email())
-                .orElseThrow(()-> new AuthException(GeneralErrorCode.RESOURCE_NOT_FOUND, "email", "사용자의 이메일을 찾을 수 없습니다"));
-
         // 액세스 토큰을 응답 본문에 포함
-        return CustomResponse.success(
-                "로그인에 성공하였습니다.",
-                new AuthResponseDto.LoginResponse(result.accessToken(), member.getNickname(), member.getClassName())
-        );
+        return CustomResponse.success("로그인에 성공하였습니다.", result);
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.auth.util;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -29,27 +30,19 @@ public class CookieUtil {
 
     /**
      * 리프레시 토큰을 담은 쿠키를 생성합니다.
-     * 생성된 쿠키는 JavaScript에서 접근할 수 없도록 HttpOnly로 설정되며,
-     * 특정 경로(/auth/tokens/refresh)에서만 전송되도록 설정됩니다.
-     *
-     * @param refreshToken 리프레시 토큰 값
-     * @return 생성된 쿠키
+     * 생성된 쿠키는 JavaScript에서 접근할 수 없도록 HttpOnly로 설정
      */
-    public Cookie createRefreshTokenCookie(String refreshToken) {
-        // 토큰을 담은 쿠키 객체 생성
-        Cookie cookie = new Cookie(refreshTokenCookieName, refreshToken);
+    public void createRefreshTokenCookie(String refreshToken, HttpServletResponse response) {
 
-        // 쿠키 만료 시간 설정 (초 단위로 변환)
-        cookie.setMaxAge((int) (refreshTokenExpiration / 1000));
+        // 수동으로 SameSite=None 주입
+        StringBuilder cookieValue = new StringBuilder()
+                .append(refreshTokenCookieName).append("=").append(refreshToken)
+                .append("; Path=").append(refreshTokenCookiePath)
+                .append("; Max-Age=").append(refreshTokenExpiration / 1000)
+                .append("; HttpOnly")
+                .append("; Secure; SameSite=None");
 
-        // 쿠키 경로 설정 (토큰 재발급 엔드포인트로 제한)
-        cookie.setPath(refreshTokenCookiePath);
-
-        // 보안 설정
-        cookie.setHttpOnly(true);     // JavaScript에서 접근 불가
-        cookie.setSecure(secureCookie); // HTTPS에서만 전송 (프로덕션 환경)
-
-        return cookie;
+        response.addHeader("Set-Cookie", cookieValue.toString());
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,17 +34,18 @@ public class CookieUtil {
      * 생성된 쿠키는 JavaScript에서 접근할 수 없도록 HttpOnly로 설정
      */
     public void createRefreshTokenCookie(String refreshToken, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(refreshTokenCookieName, refreshToken)
+                .path(refreshTokenCookiePath)
+                .maxAge(refreshTokenExpiration / 1000)
+                .httpOnly(true)
+                .secure(secureCookie)
+                .sameSite("Lax")
+                .build();
 
-        // 수동으로 SameSite=None 주입
-        StringBuilder cookieValue = new StringBuilder()
-                .append(refreshTokenCookieName).append("=").append(refreshToken)
-                .append("; Path=").append(refreshTokenCookiePath)
-                .append("; Max-Age=").append(refreshTokenExpiration / 1000)
-                .append("; HttpOnly")
-                .append("; Secure; SameSite=None");
-
-        response.addHeader("Set-Cookie", cookieValue.toString());
+        response.addHeader("Set-Cookie", cookie.toString()); // 그대로 Set-Cookie 헤더로 추가
     }
+
+
 
     /**
      * HTTP 요청의 쿠키에서 리프레시 토큰을 추출합니다.

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,5 @@
 spring:
-  profiles: prod
+  profiles: dev
 
 app:
   jwt:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,15 @@
+spring:
+  profiles: prod
+
+app:
+  jwt:
+    secure: false
+
+logging:
+  level:
+    com.amazonaws.util.EC2MetadataUtils: ERROR
+    com.amazonaws.services.s3: INFO
+    com.kakaobase.snsapp.global.security: DEBUG
+    com.kakaobase.snsapp.domain.auth: DEBUG
+    com.kakaobase.snsapp.domain.posts: DEBUG
+    org.springframework.security: DEBUG

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,15 @@
+spring:
+  profiles: prod
+
+app:
+  jwt:
+    secure: false
+
+logging:
+  level:
+    com.amazonaws.util.EC2MetadataUtils: ERROR
+    com.amazonaws.services.s3: INFO
+    com.kakaobase.snsapp.global.security: INFO
+    com.kakaobase.snsapp.domain.auth: INFO
+    com.kakaobase.snsapp.domain.posts: INFO
+    org.springframework.security: INFO

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,7 +3,7 @@ spring:
 
 app:
   jwt:
-    secure: false
+    secure: true
 
 logging:
   level:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #(이슈 번호를 입력해주세요)

## 📌 개요
- 쿠키 SameSite 설정 문제를 점검하던 중 실제로는 SameSite 설정이 Lax로 충분하다는 점을 인지
- 기존 Response Header에 직접 문자열로 쿠키 설정하던 방식을 ResponseCookie를 활용해 개선
- `application-dev.yml`, `application-prod.yml`로 **환경별 yml 분리 및 secure 설정 분리

## 🔁 변경 사항
### 1. SameSite 설정 개선
- SameSite=None으로 설정했으나 의미가 없다는 점을 확인 → SameSite=Lax로 변경
- `ResponseCookie`를 사용해 쿠키를 설정하도록 변경 → 가독성 및 유지보수성 개선

### 2. login Controller 리팩토링
- Controller의 비즈니스 로직 제거 → Service에서 응답 Dto만 반환
- Controller가 직접 Cookie 주입하는 로직 삭제 → CookieUtil에서 일괄 관리

### 3. TokenWithCookie 객체 제거
- Cookie는 response 객체에 직접 addHeader 하므로 불필요 → TokenWithCookie 클래스 삭제

### 4. yml 환경 분리
- `application-dev.yml`, `application-prod.yml`로 분리
- dev와 prod 환경에서 **쿠키 secure 옵션 분리 적용**

### 5. 기존 refreshToken 쿠키 파기 로직 추가
- login Controller에 요청에 refreshToken이 존재하면 **기존 쿠키 삭제**

## 👀 기타 더 이야기해볼 점
- 이후 배포 자동화 시 EC2 서버에 `SPRING_PROFILES_ACTIVE` 설정 필요
- ResponseCookie 적용 이후 테스트 결과 모든 환경에서 정상 동작 확인

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.