### PR TITLE
Hotfix/#88 error code fix

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
@@ -18,8 +18,10 @@ public class MemberRequestDto {
 
             @Schema(description = "비밀번호", example = "Test1234!")
             @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-            @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()]{8,20}$",
-                    message = "비밀번호는 8~20자리, 영문자와 숫자를 포함해야 합니다.")
+            @Pattern(
+                    regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*\\-_=+<>,\\.\\;:\\\"'\\{\\}\\[\\]/\\?])[A-Za-z\\d!@#$%^&*\\-_=+<>,\\.\\;:\\\"'\\{\\}\\[\\]/\\?]{8,20}$",
+                    message = "비밀번호는 8~20자리, 영문, 숫자, 특수문자를 포함해야 합니다"
+            )
             String password,
 
             @Schema(description = "이름", example = "홍길동")

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/exception/PostErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/exception/PostErrorCode.java
@@ -26,7 +26,7 @@ public enum PostErrorCode implements BaseErrorCode {
     UNSUPPORTED_SUBTITLE_LANGUAGE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "unsupported_subtitle_language", "해당 YouTube 영상의 자막이 한국어 또는 영어를 지원하지 않습니다", "youtube_url"),
     YOUTUBE_VIDEO_PRIVATE(HttpStatus.FORBIDDEN, "video_private", "해당 YouTube 영상은 비공개 동영상입니다.", "youtube_url"),
     YOUTUBE_VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "video_not_found", "존재하지 않는 youtube url입니다.", "youtube_url"),
-    AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ai_server_error", "서버에러로 youtube요약에 실패하였습니다", null),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "internal_server_error", "서버 내부 오류가 발생했습니다.", null),
 
     // 좋아요 관련 에러
     ALREADY_LIKED(HttpStatus.CONFLICT, "state_conflict", "이미 좋아요한 게시글입니다.", null),

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/exception/YoutubeSummaryStatus.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/exception/YoutubeSummaryStatus.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.exception;
 
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -11,7 +12,7 @@ public enum YoutubeSummaryStatus {
     UNSUPPORTED_SUBTITLE_LANGUAGE("unsupported_subtitle_language", PostErrorCode.UNSUPPORTED_SUBTITLE_LANGUAGE),
     YOUTUBE_VIDEO_PRIVATE("video_private", PostErrorCode.YOUTUBE_VIDEO_PRIVATE),
     YOUTUBE_VIDEO_NOT_FOUND("video_not_found", PostErrorCode.YOUTUBE_VIDEO_NOT_FOUND),
-    AI_SERVER_FAILED("internal_server_error", PostErrorCode.AI_SERVER_ERROR);
+    AI_SERVER_FAILED("internal_server_error", PostErrorCode.INTERNAL_SERVER_ERROR);
 
     private final String aiErrorCode;
     private final PostErrorCode postErrorCode;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #88 

## 📌 개요
- 유튜브 요약 요청 시 에러 응답 코드를 통합하고, 회원가입 시 허용되는 특수문자 범위를 확장합니다.

## 🔁 변경 사항
1. 유튜브 요약 조회 시 AI 서버 에러(`AI_SERVER_FAILED`)의 응답 코드를 `ai_server_error`에서 `internal_server_error`로 통합했습니다.
2. `MemberRequestDto`에서 허용되는 특수기호 범위를 확장했습니다:
   - 기존: `!@#$%^&*()`
   - 추가: `- _ + = < > , . ; : " ' { } [ ] / ?`

## 👀 기타 더 이야기해볼 점


## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.