### PR TITLE
Feat/#77 rate limit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,10 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // Spring WebFlux
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'  // Spring WebFlux
+    implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0'   // Bucketj4 - ratelimit
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' //thymeleaf
 
-    //thymeleaf
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/src/main/java/com/kakaobase/snsapp/global/config/WebMvcConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/WebMvcConfig.java
@@ -1,0 +1,34 @@
+package com.kakaobase.snsapp.global.config;
+
+import com.kakaobase.snsapp.global.interceptor.AiRateLimitInterceptor;
+import com.kakaobase.snsapp.global.interceptor.GlobalRateLimitInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Spring MVC 전역 설정
+ *
+ * <p>Global RateLimit Interceptor를 등록합니다.</p>
+ */
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final GlobalRateLimitInterceptor globalRateLimitInterceptor;
+    private final AiRateLimitInterceptor aiRateLimitInterceptor;
+
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(globalRateLimitInterceptor)
+                .addPathPatterns("/**")                     //모든 요청에 적용
+                .excludePathPatterns("/post/*/summary");    //AI 요청은 제외
+
+        registry.addInterceptor(aiRateLimitInterceptor)
+                .addPathPatterns("/api/ai/**");
+    }
+
+
+}

--- a/src/main/java/com/kakaobase/snsapp/global/interceptor/AiRateLimitInterceptor.java
+++ b/src/main/java/com/kakaobase/snsapp/global/interceptor/AiRateLimitInterceptor.java
@@ -1,0 +1,60 @@
+package com.kakaobase.snsapp.global.interceptor;
+
+import com.kakaobase.snsapp.global.util.BucketUtils;
+import io.github.bucket4j.Bucket;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * AI 요청 전용 Rate Limiting Interceptor
+ *
+ * <p>/api/ai/** 요청에만 적용됩니다.</p>
+ * <p>IP별로 1분에 1건 제한.</p>
+ */
+@Slf4j
+@Component
+public class AiRateLimitInterceptor implements HandlerInterceptor {
+
+    // IP별 사용자 Bucket
+    private final Map<String, Bucket> userBuckets = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        String userKey = getIpKey(request); //  IP 기준 key
+        Bucket userBucket = userBuckets.computeIfAbsent(userKey, key -> BucketUtils.createAiBucket());
+
+        if (!userBucket.tryConsume(1)) {
+            log.warn("[AI RateLimit] 사용자 IP 요청 제한 초과 - IP: {}, URI: {}", userKey, request.getRequestURI());
+            sendRateLimitResponse(response, "AI 요청 제한 초과 (IP당 1분 1건)");
+            return false;
+        }
+
+        return true; // 통과 → Controller로 전달
+    }
+
+    /**
+     * 사용자 식별 키 생성 (기본: IP 주소)
+     */
+    private String getIpKey(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * 요청 제한 응답 반환 (429 Too Many Requests)
+     */
+    private void sendRateLimitResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(429);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"" + message + "\"}");
+    }
+}
+
+

--- a/src/main/java/com/kakaobase/snsapp/global/interceptor/GlobalRateLimitInterceptor.java
+++ b/src/main/java/com/kakaobase/snsapp/global/interceptor/GlobalRateLimitInterceptor.java
@@ -1,0 +1,67 @@
+package com.kakaobase.snsapp.global.interceptor;
+
+import com.kakaobase.snsapp.global.util.BucketUtils;
+import io.github.bucket4j.Bucket;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 서버 전역 + 사용자별 요청 Rate Limiting Interceptor
+ */
+@Slf4j
+@Component
+public class GlobalRateLimitInterceptor implements HandlerInterceptor {
+
+    // 전역 Bucket
+    private final Bucket globalBucket = BucketUtils.createGlobalBucket();
+
+    // 사용자별 Bucket (IP 기반 개별 요청 제한)
+    private final Map<String, Bucket> ipBuckets = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        // 전역 Rate Limit 체크
+        if (!globalBucket.tryConsume(1)) {
+            log.warn("[RateLimit] 전역 요청 제한 초과 - URI: {}", request.getRequestURI());
+            sendRateLimitResponse(response, "서버 전체 요청 제한 초과");
+            return false;
+        }
+
+        // ✅ 2단계: 사용자 Rate Limit 체크
+        String userKey = getUserKey(request);  // 기본은 IP 기준
+        Bucket userBucket = ipBuckets.computeIfAbsent(userKey, key -> BucketUtils.createIpBucket());
+
+        if (!userBucket.tryConsume(1)) {
+            log.warn("[RateLimit] 사용자 요청 제한 초과 - IP: {}, URI: {}", userKey, request.getRequestURI());
+            sendRateLimitResponse(response, "사용자 요청 제한 초과");
+            return false;
+        }
+
+        return true;  // ✅ 둘 다 통과 → 요청 허용
+    }
+
+    /**
+     * 사용자 식별 키 생성 (기본: IP 주소)
+     * 추후 UserID, Token 등으로 변경 가능
+     */
+    private String getUserKey(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * 요청 제한 응답 반환 (429 Too Many Requests)
+     */
+    private void sendRateLimitResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(429);
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"" + message + "\"}");
+    }
+}
+

