### PR TITLE
Fix /#67 fix comment time

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/Application.java
+++ b/src/main/java/com/kakaobase/snsapp/Application.java
@@ -3,10 +3,13 @@ package com.kakaobase.snsapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class Application {
 
     public static void main(String[] args) {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(Application.class, args);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: UTC
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #67 

## 📌 개요
- 댓글, 대댓글 조회시 시간이 UTC에 맞춰져 있는 것을 Timezone.setDefault로 서울 시간으로 고정

## 🔁 변경 사항
- Aplication의 메인 메서드에 Timezone.setDefault을 서울로 설정
- yml파일을 통해 DB에 저장되는 표준시는 UTC로 통일


## 👀 기타 더 이야기해볼 점
현재 방식은 임시 방편이며, 다음과 같은 문제를 초래할 수 있기 때문에 꼭 바꿔줘야 합니다
- Spring Batch, Scheduler, Quartz 등의 스케줄러가 Asia/Seoul 기준으로 실행되어 잘못된 시점에 작업 실행 할 수 있음
- 운영 서버, 개발 서버, 테스트 서버, Docker 컨테이너 간 TimeZone 불일치로 인한 데이터 mismatch 및 장애 가능성 존재
- AWS, Azure 등 클라우드 인프라에서 UTC가 표준인데 Asia/Seoul로 변경 시 예상 외 동작 및 버그 유발 가능성 있음

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.