### PR TITLE
[BE - FEAt] 사용자 프로필이미지, github링크 수정 구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.kakaobase.snsapp.domain.members.controller;
 
 import com.kakaobase.snsapp.domain.members.dto.MemberRequestDto;
+import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.service.MemberService;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -81,6 +82,23 @@ public class MemberController {
     ) {
         memberService.changGithubUrl(request);
         return CustomResponse.success("GitHub 링크가 성공적으로 변경되었습니다.");
+    }
+
+    @Operation(summary = "프로필 이미지 수정", description = "회원의 프로필 이미지를 수정합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로필 이미지 수정성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 입력값"),
+            @ApiResponse(responseCode = "401", description = "로그인 되지 않음")
+    })
+    @PutMapping("/images")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public CustomResponse<MemberResponseDto.ProfileImageChange> putProfileImageUrl(
+            @Parameter(description = "프로필 이미지 수정 요청", required = true)
+            @Valid @RequestBody MemberRequestDto.ProfileImageChange request
+    ) {
+        MemberResponseDto.ProfileImageChange newImageUrl = memberService.changProfileImageUrl(request);
+        return CustomResponse.success("프로필 이미지가 성공적으로 변경되었습니다.", newImageUrl);
     }
 
 

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -66,6 +66,23 @@ public class MemberController {
         return CustomResponse.success("비밀번호 수정이 완료되었습니다");
     }
 
+    @Operation(summary = "GithubUrl 수정", description = "회원의 GithubUrl를 수정합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "GithubUrl 수정성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 입력값"),
+            @ApiResponse(responseCode = "401", description = "로그인 되지 않음")
+    })
+    @PutMapping("/github-url")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public CustomResponse<Void> putGithubUrl(
+            @Parameter(description = "GithubUrl 수정 요청", required = true)
+            @Valid @RequestBody MemberRequestDto.GithubUrlChange request
+    ) {
+        memberService.changGithubUrl(request);
+        return CustomResponse.success("GitHub 링크가 성공적으로 변경되었습니다.");
+    }
+
 
     @Operation(summary = "회원탈퇴", description = "기존 회원을 탈퇴시킵니다")
     @ApiResponses(value = {

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -77,7 +77,6 @@ public class MemberController {
     })
     @DeleteMapping
     @ResponseStatus(HttpStatus.ACCEPTED)
-    @PreAuthorize("isAuthenticated()")
     public CustomResponse<Void> deleteUser() {
 
         memberService.unregister();

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
@@ -78,4 +78,16 @@ public class MemberRequestDto {
                 @JsonProperty("github_url")
                 String githubUrl
         ) {}
+
+        @Schema(description = "프로필 이미지 수정 요청 DTO")
+        public record ProfileImageChange(
+
+                @Schema(description = "수정할 프로필 이미지 URL", example = "https://s3.amazonaws.com/bucket/uploads/dev.jpg")
+                @Pattern(
+                        regexp = "^https://[a-zA-Z0-9.-]+\\.s3\\.[a-zA-Z0-9-]+\\.amazonaws\\.com/.+$",
+                        message = "올바른 파일 URL 형식이 아닙니다."
+                )
+                @JsonProperty("image_url")
+                String imageUrl
+        ) {}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberRequestDto.java
@@ -68,4 +68,14 @@ public class MemberRequestDto {
                 @JsonProperty("new_password")
                 String NewPassword
         ) {}
+
+        @Schema(description = "GithubUrl 수정 요청 DTO")
+        public record GithubUrlChange(
+
+                @Schema(description = "수정할 GitHub URL", example = "https://github.com/gildong")
+                @Pattern(regexp = "^(https://github\\.com/)[A-Za-z0-9_-]+(/)?.*$",
+                        message = "GitHub URL 형식이 올바르지 않습니다. https://github.com/{username} 형식이어야 합니다.")
+                @JsonProperty("github_url")
+                String githubUrl
+        ) {}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
@@ -54,4 +54,11 @@ public class MemberResponseDto {
             @JsonProperty("is_following")
             Boolean isFollowing
     ) {}
+
+        @Schema(description = "회원 프로필 수정 DTO")
+        public record ProfileImageChange(
+                @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
+                @JsonProperty("image_url")
+                String profileImageUrl
+        ){}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -4,6 +4,7 @@ import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
 import com.kakaobase.snsapp.domain.comments.dto.BotRecommentRequestDto;
 import com.kakaobase.snsapp.domain.members.converter.MemberConverter;
 import com.kakaobase.snsapp.domain.members.dto.MemberRequestDto;
+import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.exception.MemberErrorCode;
 import com.kakaobase.snsapp.domain.members.exception.MemberException;
@@ -245,5 +246,17 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
 
         member.updateGithubUrl(request.githubUrl());
+    }
+
+    public MemberResponseDto.ProfileImageChange changProfileImageUrl(MemberRequestDto.@Valid ProfileImageChange request) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+
+        Member member = memberRepository.findById(Long.valueOf(userDetails.getId()))
+                .orElseThrow(() -> new MemberException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
+
+        member.updateProfile(request.imageUrl());
+
+        return new MemberResponseDto.ProfileImageChange(request.imageUrl());
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -10,6 +10,7 @@ import com.kakaobase.snsapp.domain.members.exception.MemberException;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.global.common.email.service.EmailVerificationService;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -232,5 +233,17 @@ public class MemberService {
 
         member.updatePassword(passwordEncoder.encode(newPassword));
 
+    }
+
+    @Transactional
+    public void changGithubUrl(MemberRequestDto.@Valid GithubUrlChange request) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
+
+        Member member = memberRepository.findById(Long.valueOf(userDetails.getId()))
+                .orElseThrow(() -> new MemberException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
+
+        member.updateGithubUrl(request.githubUrl());
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #173 

## 📌 개요
- 사용자 프로필 이미지 변경 기능 구현
- GitHub URL 수정 기능 구현
- 회원탈퇴 API의 중복된 인증 로직 제거

## 🔁 변경 사항
###  추가된 기능
- **프로필 이미지 수정**
  - 프로필 이미지 수정 DTO 구현
  - MemberController에 프로필 이미지 수정 API 추가
  - 프로필 이미지 수정 비즈니스 로직 구현

- **GitHub URL 수정**
  - GitHub URL 수정 요청 DTO 추가
  - Controller에 GitHub URL 수정 API 추가
  - GitHub URL 수정 비즈니스 로직 구현

###  개선 사항
- 회원탈퇴 API에서 중복된 인증 로직(@PreAuthorize) 제거로 코드 최적화

## 👀 기타 더 이야기해볼 점
- GitHub URL 유효성 검증 로직 확인 필요
- API 응답 형식 및 에러 처리 방식 통일성 검토

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.