### PR TITLE
[BE - FIX] 댓글, 대댓글을 작성순으로 반환하도록 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -38,7 +38,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     /**
      * 특정 게시글의 댓글을 커서 기반으로 조회합니다.
-     * 삭제되지 않은 댓글만 조회합니다.
+     * 삭제되지 않은 댓글을 작성순(오래된 순)으로 조회합니다.
      *
      * @param postId 게시글 ID
      * @param cursor 마지막으로 조회한 댓글 ID (첫 페이지에서는 null)
@@ -48,8 +48,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query(value = "SELECT c.* FROM comments c " +
             "WHERE c.post_id = :postId " +
             "AND c.deleted_at IS NULL " +
-            "AND (:cursor IS NULL OR c.id < :cursor) " +
-            "ORDER BY c.id DESC " +
+            "AND (:cursor IS NULL OR c.id > :cursor) " + // 부등호 방향 변경 (< 에서 > 로)
+            "ORDER BY c.id ASC " +                      // 정렬 방향 변경 (DESC에서 ASC로)
             "LIMIT :limit",
             nativeQuery = true)
     List<Comment> findByPostIdWithCursor(

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -1,6 +1,7 @@
 // RecommentRepository.java
 package com.kakaobase.snsapp.domain.comments.repository;
 
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
 import com.kakaobase.snsapp.domain.comments.entity.Recomment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -72,7 +73,7 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
             "ORDER BY r.id ASC " +
             "LIMIT :limit",
             nativeQuery = true)
-    List<Recomment> findByCommentIdWithCursor(
+    List<Recomment> findByRecommentIdWithCursor(
             @Param("commentId") Long commentId,
             @Param("cursor") Long cursor,
             @Param("limit") int limit);

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -268,7 +268,7 @@ public class CommentService {
         int limit = pageRequest.limit() != null ? pageRequest.limit() : DEFAULT_PAGE_SIZE;
 
         // 대댓글 목록 조회
-        List<Recomment> recomments = recommentRepository.findByCommentIdWithCursor(commentId, pageRequest.cursor(), limit);
+        List<Recomment> recomments = recommentRepository.findByRecommentIdWithCursor(commentId, pageRequest.cursor(), limit);
 
         if (recomments.isEmpty()) {
             return new CommentResponseDto.RecommentListResponse(


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #75 

## 📌 개요
-  댓글, 대댓글을 작성순으로 조회하도록 변경

## 🔁 변경 사항
- CommentRepository의 조회 메서드를 작성순으로 반환하도록
- RecommentRepository의 조회 메서드를 작성순으로 반환하도록
- RecommentRepository의 조회 메서드 findByCommentIdWithCursor를 findByRecommentIdWithCursor로 변경

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.