### PR TITLE
[BE - FIX] 이메일 인증시 401에러가뜨는 버그 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -4,11 +4,11 @@ import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.entity.PostImage;
-import com.kakaobase.snsapp.domain.posts.repository.PostImageRepository;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Post 도메인의 Entity와 DTO 간 변환을 담당하는 Converter 클래스
@@ -93,7 +93,7 @@ public class PostConverter {
         );
 
         // 이미지 URL 가져오기 (첫 번째 이미지만 사용)
-        String imageUrl = postImages.isEmpty() ? null : postImages.get(0).getImgUrl().toString();
+        String imageUrl = postImages.isEmpty() ? null : postImages.get(0).getImgUrl();
 
 
         // 상세 정보 생성
@@ -252,7 +252,7 @@ public class PostConverter {
             String enumFormat = postType.toUpperCase();
             return Post.BoardType.valueOf(enumFormat);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("유효하지 않은 게시판 타입입니다: " + postType);
+            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "postType");
         }
     }
 

--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -37,8 +37,9 @@ public class AccessChecker {
      */
     public boolean hasAccessToBoard(String postType, CustomUserDetails userDetails) {
         // 인증되지 않은 사용자는 'all' 게시판만 접근 가능
-        if (userDetails == null) {
-            return "all".equalsIgnoreCase(postType);
+        if (userDetails == null ||
+            userDetails.isEnabled()) {
+            throw new PostException(GeneralErrorCode.FORBIDDEN, "postType");
         }
 
         // 관리자, 봇 권한이 있는 경우 모든 게시판 접근 가능
@@ -91,7 +92,7 @@ public class AccessChecker {
         }
 
         // 사용자 ID 확인
-        Long memberId = Long.valueOf(userDetails.getId());;
+        Long memberId = Long.valueOf(userDetails.getId());
         if (memberId == null) {
             return false;
         }
@@ -118,7 +119,7 @@ public class AccessChecker {
         }
 
         // 사용자 ID 확인
-        Long memberId = Long.valueOf(userDetails.getId());;
+        Long memberId = Long.valueOf(userDetails.getId());
         if (memberId == null) {
             return false;
         }
@@ -164,7 +165,7 @@ public class AccessChecker {
             return true;
         }
 
-        Long memberId = Long.valueOf(userDetails.getId());;
+        Long memberId = Long.valueOf(userDetails.getId());
         if (memberId == null) {
             return false;
         }

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
@@ -64,7 +64,6 @@ public class SecurityConfig {
                         .requestMatchers("/users/email/verification-requests").permitAll()
                         .requestMatchers("/users/email/verification").permitAll()
                         .requestMatchers("/users").permitAll()
-                        .requestMatchers("/posts/{postType}").permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,6 +23,7 @@ import org.springframework.web.filter.CorsFilter;
  */
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,3 +67,7 @@ springdoc:
 ai:
   server:
     url: ${AI_SERVER_URL}
+
+server:
+  servlet:
+    context-path: /api


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #141 

## 📌 개요
- API 경로 통일화 및 게시글 접근 권한 관리 기능 구현
- Spring Security 메서드 레벨 보안 활성화를 통한 접근 제어 강화

## 🔁 변경 사항
- **API 경로 통일화**: 모든 API 엔드포인트에 `/api` prefix 추가
- **게시글 접근 권한 관리**: 로그인 사용자만 게시글 목록 및 상세 조회 가능하도록 변경

- **Method Security 활성화**: `@EnableMethodSecurity(prePostEnabled = true)` 추가로 `@PreAuthorize` 동작 가능
- **AccessChecker 정상 동작**: 메서드 레벨 보안 활성화로 커스텀 접근 권한 체크 로직 적용
- **게시글 접근 제한**: 비로그인 사용자의 게시글 접근 차단
- **Converter 에러 추적**: 에러 발생 시 원인 추적이 가능하도록 로깅 개선

- Context path 설정을 통한 API 경로 표준화
- Spring Security 설정 업데이트 (URL 패턴 매칭 수정)
- JwtAuthenticationFilter의 excludedPaths 업데이트

## 👀 기타 더 이야기해볼 점
- API 경로 변경으로 인한 프론트엔드 호출 URL 수정 필요성
- 게시글 접근 권한 정책에 대한 추가 논의 (공개 게시판 vs 회원 전용)
- AccessChecker 로직의 확장 가능성 (게시판별 세분화된 권한 관리)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.