### PR TITLE
[BE- FIX] PostResponseDto의 createAt에 있는 JsonForamt어노테이션 제거

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -49,7 +49,6 @@ public class PostResponseDto {
             String youtubeSummary,
 
             @Schema(description = "생성 시간", example = "2024-04-23T12:34:56Z")
-            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
             @JsonProperty("created_at")
             LocalDateTime createdAt,
 
@@ -106,7 +105,6 @@ public class PostResponseDto {
             String youtubeSummary,
 
             @Schema(description = "생성 시간", example = "2024-04-23T10:00:00Z")
-            @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
             @JsonProperty("created_at")
             LocalDateTime createdAt,
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #69

## 📌 개요
- 게시글의 created_at을 JVM시간에 맞춰 반환하도록 변경

## 🔁 변경 사항
PostResponseDto의 createdAt필드에 있는 @JsonFormat제거


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.