### PR TITLE
[BE - !HOTFIX] 배포 서버의 로그를 디스코드 웹훅으로 전송

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -58,6 +59,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.testcontainers:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //discord webhook
+    implementation 'com.github.napstr:logback-discord-appender:1.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -15,3 +15,6 @@ logging:
     com.kakaobase.snsapp.domain.auth: INFO
     com.kakaobase.snsapp.domain.posts: INFO
     org.springframework.security: INFO
+  discord:
+    webhook-url: ${DISCORD_ERROR_WEBHOOK_URL}
+    config: classpath:logback-spring.xml

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/discord-error-appender.xml
+++ b/src/main/resources/discord-error-appender.xml
@@ -1,0 +1,22 @@
+<included>
+    <appender name="DISCORD" class="com.github.napstr.logback.DiscordAppender">
+        <webhookUri>${DISCORD_ERROR_WEBHOOK_URL}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>
+
+                \n [ERROR LOG] ============================================================================
+                \n %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level [%logger{2}.%M:%L] - %msg%n
+                %ex{full}%n
+            </pattern>
+        </layout>
+        <username>🚨PROD-BE-ERROR-bot</username>
+        <tts>false</tts>
+    </appender>
+
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD" />
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+</included>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,23 @@
+<configuration>
+    <include resource="console-appender.xml"/>
+
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <springProperty name="DISCORD_ERROR_WEBHOOK_URL" source="logging.discord.webhook-url"/>
+
+    <!-- 콘솔 로깅은 항상 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- ✅ DiscordAppender는 prod 환경에서만 활성화 -->
+    <springProfile name="prod">
+        <include resource="discord-error-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="ASYNC_DISCORD" />
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #111 

## 📌 개요
- 배포 서버의 로그를 디스코드 웹훅으로 전송

## 🔁 변경 사항
discord webhook 의존성 추가
196e87f3dffa40a26c5c131e9634b6ea49afe7a6

webhook url 외부 설정
77a2b3e69549ac6c2a4cea8961d8b0af5c5e9b18

log 설정 및 포맷, 전송 정의
15db99cd08db74085c3d3623320ef16177f2c7bf

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.