### PR TITLE
[BE - FIX] 게시글 목록조회시 403에러 수정 및 로컬전용 Context-path추가

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -36,11 +36,6 @@ public class AccessChecker {
      * @return 접근 가능하면 true, 아니면 false
      */
     public boolean hasAccessToBoard(String postType, CustomUserDetails userDetails) {
-        // 인증되지 않은 사용자는 'all' 게시판만 접근 가능
-        if (userDetails == null ||
-            userDetails.isEnabled()) {
-            throw new PostException(GeneralErrorCode.FORBIDDEN, "postType");
-        }
 
         // 관리자, 봇 권한이 있는 경우 모든 게시판 접근 가능
         if (isAdminOrBot(userDetails)) {

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -53,7 +53,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
+        String path = request.getServletPath();
 
         return excludedPaths.stream()
                 .anyMatch(pattern -> pathMatcher.match(pattern, path));


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #150 

## 📌 개요
- AccessChecker에 CustomUserDetilas를 기반으로 로그인 여부를 확인하는 로직을 삭제하였습니다
- Local환경에서 Context Path 설정 후 JWT 필터에서 경로 매칭이 실패하여 
인증이 필요 없는 경로에서도 토큰 검증이 실행되는 문제를 해결했습니다.

## 🔁 변경 사항
- **JWT Filter 경로 매칭 방식 변경**: `getRequestURI()` → `getServletPath()` 사용
- **AccessChecker 중복 로직 제거**: 인증된 사용자 검사를 `isAuthenticated()`로 책임 단일화
- **Configuration Properties 설정**: `@ConfigurationProperties`를 통한 경로 설정 관리
- **Security Config 경로 허용**: JWT Filter와 동일한 경로들을 `.permitAll()`로 설정

## 👀 기타 더 이야기해볼 점

### 해결 과정
1. **Configuration Properties 주입 실패**
   - `@Value`로 YAML List를 직접 주입할 수 없어 `@ConfigurationProperties` + `@Component` 방식으로 변경

2. **Properties 값이 빈 배열로 로드되는 문제**
   - `@Component`와 `@EnableConfigurationProperties` 중복 사용으로 인한 충돌 해결
   - `@Component` 방식으로 통일하여 Properties 클래스에서 직접 주입

3. **경로 매칭은 되지만 필터가 계속 실행되는 문제**
   - JWT Filter는 정상적으로 건너뛰지만 Spring Security의 다른 필터에서 차단 발생
   - SecurityConfig에서 동일한 경로들을 `.permitAll()`로 명시적 허용

4. **Context Path 설정 후 경로 매칭 실패**
   - `server.servlet.context-path: /api` 설정으로 톰캣 레벨에서 Context Path 처리
   - `getRequestURI()`는 전체 경로(`/api/auth/tokens`)를 반환하지만, 실제 애플리케이션에서 처리할 경로는 `getServletPath()`(`/auth/tokens`)
   - 모든 경로 설정에서 Context Path(`/api`) 제거하여 애플리케이션 내부 경로 기준으로 통일

### Context Path 동작 원리
- **톰캣 레벨**: URL에서 Context Path를 분리하여 어떤 애플리케이션으로 라우팅할지 결정
- **Spring 애플리케이션 레벨**: Context Path가 제거된 경로(`Servlet Path`)를 기준으로 처리
- **JWT Filter 실행 시점**: 톰캣의 Context Path 처리 완료 후, DispatcherServlet 실행 전

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.