### PR TITLE
[BE - FEAT]follow도메인 구현 및 기존 로직에 반영

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,0 +1,48 @@
+name: Backend CI - Develop
+
+on:
+  push:
+    branches: [develop, feature/**]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Lint (Checkstyle)
+        run: ./gradlew checkstyleMain checkstyleTest
+
+  notify:
+    name: Discord Notification
+    needs: ci
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        run: |
+          if [ "${{ needs.ci.result }}" == "success" ]; then
+            STATUS="✅ 성공"
+            COLOR="3066993"
+          else
+            STATUS="❌ 실패"
+            COLOR="15158332"
+          fi
+
+          curl -X POST -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"$STATUS: ${{ github.workflow }}\",
+                \"description\": \"브랜치: \`${{ github.ref_name }}\`\n커밋한 사람: \`${{ github.actor }}\`\n[👉 액션 보기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\",
+                \"color\": $COLOR
+              }]
+            }" \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
@@ -171,19 +171,17 @@ public class CommentController {
             description = "댓글에 좋아요를 추가합니다. 이미 좋아요를 누른 경우 에러가 발생합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "좋아요 추가 성공",
-                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CommentLikeResponse.class))),
+            @ApiResponse(responseCode = "200", description = "좋아요 추가 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이미 좋아요한 댓글입니다")
     })
-    public ResponseEntity<CustomResponse<CommentResponseDto.CommentLikeResponse>> addCommentLike(
+    public CustomResponse<?> addCommentLike(
             @PathVariable Long commentId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = Long.valueOf(userDetails.getId());
-        CommentResponseDto.CommentLikeResponse response = commentLikeService.addCommentLike(memberId, commentId);
-        return ResponseEntity.ok(CustomResponse.success("댓글에 좋아요를 눌렀습니다.", response));
+        Long memberId = Long.valueOf(userDetails.getId());commentLikeService.addCommentLike(memberId, commentId);
+        return CustomResponse.success("좋아요가 성공적으로 등록되었습니다");
     }
 
     /**
@@ -196,19 +194,18 @@ public class CommentController {
             description = "댓글의 좋아요를 취소합니다. 좋아요하지 않은 경우 에러가 발생합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "좋아요 취소 성공",
-                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CommentLikeResponse.class))),
+            @ApiResponse(responseCode = "200", description = "좋아요 취소 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "좋아요하지 않은 댓글입니다")
     })
-    public ResponseEntity<CustomResponse<CommentResponseDto.CommentLikeResponse>> removeCommentLike(
+    public CustomResponse<?> removeCommentLike(
             @PathVariable Long commentId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getId());
-        CommentResponseDto.CommentLikeResponse response = commentLikeService.removeCommentLike(memberId, commentId);
-        return ResponseEntity.ok(CustomResponse.success("댓글 좋아요를 취소했습니다.", response));
+        commentLikeService.removeCommentLike(memberId, commentId);
+        return CustomResponse.success("좋아요가 성공적으로 취소되었습니다.");
     }
 
     /**
@@ -221,19 +218,18 @@ public class CommentController {
             description = "대댓글에 좋아요를 추가합니다. 이미 좋아요를 누른 경우 에러가 발생합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "좋아요 추가 성공",
-                    content = @Content(schema = @Schema(implementation = CommentResponseDto.RecommentLikeResponse.class))),
+            @ApiResponse(responseCode = "200", description = "좋아요 추가 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "대댓글을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이미 좋아요한 대댓글입니다")
     })
-    public ResponseEntity<CustomResponse<CommentResponseDto.RecommentLikeResponse>> addRecommentLike(
+    public CustomResponse<?> addRecommentLike(
             @PathVariable Long recommentId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getId());
-        CommentResponseDto.RecommentLikeResponse response = commentLikeService.addRecommentLike(memberId, recommentId);
-        return ResponseEntity.ok(CustomResponse.success("대댓글에 좋아요를 눌렀습니다.", response));
+        commentLikeService.addRecommentLike(memberId, recommentId);
+        return CustomResponse.success("좋아요가 성공적으로 등록되었습니다");
     }
 
     /**
@@ -246,19 +242,18 @@ public class CommentController {
             description = "대댓글의 좋아요를 취소합니다. 좋아요하지 않은 경우 에러가 발생합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "좋아요 취소 성공",
-                    content = @Content(schema = @Schema(implementation = CommentResponseDto.RecommentLikeResponse.class))),
+            @ApiResponse(responseCode = "200", description = "좋아요 취소 성공"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "대댓글을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "좋아요하지 않은 대댓글입니다")
     })
-    public ResponseEntity<CustomResponse<CommentResponseDto.RecommentLikeResponse>> removeRecommentLike(
+    public CustomResponse<?> removeRecommentLike(
             @PathVariable Long recommentId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getId());
-        CommentResponseDto.RecommentLikeResponse response = commentLikeService.removeRecommentLike(memberId, recommentId);
-        return ResponseEntity.ok(CustomResponse.success("대댓글 좋아요를 취소했습니다.", response));
+        commentLikeService.removeRecommentLike(memberId, recommentId);
+        return CustomResponse.success("대댓글 좋아요를 취소했습니다.");
     }
 
 
@@ -277,12 +272,12 @@ public class CommentController {
             @ApiResponse(responseCode = "403", description = "본인이 작성한 대댓글만 삭제할 수 있습니다"),
             @ApiResponse(responseCode = "404", description = "해당 대댓글을 찾을 수 없습니다")
     })
-    public ResponseEntity<CustomResponse<Void>> deleteRecomment(
+    public CustomResponse<?> deleteRecomment(
             @PathVariable Long recommentId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getId());
         commentService.deleteRecomment(memberId, recommentId);
-        return ResponseEntity.ok(CustomResponse.success("대댓글이 삭제되었습니다.", null));
+        return CustomResponse.success("좋아요가 성공적으로 취소되었습니다.", null);
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/LikeConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/LikeConverter.java
@@ -37,31 +37,4 @@ public class LikeConverter {
         return new RecommentLike(memberId, recommentId);
     }
 
-    /**
-     * 댓글 좋아요 토글 응답 DTO 생성
-     *
-     * @param comment 댓글 엔티티
-     * @param isLiked 좋아요 상태
-     * @return 댓글 좋아요 토글 응답 DTO
-     */
-    public CommentResponseDto.CommentLikeResponse toCommentLikeResponse(Comment comment, boolean isLiked) {
-        if (comment == null) {
-            throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "존재하지 않는 댓글입니다.");
-        }
-        return new CommentResponseDto.CommentLikeResponse(isLiked, comment.getLikeCount());
-    }
-
-    /**
-     * 대댓글 좋아요 토글 응답 DTO 생성
-     *
-     * @param recomment 대댓글 엔티티
-     * @param isLiked 좋아요 상태
-     * @return 대댓글 좋아요 토글 응답 DTO
-     */
-    public CommentResponseDto.RecommentLikeResponse toRecommentLikeResponse(Recomment recomment, boolean isLiked) {
-        if (recomment == null) {
-            throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId", "존재하지 않는 대댓글입니다.");
-        }
-        return new CommentResponseDto.RecommentLikeResponse(isLiked, recomment.getLikeCount());
-    }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.comments.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -26,10 +27,12 @@ public class CommentResponseDto {
             String nickname,
 
             @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
-            String profile_image,
+            @JsonProperty("image_url")
+            String imageUrl,
 
             @Schema(description = "팔로우 여부 (V2에서 구현)", example = "false")
-            boolean is_followed
+            @JsonProperty("is_followed")
+            boolean isFollowed
     ) {
         // 팔로우 정보 없이 생성하는 생성자 추가 (V2 전까지 임시로 사용)
         public UserInfo(Long id, String nickname, String profile_image) {

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -1,6 +1,7 @@
 package com.kakaobase.snsapp.domain.comments.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
@@ -15,30 +16,6 @@ import java.util.List;
 @Schema(description = "댓글 관련 응답 DTO 클래스")
 public class CommentResponseDto {
 
-    /**
-     * 댓글 작성자 정보 DTO
-     */
-    @Schema(description = "댓글 작성자 정보")
-    public record UserInfo(
-            @Schema(description = "회원 ID", example = "10")
-            Long id,
-
-            @Schema(description = "회원 닉네임", example = "댓글러")
-            String nickname,
-
-            @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
-            @JsonProperty("image_url")
-            String imageUrl,
-
-            @Schema(description = "팔로우 여부 (V2에서 구현)", example = "false")
-            @JsonProperty("is_followed")
-            boolean isFollowed
-    ) {
-        // 팔로우 정보 없이 생성하는 생성자 추가 (V2 전까지 임시로 사용)
-        public UserInfo(Long id, String nickname, String profile_image) {
-            this(id, nickname, profile_image, false);  // 팔로우 여부는 항상 false로 설정
-        }
-    }
 
     /**
      * 대댓글 정보 DTO
@@ -49,7 +26,7 @@ public class CommentResponseDto {
             Long id,
 
             @Schema(description = "작성자 정보")
-            UserInfo user,
+            MemberResponseDto.UserInfoWithFollowing user,
 
             @Schema(description = "대댓글 내용", example = "저도 그렇게 생각해요!")
             String content,
@@ -76,7 +53,7 @@ public class CommentResponseDto {
             Long id,
 
             @Schema(description = "작성자 정보")
-            UserInfo user,
+            MemberResponseDto.UserInfoWithFollowing user,
 
             @Schema(description = "댓글 내용", example = "이 게시글 정말 유익하네요!")
             String content,
@@ -106,7 +83,7 @@ public class CommentResponseDto {
             Long id,
 
             @Schema(description = "작성자 정보")
-            UserInfo user,
+            MemberResponseDto.UserInfo user,
 
             @Schema(description = "댓글 내용", example = "이 댓글은 정말 유익하네요!")
             String content,

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -122,29 +122,6 @@ public class CommentResponseDto {
             Long next_cursor
     ) {}
 
-    /**
-     * 댓글 좋아요 토글 응답 DTO
-     */
-    @Schema(description = "댓글 좋아요 토글 응답")
-    public record CommentLikeResponse(
-            @Schema(description = "좋아요 상태 (true: 좋아요 등록, false: 좋아요 취소)", example = "true")
-            boolean liked,
-
-            @Schema(description = "좋아요 수", example = "4")
-            int like_count
-    ) {}
-
-    /**
-     * 대댓글 좋아요 토글 응답 DTO
-     */
-    @Schema(description = "대댓글 좋아요 토글 응답")
-    public record RecommentLikeResponse(
-            @Schema(description = "좋아요 상태 (true: 좋아요 등록, false: 좋아요 취소)", example = "true")
-            boolean liked,
-
-            @Schema(description = "좋아요 수", example = "2")
-            int like_count
-    ) {}
 
     /**
      * 댓글 상세 조회 응답 DTO

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentLikeService.java
@@ -43,11 +43,10 @@ public class CommentLikeService {
      *
      * @param commentId 댓글 ID
      * @param memberId 회원 ID
-     * @return 좋아요 응답 DTO
      * @throws CommentException 댓글이 없거나 이미 좋아요한 경우
      */
     @Transactional
-    public CommentResponseDto.CommentLikeResponse addCommentLike(Long memberId, Long commentId) {
+    public void addCommentLike(Long memberId, Long commentId) {
         // 댓글 존재 여부 확인
         Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId"));
@@ -66,8 +65,6 @@ public class CommentLikeService {
         commentRepository.save(comment);
 
         log.info("댓글 좋아요 추가 완료: 댓글 ID={}, 회원 ID={}", commentId, memberId);
-
-        return new CommentResponseDto.CommentLikeResponse(true, comment.getLikeCount());
     }
 
     /**
@@ -79,7 +76,7 @@ public class CommentLikeService {
      * @throws CommentException 댓글이 없거나 좋아요하지 않은 경우
      */
     @Transactional
-    public CommentResponseDto.CommentLikeResponse removeCommentLike(Long memberId, Long commentId) {
+    public void removeCommentLike(Long memberId, Long commentId) {
         // 댓글 존재 여부 확인
         Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId"));
@@ -96,8 +93,6 @@ public class CommentLikeService {
         commentRepository.save(comment);
 
         log.info("댓글 좋아요 취소 완료: 댓글 ID={}, 회원 ID={}", commentId, memberId);
-
-        return new CommentResponseDto.CommentLikeResponse(false, comment.getLikeCount());
     }
 
     /**
@@ -105,11 +100,10 @@ public class CommentLikeService {
      *
      * @param recommentId 대댓글 ID
      * @param memberId 회원 ID
-     * @return 좋아요 응답 DTO
      * @throws CommentException 대댓글이 없거나 이미 좋아요한 경우
      */
     @Transactional
-    public CommentResponseDto.RecommentLikeResponse addRecommentLike(Long memberId, Long recommentId) {
+    public void addRecommentLike(Long memberId, Long recommentId) {
         // 대댓글 존재 여부 확인
         Recomment recomment = recommentRepository.findByIdAndDeletedAtIsNull(recommentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId"));
@@ -128,8 +122,6 @@ public class CommentLikeService {
         recommentRepository.save(recomment);
 
         log.info("대댓글 좋아요 추가 완료: 대댓글 ID={}, 회원 ID={}", recommentId, memberId);
-
-        return new CommentResponseDto.RecommentLikeResponse(true, recomment.getLikeCount());
     }
 
     /**
@@ -137,11 +129,10 @@ public class CommentLikeService {
      *
      * @param recommentId 대댓글 ID
      * @param memberId 회원 ID
-     * @return 좋아요 응답 DTO
      * @throws CommentException 대댓글이 없거나 좋아요하지 않은 경우
      */
     @Transactional
-    public CommentResponseDto.RecommentLikeResponse removeRecommentLike(Long memberId, Long recommentId) {
+    public void removeRecommentLike(Long memberId, Long recommentId) {
         // 대댓글 존재 여부 확인
         Recomment recomment = recommentRepository.findByIdAndDeletedAtIsNull(recommentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId"));
@@ -159,7 +150,6 @@ public class CommentLikeService {
 
         log.info("대댓글 좋아요 취소 완료: 대댓글 ID={}, 회원 ID={}", recommentId, memberId);
 
-        return new CommentResponseDto.RecommentLikeResponse(false, recomment.getLikeCount());
     }
 
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -188,22 +188,6 @@ public class CommentService {
      * @param pageRequest 페이지 요청 DTO
      * @return 댓글 목록 응답 DTO
      */
-    /**
-     * 게시글에 달린 댓글 목록을 조회합니다.
-     *
-     * @param memberId 현재 로그인한 회원 ID
-     * @param postId 조회할 게시글 ID
-     * @param pageRequest 페이지 요청 정보
-     * @return 댓글 목록 응답 DTO
-     */
-    /**
-     * 게시글에 달린 댓글 목록을 조회합니다.
-     *
-     * @param memberId 현재 로그인한 회원 ID
-     * @param postId 조회할 게시글 ID
-     * @param pageRequest 페이지 요청 정보
-     * @return 댓글 목록 응답 DTO
-     */
     public CommentResponseDto.CommentListResponse getCommentsByPostId(Long memberId, Long postId, CommentRequestDto.CommentPageRequest pageRequest) {
         // 게시글 존재 확인
         Post post = postService.findById(postId);

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -53,14 +53,6 @@ public class CommentService {
      * @param request 댓글 생성 요청 DTO
      * @return 생성된 댓글 응답 DTO
      */
-    /**
-     * 댓글을 생성합니다.
-     *
-     * @param memberId 회원 ID
-     * @param postId 게시글 ID
-     * @param request 댓글 생성 요청 DTO
-     * @return 생성된 댓글 응답 DTO
-     */
     @Transactional
     public CommentResponseDto.CreateCommentResponse createComment(Long memberId, Long postId, CommentRequestDto.CreateCommentRequest request) {
         // 게시글 존재 확인

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
@@ -64,6 +64,8 @@ public class FollowController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
+        followService.removeFollowing(targetUserId, userDetails);
+
         return CustomResponse.success("팔로우를 성공적으로 취소하였습니다.");
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
@@ -73,7 +73,7 @@ public class FollowController {
         return CustomResponse.success("팔로우를 성공적으로 취소하였습니다.");
     }
 
-    @DeleteMapping("{userId}/followers")
+    @GetMapping("{userId}/followers")
     @Operation(
             summary = "팔로워 목록 요청",
             description = "특정유저를 팔로잉하는 회원 목록을 요청합니다"
@@ -93,5 +93,27 @@ public class FollowController {
             List<FollowResponse.UserInfo> response =followService.getFollowers(userId, limit, cursor);
 
             return CustomResponse.success("팔로워 목록이 정상적으로 조회되었습니다" , response);
+    }
+
+    @GetMapping("{userId}/followings")
+    @Operation(
+            summary = "팔로잉 목록 요청",
+            description = "특정유저를 팔로잉하는 회원 목록을 요청합니다"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로우 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CreateCommentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 요청"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음")
+    })
+    public CustomResponse<List<FollowResponse.UserInfo>> getFollowingList(
+            @PathVariable Long userId,
+            @Parameter(description = "한 번에 불러올 팔로워 수 (기본값: 22)") @RequestParam(required = false, defaultValue = "22") Integer limit,
+            @Parameter(description = "페이지네이션 커서 (이전 응답의 next_cursor)") @RequestParam(required = false) Long cursor
+    ) {
+        List<FollowResponse.UserInfo> response =followService.getFollowings(userId, limit, cursor);
+
+        return CustomResponse.success("팔로잉 목록이 정상적으로 조회되었습니다" , response);
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
@@ -1,0 +1,69 @@
+package com.kakaobase.snsapp.domain.follow.controller;
+
+
+import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.follow.service.FollowService;
+import com.kakaobase.snsapp.global.common.response.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Tag(name = "팔로우 API", description = "팔로잉, 팔로우 관련 API")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("{targetUserId}/follows")
+    @Operation(
+            summary = "팔로우 요청",
+            description = "유저에게 팔로우를 요청합니다"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로우 요청 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CreateCommentResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 요청"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 팔로우 한 유저")
+    })
+    public CustomResponse<?> createFollowing(
+            @PathVariable Long targetUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        followService.addFollowing(targetUserId, userDetails);
+
+        return CustomResponse.success("팔로우가 성공적으로 완료되었습니다.");
+    }
+
+    @DeleteMapping("{targetUserId}/follows")
+    @Operation(
+            summary = "팔로우 요청",
+            description = "유저에게 팔로우를 요청합니다"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로우 취소 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CreateCommentResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 요청"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 언팔로우 한 유저")
+    })
+    public CustomResponse<?> deleteFollowing(
+            @PathVariable Long targetUserId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        return CustomResponse.success("팔로우를 성공적으로 취소하였습니다.");
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/controller/FollowController.java
@@ -3,9 +3,11 @@ package com.kakaobase.snsapp.domain.follow.controller;
 
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
 import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.follow.dto.FollowResponse;
 import com.kakaobase.snsapp.domain.follow.service.FollowService;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -49,8 +53,8 @@ public class FollowController {
 
     @DeleteMapping("{targetUserId}/follows")
     @Operation(
-            summary = "팔로우 요청",
-            description = "유저에게 팔로우를 요청합니다"
+            summary = "언팔로우 요청",
+            description = "유저에게 팔로잉 취소를 요청합니다"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "팔로우 취소 성공",
@@ -67,5 +71,27 @@ public class FollowController {
         followService.removeFollowing(targetUserId, userDetails);
 
         return CustomResponse.success("팔로우를 성공적으로 취소하였습니다.");
+    }
+
+    @DeleteMapping("{userId}/followers")
+    @Operation(
+            summary = "팔로워 목록 요청",
+            description = "특정유저를 팔로잉하는 회원 목록을 요청합니다"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팔로우 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponseDto.CreateCommentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요한 요청"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없음")
+    })
+    public CustomResponse<List<FollowResponse.UserInfo>> getFollowerList(
+            @PathVariable Long userId,
+            @Parameter(description = "한 번에 불러올 팔로워 수 (기본값: 22)") @RequestParam(required = false, defaultValue = "22") Integer limit,
+            @Parameter(description = "페이지네이션 커서 (이전 응답의 next_cursor)") @RequestParam(required = false) Long cursor
+    ) {
+            List<FollowResponse.UserInfo> response =followService.getFollowers(userId, limit, cursor);
+
+            return CustomResponse.success("팔로워 목록이 정상적으로 조회되었습니다" , response);
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/converter/FollowConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/converter/FollowConverter.java
@@ -1,0 +1,16 @@
+package com.kakaobase.snsapp.domain.follow.converter;
+
+import com.kakaobase.snsapp.domain.follow.entity.Follow;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FollowConverter {
+
+    public Follow toFollowEntity(Member follower, Member following){
+        return Follow.builder()
+                .followerUser(follower)
+                .followingUser(following)
+                .build();
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/converter/FollowConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/converter/FollowConverter.java
@@ -1,16 +1,32 @@
 package com.kakaobase.snsapp.domain.follow.converter;
 
+import com.kakaobase.snsapp.domain.follow.dto.FollowResponse;
 import com.kakaobase.snsapp.domain.follow.entity.Follow;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 public class FollowConverter {
+
 
     public Follow toFollowEntity(Member follower, Member following){
         return Follow.builder()
                 .followerUser(follower)
                 .followingUser(following)
                 .build();
+    }
+
+    public List<FollowResponse.UserInfo> toUserInfoList(List<Object[]> rawDataList) {
+        return rawDataList.stream()
+                .map(row -> new FollowResponse.UserInfo(
+                        ((Number) row[0]).longValue(), // id
+                        (String) row[1],               // nickname
+                        (String) row[2],               // name
+                        (String) row[3]                // profile_image
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/dto/FollowResponse.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/dto/FollowResponse.java
@@ -1,0 +1,23 @@
+package com.kakaobase.snsapp.domain.follow.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "팔로우 관련 응답 DTO 클래스")
+public class FollowResponse {
+
+    @Schema(description = "팔로워 정보")
+    public record UserInfo(
+            @Schema(description = "회원 ID", example = "10")
+            Long id,
+
+            @Schema(description = "회원 닉네임", example = "kevin.hong")
+            String nickname,
+
+            @Schema(description = "회원 이름", example = "홍길동")
+            String name,
+
+            @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
+            String profile_image
+    ){}
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/dto/FollowResponse.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/dto/FollowResponse.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.follow.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "팔로우 관련 응답 DTO 클래스")
@@ -17,7 +18,8 @@ public class FollowResponse {
             String name,
 
             @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
-            String profile_image
+            @JsonProperty("image_url")
+            String imageUrl
     ){}
 
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/entity/Follow.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/entity/Follow.java
@@ -18,10 +18,12 @@ public class Follow extends BaseCreatedTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    //팔로잉 요청건 사람
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_user_id", nullable = false)
     private Member followerUser;
 
+    //팔로잉 요청 받은 사람
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id", nullable = false)
     private Member followingUser;

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/entity/Follow.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/entity/Follow.java
@@ -28,7 +28,6 @@ public class Follow extends BaseCreatedTimeEntity {
 
     @Builder
     public Follow(Long id, Member followerUser, Member followingUser) {
-        this.id = id;
         this.followerUser = followerUser;
         this.followingUser = followingUser;
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/entity/Follow.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/entity/Follow.java
@@ -1,0 +1,36 @@
+package com.kakaobase.snsapp.domain.follow.entity;
+
+
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.global.common.entity.BaseCreatedTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseCreatedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_user_id", nullable = false)
+    private Member followerUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id", nullable = false)
+    private Member followingUser;
+
+    @Builder
+    public Follow(Long id, Member followerUser, Member followingUser) {
+        this.id = id;
+        this.followerUser = followerUser;
+        this.followingUser = followingUser;
+    }
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/exception/FollowErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/exception/FollowErrorCode.java
@@ -1,0 +1,19 @@
+package com.kakaobase.snsapp.domain.follow.exception;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FollowErrorCode {
+
+    ALREADY_FOLLOWING(HttpStatus.CONFLICT, "state_conflict", "이미 팔로잉한 유저입니다", "traget_user_id"),
+    ALREADY_UNFOLLOWING(HttpStatus.CONFLICT, "state_conflict", "이미 언팔로잉한 유저입니다", "traget_user_id");
+
+    private final HttpStatus status;
+    private final String error;
+    private final String message;
+    private final String field;
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/exception/FollowErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/exception/FollowErrorCode.java
@@ -1,13 +1,14 @@
 package com.kakaobase.snsapp.domain.follow.exception;
 
 
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum FollowErrorCode {
+public enum FollowErrorCode implements BaseErrorCode {
 
     ALREADY_FOLLOWING(HttpStatus.CONFLICT, "state_conflict", "이미 팔로잉한 유저입니다", "traget_user_id"),
     ALREADY_UNFOLLOWING(HttpStatus.CONFLICT, "state_conflict", "이미 언팔로잉한 유저입니다", "traget_user_id");

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/exception/FollowException.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/exception/FollowException.java
@@ -1,0 +1,19 @@
+package com.kakaobase.snsapp.domain.follow.exception;
+
+import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
+import com.kakaobase.snsapp.global.error.exception.CustomException;
+
+public class FollowException extends CustomException {
+
+    public FollowException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public FollowException(BaseErrorCode errorCode, String field) {
+        super(errorCode, field);
+    }
+
+    public FollowException(BaseErrorCode errorCode, String field, String additionalMessage) {
+        super(errorCode, field, additionalMessage);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
@@ -49,5 +50,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
             @Param("cursor") Long cursor
     );
 
+    @Query("SELECT f.followingUser.id FROM Follow f WHERE f.followerUser = :followerUser")
+    Set<Long> findFollowingUserIdsByFollowerUser(@Param("followerUser") Member followerUser);
 
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
@@ -19,9 +19,9 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<Follow> findByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
 
     @Query(value = """
-    SELECT m.id, m.nickname, m.name, m.profile_image
+    SELECT m.id, m.nickname, m.name, m.profile_img_url
     FROM follow f
-    JOIN member m ON f.follower_user_id = m.id
+    JOIN members m ON f.follower_user_id = m.id
     WHERE f.following_id = :followingId
       AND (:cursor IS NULL OR m.id > :cursor)
     ORDER BY m.id ASC
@@ -33,5 +33,21 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
             @Param("cursor") Long cursor
 
     );
+
+    @Query(value = """
+    SELECT m.id, m.nickname, m.name, m.profile_img_url
+    FROM follow f
+    JOIN members m ON f.following_id = m.id
+    WHERE f.follower_user_id = :followerId
+      AND (:cursor IS NULL OR m.id > :cursor)
+    ORDER BY m.id ASC
+    LIMIT :limit
+    """, nativeQuery = true)
+    List<Object[]> findFollowingsByFollowerUserWithCursor(
+            @Param("followerId") Long followerId,
+            @Param("limit") Integer limit,
+            @Param("cursor") Long cursor
+    );
+
 
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
@@ -6,8 +6,12 @@ import com.kakaobase.snsapp.domain.members.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
+
+    Optional<Follow> findByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
@@ -4,8 +4,11 @@ package com.kakaobase.snsapp.domain.follow.repository;
 import com.kakaobase.snsapp.domain.follow.entity.Follow;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +17,21 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
 
     Optional<Follow> findByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
+
+    @Query(value = """
+    SELECT m.id, m.nickname, m.name, m.profile_image
+    FROM follow f
+    JOIN member m ON f.follower_user_id = m.id
+    WHERE f.following_id = :followingId
+      AND (:cursor IS NULL OR m.id > :cursor)
+    ORDER BY m.id ASC
+    LIMIT :limit
+    """, nativeQuery = true)
+    List<Object[]> findFollowersByFollowingUserWithCursor(
+            @Param("followingId") Long followingId,
+            @Param("limit") Integer limit,
+            @Param("cursor") Long cursor
+
+    );
+
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,13 @@
+package com.kakaobase.snsapp.domain.follow.repository;
+
+
+import com.kakaobase.snsapp.domain.follow.entity.Follow;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    boolean existsByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
@@ -1,0 +1,42 @@
+package com.kakaobase.snsapp.domain.follow.service;
+
+
+import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.follow.entity.Follow;
+import com.kakaobase.snsapp.domain.follow.exception.FollowErrorCode;
+import com.kakaobase.snsapp.domain.follow.exception.FollowException;
+import com.kakaobase.snsapp.domain.follow.repository.FollowRepository;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final EntityManager entityManager;
+
+    public void addFollowing(Long targetUserId, CustomUserDetails userDetails) {
+
+        //팔로잉 신청한 사람
+        Member followerProxy = entityManager.getReference(Member.class, Long.valueOf(userDetails.getId()));
+        //팔로잉 요청 받은 사람
+        Member followingProxy = entityManager.getReference(Member.class, targetUserId);
+
+        if(followRepository.existsByFollowerUserAndFollowingUser(followerProxy, followingProxy)){
+            throw new FollowException(FollowErrorCode.ALREADY_FOLLOWING);
+        }
+        //Converter로 follower생성
+        followRepository.save();
+
+
+    }
+
+    public void removeFollowing(){
+
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
@@ -2,11 +2,14 @@ package com.kakaobase.snsapp.domain.follow.service;
 
 
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.follow.converter.FollowConverter;
 import com.kakaobase.snsapp.domain.follow.entity.Follow;
 import com.kakaobase.snsapp.domain.follow.exception.FollowErrorCode;
 import com.kakaobase.snsapp.domain.follow.exception.FollowException;
 import com.kakaobase.snsapp.domain.follow.repository.FollowRepository;
 import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
+import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +21,19 @@ import org.springframework.stereotype.Service;
 public class FollowService {
 
     private final FollowRepository followRepository;
+    private final FollowConverter followConverter;
+    private final MemberRepository memberRepository;
     private final EntityManager entityManager;
 
     public void addFollowing(Long targetUserId, CustomUserDetails userDetails) {
+
+        if(!memberRepository.existsById(targetUserId)) {
+            throw new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "targetUserId");
+        }
+
+        if(!memberRepository.existsById(Long.valueOf(userDetails.getId()))) {
+            throw new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "targetUserId");
+        }
 
         //팔로잉 신청한 사람
         Member followerProxy = entityManager.getReference(Member.class, Long.valueOf(userDetails.getId()));
@@ -30,10 +43,9 @@ public class FollowService {
         if(followRepository.existsByFollowerUserAndFollowingUser(followerProxy, followingProxy)){
             throw new FollowException(FollowErrorCode.ALREADY_FOLLOWING);
         }
-        //Converter로 follower생성
-        followRepository.save();
 
-
+        Follow follow = followConverter.toFollowEntity(followerProxy, followingProxy);
+        followRepository.save(follow);
     }
 
     public void removeFollowing(){

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
@@ -3,6 +3,7 @@ package com.kakaobase.snsapp.domain.follow.service;
 
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
 import com.kakaobase.snsapp.domain.follow.converter.FollowConverter;
+import com.kakaobase.snsapp.domain.follow.dto.FollowResponse;
 import com.kakaobase.snsapp.domain.follow.entity.Follow;
 import com.kakaobase.snsapp.domain.follow.exception.FollowErrorCode;
 import com.kakaobase.snsapp.domain.follow.exception.FollowException;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -26,10 +29,9 @@ public class FollowService {
     private final MemberRepository memberRepository;
     private final EntityManager entityManager;
 
+
     @Transactional
     public void addFollowing(Long targetUserId, CustomUserDetails userDetails) {
-
-
 
         //팔로잉 신청한 사람
         Member followerUser = memberRepository.findById(Long.valueOf(userDetails.getId()))
@@ -67,5 +69,14 @@ public class FollowService {
         followingUser.decrementFollowerCount();
 
         followRepository.delete(follow);
+    }
+
+
+    public List<FollowResponse.UserInfo> getFollowers(Long userId, Integer limit, Long cursor) {
+        if(!memberRepository.existsById(userId)){
+            throw new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId");
+        }
+
+        return followConverter.toUserInfoList(followRepository.findFollowersByFollowingUserWithCursor(userId, limit, cursor));
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
@@ -79,4 +79,12 @@ public class FollowService {
 
         return followConverter.toUserInfoList(followRepository.findFollowersByFollowingUserWithCursor(userId, limit, cursor));
     }
+
+    public List<FollowResponse.UserInfo> getFollowings(Long userId, Integer limit, Long cursor) {
+        if(!memberRepository.existsById(userId)){
+            throw new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId");
+        }
+
+        return followConverter.toUserInfoList(followRepository.findFollowingsByFollowerUserWithCursor(userId, limit, cursor));
+    }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
@@ -33,8 +33,14 @@ public class FollowService {
     @Transactional
     public void addFollowing(Long targetUserId, CustomUserDetails userDetails) {
 
+        Long currentUserId = Long.valueOf(userDetails.getId());
+
+        if(targetUserId.equals(currentUserId)) {
+            throw new FollowException(GeneralErrorCode.INVALID_FORMAT, "스스로를 팔로잉 할 수 없습니다");
+        }
+
         //팔로잉 신청한 사람
-        Member followerUser = memberRepository.findById(Long.valueOf(userDetails.getId()))
+        Member followerUser = memberRepository.findById(currentUserId)
                 .orElseThrow(()-> new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
 
         //팔로잉 요청 받은 사람

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.members.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 /**
  * 회원 응답 DTO
@@ -55,10 +56,47 @@ public class MemberResponseDto {
             Boolean isFollowing
     ) {}
 
-        @Schema(description = "회원 프로필 수정 DTO")
-        public record ProfileImageChange(
-                @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
-                @JsonProperty("image_url")
-                String profileImageUrl
-        ){}
+    @Schema(description = "회원 프로필 수정 DTO")
+    public record ProfileImageChange(
+            @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
+            @JsonProperty("image_url")
+            String profileImageUrl
+    ){}
+
+    //게시물 생성, 좋아요 유저 목록, 팔로잉&팔로워 유저 목록에 사용
+    @Schema(description = "회원 정보 DTO")
+    @Builder
+    public record UserInfo(
+            @Schema(description = "회원 ID", example = "10")
+            Long id,
+
+            @Schema(description = "회원 이름", example = "홍길동")
+            String name,
+
+            @Schema(description = "회원 닉네임", example = "gildong.hong")
+            String nickname,
+
+            @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
+            @JsonProperty("image_url")
+            String imageUrl
+    ){}
+
+    //게시물 목록 조회, 상세조회에 사용
+    @Schema(description = "팔로우 필드 추가 회원 정보 DTO")
+    @Builder
+    public record UserInfoWithFollowing(
+            @Schema(description = "회원 ID", example = "10")
+            Long id,
+
+            @Schema(description = "회원 닉네임", example = "홍길동")
+            String nickname,
+
+            @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
+            @JsonProperty("image_url")
+            String imageUrl,
+
+            @Schema(description = "팔로우 여부", example = "false")
+            @JsonProperty("is_followed")
+            boolean isFollowed
+    ){}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,9 +44,6 @@ spring:
 
 server:
   forward-headers-strategy: framework
-
-server:
-  forward-headers-strategy: framework
   
 app:
   jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,8 @@ spring:
           timeout: 5000
           writetimeout: 5000
 
+server:
+  forward-headers-strategy: framework
 
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #178

## 📌 개요
- 팔로우/언팔로우 기능을 구현
- 팔로잉/팔로워 목록 조회 기능을 추가
- 게시글 및 댓글 조회 시 작성자와의 팔로우 상태를 함께 반환하도록 기능 추가

## 🔁 변경 사항

### 🆕 새로운 기능
- **Follow Entity 및 도메인 로직 구현**
  - Follow Entity 추가로 팔로우 관계 데이터 모델링
  - 팔로우/언팔로우 요청 처리 비즈니스 로직 구현
  - 자기 자신을 팔로우하지 못하도록 예외 처리 추가

- **Follow API 엔드포인트 추가**
  - `POST /follow` - 팔로우 요청
  - `DELETE /follow` - 언팔로우 요청  
  - `GET /following` - 팔로잉 목록 조회
  - `GET /followers` - 팔로워 목록 조회

- **응답 DTO 및 변환 로직**
  - 팔로잉/팔로워 목록 조회용 응답 DTO 추가
  - Follow 엔티티를 DTO로 변환하는 Converter 메서드 구현
  - 재사용 가능한 User 정보 DTO 추가 및 책임 분리

- **팔로우 상태 통합**
  - 게시글 상세/목록 조회 시 작성자와의 팔로우 여부 표시
  - 댓글/대댓글 조회 시 팔로우 상태 정보 포함
  - 특정 유저의 팔로잉 목록을 ID Set으로 반환하는 메서드 추가

### 🔧 수정 사항
- **데이터 일관성 개선**
  - 프로필 이미지 필드명을 `image_url`로 통일 (기존 `profile_image`와 혼용 해결)
  - 팔로우/언팔로우 시 사용자의 `followCount` 자동 조정
  
- **코드 품질 개선**
  - 중복 주석 및 불필요한 코드 제거
  - yml 파일의 중복 변수 정리
  - 댓글/대댓글 좋아요 관련 미사용 DTO 제거

## 👀 기타 더 이야기해볼 점
- **성능 최적화 고려사항**: Redis 도입 후 Follow 생성을 proxy 객체로 처리하고, 사용자의 follower/followingCount 업데이트를 비동기 방식으로 변경 필요
- **확장성**: 대용량 팔로우 데이터 처리를 위한 페이지네이션 및 캐싱 전략 수립 필요
- **알림 기능**: 팔로우 요청 시 알림 기능 연동 고려

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.