### PR TITLE
[BE - FEAT] 비밀번호 수정 기능 구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -58,10 +58,12 @@ public class MemberController {
     @PutMapping("/password")
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PreAuthorize("isAuthenticated()")
-    public CustomResponse<Void> putPassword() {
-
-        memberService.ChangePassword();
-        return CustomResponse.success("회원탈퇴가 완료되었습니다.");
+    public CustomResponse<Void> putPassword(
+            @Parameter(description = "비밀번호 수정 요청", required = true)
+            @Valid @RequestBody MemberRequestDto.PasswordChange request
+    ) {
+        memberService.ChangePassword(request);
+        return CustomResponse.success("비밀번호 수정이 완료되었습니다");
     }
 
 

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -47,6 +47,22 @@ public class MemberController {
         return CustomResponse.success("회원가입이 완료되었습니다.");
     }
 
+    @Operation(summary = "비밀번호 수정", description = "회원의 비밀번호를 수정합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 수정성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 입력값"),
+            @ApiResponse(responseCode = "401", description = "이메일 인증 미완료"),
+            @ApiResponse(responseCode = "401", description = "로그인 되지 않음")
+    })
+    @PutMapping("/password")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @PreAuthorize("isAuthenticated()")
+    public CustomResponse<Void> putPassword() {
+
+        memberService.ChangePassword();
+        return CustomResponse.success("회원탈퇴가 완료되었습니다.");
+    }
 
 
     @Operation(summary = "회원탈퇴", description = "기존 회원을 탈퇴시킵니다")

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -62,7 +62,7 @@ public class MemberController {
             @Parameter(description = "비밀번호 수정 요청", required = true)
             @Valid @RequestBody MemberRequestDto.PasswordChange request
     ) {
-        memberService.ChangePassword(request);
+        memberService.changePassword(request);
         return CustomResponse.success("비밀번호 수정이 완료되었습니다");
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
     })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public CustomResponse<Void> signUp(
+    public CustomResponse<Void> postUser(
             @Parameter(description = "회원가입 정보", required = true)
             @Valid @RequestBody MemberRequestDto.SignUp request) {
 
@@ -76,7 +76,7 @@ public class MemberController {
     @DeleteMapping
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PreAuthorize("isAuthenticated()")
-    public CustomResponse<Void> unregister() {
+    public CustomResponse<Void> deleteUser() {
 
         memberService.unregister();
         return CustomResponse.success("회원탈퇴가 완료되었습니다.");

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
@@ -66,6 +66,6 @@ public class MemberRequestDto {
                         message = "비밀번호는 8~20자리, 영문, 숫자, 특수문자를 포함해야 합니다"
                 )
                 @JsonProperty("new_password")
-                String password
+                String NewPassword
         ) {}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
@@ -50,4 +50,22 @@ public class MemberRequestDto {
             @JsonProperty("github_url")
             String githubUrl
     ) {}
+
+        @Schema(description = "비밀번호 수정 요청 DTO")
+        public record PasswordChange(
+                @Schema(description = "이메일", example = "example@domain.com")
+                @NotBlank(message = "이메일은 필수 입력값입니다.")
+                @Email(message = "이메일 형식이 올바르지 않습니다.")
+                @JsonProperty("email")
+                String email,
+
+                @Schema(description = "비밀번호", example = "Test1234!")
+                @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+                @Pattern(
+                        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*\\-_=+<>,\\.\\;:\\\"'\\{\\}\\[\\]/\\?])[A-Za-z\\d!@#$%^&*\\-_=+<>,\\.\\;:\\\"'\\{\\}\\[\\]/\\?]{8,20}$",
+                        message = "비밀번호는 8~20자리, 영문, 숫자, 특수문자를 포함해야 합니다"
+                )
+                @JsonProperty("new_password")
+                String password
+        ) {}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -193,7 +193,7 @@ public class MemberService {
 
     @Transactional
     public void unregister() {
-        log.info("회원탈퇴 처리 시작: {}");
+        log.debug("회원탈퇴 처리 시작");
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
@@ -210,6 +210,25 @@ public class MemberService {
 
         // Member 엔티티 삭제
         member.softDelete();
+
+    }
+
+    @Transactional
+    public void ChangePassword(MemberRequestDto.PasswordChange request) {
+        log.debug("비밀번호 수정 시작");
+
+        String email = request.email();
+        String newPassword = request.NewPassword();
+
+        // 이메일 인증 확인
+        if (!emailVerificationService.isEmailVerified(email)) {
+            throw new MemberException(MemberErrorCode.EMAIL_VERIFICATION_FAILED);
+        }
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
+
+        member.updatePassword(newPassword);
 
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -216,7 +216,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void ChangePassword(MemberRequestDto.PasswordChange request) {
+    public void changePassword(MemberRequestDto.PasswordChange request) {
         log.debug("비밀번호 수정 시작");
 
         String email = request.email();

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberConverter memberConverter;
     private final EmailVerificationService emailVerificationService;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 회원 가입 처리
@@ -228,7 +230,7 @@ public class MemberService {
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new MemberException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
 
-        member.updatePassword(newPassword);
+        member.updatePassword(passwordEncoder.encode(newPassword));
 
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/global/common/email/dto/EmailRequest.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/email/dto/EmailRequest.java
@@ -16,9 +16,9 @@ public class EmailRequest {
             @JsonProperty("email")
             String email,
 
-            @Schema(description = "인증 목적", example = "sign-up", allowableValues = {"sign-up", "password-reset", "unregister"})
+            @Schema(description = "인증 목적", example = "sign-up", allowableValues = {"sign-up", "password-change", "unregister"})
             @NotNull(message = "인증 목적은 필수 입력값입니다.")
-            @Pattern(regexp = "^(sign-up|password-reset|unregister)$", message = "인증목적이 올바르지 않습니다")
+            @Pattern(regexp = "^(sign-up|password-change|unregister)$", message = "인증목적이 올바르지 않습니다")
             @JsonProperty("purpose")
             String purpose
     ) {}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #171 

## 📌 개요
- 사용자가 비밀번호를 변경할 수 있는 기능을 구현했습니다.
- 기존 비밀번호 검증과 새 비밀번호 설정을 위한 안전한 API를 제공합니다.

## 🔁 변경 사항

### ✨새로운 기능
- **비밀번호 수정 API**: PUT /users/password 엔드포인트 구현
- **비밀번호 변경 DTO**: `MemberRequestDto`에 비밀번호 수정용 DTO 추가
- **비밀번호 검증 로직**:  DTO의 @Vaild기반 새 비밀번호 유효성 검사

### 🏗️ 구현 내용

#### DTO 계층
- **비밀번호 수정 DTO 추가**: email과 새 비밀번호를 받는 요청 DTO
- **유효성 검증**: 비밀번호 형식 및 제약 조건 검증 어노테이션 적용

#### Controller 계층  
- **비밀번호 수정 엔드포인트**: 인증된 사용자의 비밀번호 변경 요청 처리
- **예외 처리**: 잘못된 요청에 대한 적절한 응답 처리

#### Service 계층
- **비밀번호 변경 비즈니스 로직**: 이메일 인증 후 새 비밀번호로 업데이트
- **암호화 처리**: 새 비밀번호를 안전하게 해시화하여 저장
- **트랜잭션 관리**: 비밀번호 변경 과정의 데이터 일관성 보장

## 👀 기타 더 이야기해볼 점
이메일 인증시 요청으로 보내는 purpose필드값을 프론트와 통일할 필요가 있습니다
비밀번호 수정시: password-change
회원 탈퇴시: unregister
회원가입시: sign-up

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
