### PR TITLE
Fix/#73 fix bot post filter logic

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -1,5 +1,7 @@
 package com.kakaobase.snsapp.domain.posts.service;
 
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
 import com.kakaobase.snsapp.domain.posts.dto.BotRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
@@ -15,10 +17,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -33,6 +32,7 @@ public class BotPostService {
 
     private final PostService postService;
     private final WebClient webClient;
+    private final MemberRepository memberRepository;
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
@@ -134,9 +134,10 @@ public class BotPostService {
                         throw new IllegalStateException("회원 정보를 찾을 수 없습니다. memberId: " + post.getMemberId());
                     }
 
-                    // Member 엔티티에서 className을 가져오는 로직이 필요
-                    // 현재 PostService의 getMemberInfo가 className을 포함하지 않을 수 있음
-                    String className = memberInfo.getOrDefault("className", "UNKNOWN");
+
+                    Optional<Member> member = memberRepository.findById(post.getMemberId());
+                    String className  = member.get().getClassName();
+                    log.debug("게시글 작성자 정보: {}, {}", memberInfo.get("nickname"), className);
 
                     return new BotRequestDto.PostDto(
                             new BotRequestDto.UserDto(


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #73 

## 📌 개요
- 소셜봇 게시글 작성 요청시 소셜봇 게시글 필터링하는 로직을 수정
- 요청시 게시글을 오래된순으로 전송하도록 수정
- 요청시 유저정보에 class_name이 null값인 에러 수정

## 🔁 변경 사항
- cursor기반 최신 게시물을 10개 조회, 이를 최신순으로 5개까지만 처리
- filteredPosts를 List로 선언하여 ArrayList로 업케스팅, 이를통해 Dto를 생성하도록 수정
- 게시글 정보에 사용자의 class_name이 누락되어있는 부분 수정

## 👀 기타 더 이야기해볼 점
현재 Service에서 MemberRepository를 호출해서 사용하는데,
이는 나중에 객체그래프 도입시 수정 필요

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.