### PR TITLE
[FIX] JwtFilter에 경로에 /api를 붙여 필터에서 제외되도록 설정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -35,13 +35,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // 필터를 적용하지 않을 경로 패턴 목록
     private final List<String> excludedPaths = List.of(
-            "/auth/tokens",
-            "/auth/tokens/refresh",
-            "/users/email/verification-requests",
-            "/users/email/verification",
-            "/users",
-            "/swagger-ui/**",
-            "/v3/api-docs/**"
+            "/api/auth/tokens",
+            "/api/auth/tokens/refresh",
+            "/api/users/email/verification-requests",
+            "/api/users/email/verification",
+            "/api/users",
+            "/api/swagger-ui/**",
+            "/api/v3/api-docs/**"
     );
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #144 

## 📌 개요
- Context path 설정(`/api`) 적용 후 JWT 필터에서 제외 경로 패턴 불일치 문제 해결
- API 경로 표준화에 따른 JWT 인증 필터 설정 수정

## 🔁 변경 사항

### 🐛 버그 수정
- **JWT 필터 경로 패턴 수정**: `excludedPaths`에 `/api` prefix 추가하여 context path와 일치시킴
- **인증 제외 경로 정상화**: 회원가입, 이메일 인증, 토큰 발급 등의 경로가 JWT 필터에서 올바르게 제외되도록 수정

### 🔧 수정된 경로 목록
```java
// 기존 (context path 미반영)
"/auth/tokens" → "/api/auth/tokens"
"/users/email/verification-requests" → "/api/users/email/verification-requests"
"/users/email/verification" → "/api/users/email/verification"
"/users" → "/api/users"
"/swagger-ui/**" → "/api/swagger-ui/**"
"/v3/api-docs/**" → "/api/v3/api-docs/**"
```

### 📋 해결된 문제
- 토큰 없이 접근해야 하는 API들이 JWT 필터에 걸려 401 에러가 발생하던 문제 해결
- 회원가입 및 이메일 인증 요청 시 "유효한 토큰이 필요합니다" 에러 해결
- Swagger 문서 접근 시 인증 요구 문제 해결

## 👀 기타 더 이야기해볼 점
- Context path 변경 시 필터와 Security 설정의 경로 패턴 일관성 유지 필요성
- 향후 새로운 인증 제외 경로 추가 시 `/api` prefix 고려 필요

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.