### PR TITLE
[BE - CHORE] 개발 환경별 Cookie SameSite변경

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
@@ -31,6 +31,9 @@ public class CookieUtil {
     @Value("${app.jwt.refresh.domain}")
     private String cookieDomain;
 
+    @Value("${app.jwt.refresh.same-site}")
+    private String cookieSameSite;
+
     /**
      * 리프레시 토큰을 담은 쿠키를 생성합니다.
      * 생성된 쿠키는 JavaScript에서 접근할 수 없도록 HttpOnly로 설정
@@ -42,7 +45,7 @@ public class CookieUtil {
                 .maxAge(refreshTokenExpiration / 1000)
                 .httpOnly(true)
                 .secure(secureCookie)
-                .sameSite("Lax")
+                .sameSite(cookieSameSite)
                 .build();
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,9 +4,10 @@ spring:
       on-profile: dev
 app:
   jwt:
-    secure: false
+    secure: true
     refresh:
       domain: ${COOKIE_DOMAIN}
+      same-site: None
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ app:
     secure: false
     refresh:
       domain: ${COOKIE_DOMAIN}
-      path: api/auth/tokens
+      same-site: Lax
 
 server:
   servlet:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,6 +8,7 @@ app:
     secure: true
     refresh:
       domain: ${COOKIE_DOMAIN}
+      same-site: Lax
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ app:
     refresh:
       expiration-time: 604800000 # 7일
       token-name: kakaobase_refresh_token
-      path: /auth/tokens
+      path: api/auth/tokens
 
 cloud:
   aws:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #152 

## 📌 개요
- 개발 환경에 맞게 쿠키의 Secure, Same-Site설정을 변경
- 리프레시 토큰 쿠키의 경로를 api/auth/tokens로 일괄 적용

## 🔁 변경 사항
공통사항
Path: api/auth/tokens

local환경: 
Secure = false, Same-Site = Lax

dev환경: 
Secure = true, Same-Site = Nond

prod환경: 
Secure = true, Same-Site = Lax

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.