### PR TITLE
Fix/#146 front 404 error

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -35,14 +35,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     // 필터를 적용하지 않을 경로 패턴 목록
     private final List<String> excludedPaths = List.of(
-            "/api/auth/tokens",
-            "/api/auth/tokens/refresh",
-            "/api/users/email/verification-requests",
-            "/api/users/email/verification",
-            "/api/users",
-            "/api/swagger-ui/**",
-            "/api/v3/api-docs/**"
+            "/auth/tokens",
+            "/auth/tokens/refresh",
+            "/users/email/verification-requests",
             "/users/email/verification",
+            "/users",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
     );
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -42,6 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/users",
             "/api/swagger-ui/**",
             "/api/v3/api-docs/**"
+            "/users/email/verification",
     );
 
     /**

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,6 +7,9 @@ app:
     secure: false
     refresh:
       domain: ${COOKIE_DOMAIN}
+server:
+  servlet:
+    context-path: /api
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,6 +7,8 @@ app:
     secure: false
     refresh:
       domain: ${COOKIE_DOMAIN}
+      path: api/auth/tokens
+
 server:
   servlet:
     context-path: /api

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,9 +34,7 @@ spring:
 
 server:
   forward-headers-strategy: framework
-  servlet:
-    context-path: /api
-
+  
 app:
   jwt:
     secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #146

## 📌 개요
- 로컬 개발환경에서 Swagger UI를 통한 API 요청 시 404 오류가 발생하는 문제를 해결했습니다.
- develop 브랜치에서만 발생하던 JWT 필터가 모든 API 요청을 차단하는 문제를 수정했습니다.

## 🔁 변경 사항

### **문제 상황**
- Swagger가 `/api` prefix로 요청을 보내지만 서버는 해당 경로를 인식하지 못함
- JwtAuthenticationFilter의 excludedPaths가 `/api` prefix가 포함된 경로로 설정되어 있어 필터 적용 안됨
- 배포환경에서는 이미 `/api` 경로로 라우팅되어 context-path 중복 문제 발생으로 404에러 발생

### **해결 방법**
1. **환경별 context-path 설정 분리**
   - `application.yml`에서 공통 context-path 제거
   - `application-local.yml`에 로컬용 context-path 설정 추가

2. **JwtAuthenticationFilter excludedPaths 수정**
   - 모든 경로에서 `/api` prefix 제거
   - 배포/로컬 환경 모두에서 동일하게 동작하도록 수정

3. **JWT Refresh Token 경로 환경별 설정**
   - 로컬환경에서 context-path에 맞춰 쿠키 경로 설정

### **변경된 파일들**
- `JwtAuthenticationFilter.java`: excludedPaths에서 `/api` prefix 제거 (7개 경로)
- `application.yml`: context-path 설정 제거
- `application-local.yml`: 로컬용 context-path 및 JWT refresh token 경로 설정 추가

## 👀 기타 더 이야기해볼 점
- 환경별 설정 분리로 배포환경에는 영향 없이 로컬 개발 편의성만 향상됨
- JWT 쿠키 경로가 환경별로 다르게 설정되는 점 (로컬: `/api/auth/tokens`, 배포: `/auth/tokens`)
- context-path 설정이 다른 기능들에 미칠 수 있는 영향도 검토 필요

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.