--- a/src/main/java/com/kakaobase/snsapp/global/util/BucketUtils.java
+++ b/src/main/java/com/kakaobase/snsapp/global/util/BucketUtils.java
@@ -1,0 +1,60 @@
+package com.kakaobase.snsapp.global.util;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import io.github.bucket4j.Bucket4j;
+
+
+import java.time.Duration;
+
+/**
+ * Bucket4j Bucket 생성 유틸리티 클래스
+ *
+ * <p>전역 Bucket, 사용자 Bucket, AI Bucket 등을 중앙에서 일괄 관리.</p>
+ */
+public class BucketUtils {
+
+    private BucketUtils() {
+        // 유틸 클래스 → 인스턴스 생성 방지
+    }
+
+    /**
+     * 서버 전체 요청을 제한하는 Global Bucket
+     * 예: 1분에 1000건
+     */
+    public static Bucket createGlobalBucket() {
+        return Bucket4j.builder()
+                .addLimit(Bandwidth.classic(
+                        1000,                                        // capacity: 1000 requests
+                        Refill.greedy(1000, Duration.ofMinutes(1))  // refill: 1분마다 1000개
+                ))
+                .build();
+    }
+
+    /**
+     * UserID별 요청을 제한하는 User Bucket
+     * 1분에 10건
+     */
+    public static Bucket createIpBucket() {
+        return Bucket4j.builder()
+                .addLimit(Bandwidth.classic(
+                        10,                                         // capacity: 10 requests
+                        Refill.greedy(10, Duration.ofMinutes(1))    // refill: 1분마다 10개
+                ))
+                .build();
+    }
+
+    /**
+     * AI 요청을 위한 별도 Bucket
+     * 1분에 5건
+     */
+    public static Bucket createAiBucket() {
+        return Bucket4j.builder()
+                .addLimit(Bandwidth.classic(
+                        5,                                          // capacity: 5 requests
+                        Refill.greedy(1, Duration.ofMinutes(1))     // refill: 1분마다 1개
+                ))
+                .build();
+    }
+}


### PR DESCRIPTION
# PR: Rate Limit 기능 구현

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Closes #77

## 📌 개요
- Bucket4j를 사용하여 API 요청에 대한 Rate Limit 기능을 구현
- 전역적인 API 요청 제한, IP별 요청 제한, AI 관련 요청에 대한 사용자별 제한을 적용

## 🔁 변경 사항
1. `build.gradle`에 Bucket4j 의존성 추가
2. `BucketUtil` 클래스 구현
   - 전역 요청은 1분에 1000개로 제한
   - IP별 요청은 1분에 10개로 제한
   - AI 관련 요청은 사용자당 1개로 제한
3. `WebMvcConfig` 구현
   - 각 API 경로마다 인터셉터 구성
4. 인터셉터 구현
   - AI 관련 요청 인터셉터 구현
   - 전역 인터셉터 구현

## 👀 기타 더 이야기해볼 점
- 향후 Rate Limit 설정을 외부 설정 파일(application.yml)로 분리하는 것이 좋을 것 같습니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.