### PR TITLE
[FIX] 소셜봇 게시글 필터 로직을 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -60,7 +60,7 @@ public class BotPostService {
             // 봇이 작성하지 않은 게시글만 필터링
             int botPostCount = 0;
             for (Post post : recentPosts) {
-                if (post.getMemberId() != BotConstants.BOT_MEMBER_ID) {
+                if (!post.getMemberId().equals(BotConstants.BOT_MEMBER_ID)) {
                     filteredPosts.add(post);
                     log.debug("일반 게시글 추가: id={}, content={}, createdAt={}",
                             post.getId(), post.getContent(), post.getCreatedAt());


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #79 

## 📌 개요
- 소셜봇 게시글 요청시 봇이 작성한 게시글을 필터링 하지 못한 에러를 수정

## 🔁 변경 사항
소셜봇Id와 게시글의 Id 비교를 "=="으로 파악하던걸
.equals로 수정
## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.