### PR TITLE
Refactor/#138 refreshtoken to jwt

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
@@ -78,20 +78,17 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = AuthResponseDto.RefreshTokenInvalid.class)))
     })
     @PostMapping("/tokens/refresh")
-    public CustomResponse<AuthResponseDto.TokenResponse> refreshToken(
+    public CustomResponse<AuthResponseDto.LoginResponse> refreshToken(
             @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String providedRefreshToken) {
 
         log.info("액세스 토큰 재발급 요청");
 
-        String newAccessToken = authService.getAccessToken(providedRefreshToken);
+        AuthResponseDto.LoginResponse response = authService.getAccessToken(providedRefreshToken);
 
         log.info("액세스 토큰 재발급 성공");
 
         // 새 액세스 토큰을 응답 본문에 포함
-        return CustomResponse.success(
-                "Access Token이 재발급되었습니다.",
-                new AuthResponseDto.TokenResponse(newAccessToken)
-        );
+        return CustomResponse.success("Access Token이 재발급되었습니다.", response);
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
@@ -4,6 +4,8 @@ import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
 import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
 import com.kakaobase.snsapp.domain.auth.entity.AuthToken;
 import com.kakaobase.snsapp.domain.auth.entity.RevokedRefreshToken;
+import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.members.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -81,5 +83,29 @@ public class AuthConverter {
      */
     public AuthResponseDto.TokenResponse toAccessTokenOnlyResponseDto(String accessToken) {
         return new AuthResponseDto.TokenResponse(accessToken);
+    }
+
+    public AuthResponseDto.LoginResponse toLoginResponseDto(CustomUserDetails userDetails, String accessToken) {
+        return AuthResponseDto.LoginResponse
+                .builder()
+                .memberId(Long.valueOf(userDetails.getId()))
+                .nickname(userDetails.getNickname())
+                .className(userDetails.getClassName())
+                .imageUrl(userDetails.getProfileImgUrl())
+                .accessToken(accessToken)
+                .build();
+
+    }
+
+    public AuthResponseDto.LoginResponse toLoginResponseDto(Member member, String accessToken) {
+        return AuthResponseDto.LoginResponse
+                .builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .className(member.getClassName())
+                .imageUrl(member.getProfileImgUrl())
+                .accessToken(accessToken)
+                .build();
+
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 /**
  * 인증 관련 응답 DTO 모음 클래스입니다.
@@ -13,6 +14,7 @@ public class AuthResponseDto {
      * - RefreshToken은 쿠키로 전달됨
      */
     @Schema(description = "로그인 또는 토큰 재발급 성공 응답 DTO")
+    @Builder
     public record LoginResponse(
 
             @Schema(description = "로그인 유저의 memberId", example = "12...")


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #126 

## 📌 개요
- JWT 기반 Refresh Token 구현 계획을 파기하고, AccessToken 재발급 시 사용자 정보 반환 기능만 구현
- 당초 DB 조회 없이 빠른 토큰 발급을 목표로 했으나, 추가 요구사항으로 인해 JWT 방식의 효용성이 감소하여 기존 난수 방식 유지

## 🔁 변경 사항

### ✅ 구현된 기능
- **LoginResponse DTO 개선**: 빌더 패턴을 추가하여 객체 생성의 유연성 향상
- **AuthConverter 확장**: LoginResponse 생성을 담당하는 전용 메서드 추가로 변환 로직 분리
- **AccessToken 재발급 API 개선**: 토큰 재발급 시 사용자 정보(LoginResponse)를 함께 반환하도록 수정
- **비즈니스 로직 강화**: AccessToken 재발급 과정에서 사용자 정보 조회 및 반환 로직 추가

### 🚫 파기된 기능 및 사유
**파기된 기능:**
- JWT 기반 Refresh Token 생성 로직
- `JwtTokenProvider.createToken` 통합 메서드 리팩토링
- `SecurityTokenManager` 내 난수/해싱 메서드 제거
- JWT 기반 Refresh Token 유효성 검증 로직

**파기 사유:**
1. **필연적 DB 조회 발생**: AccessToken 재발급 시 사용자 정보 반환이 필수가 되어, JWT 방식을 사용해도 DB 조회를 피할 수 없어 성능상 이점 소멸
2. **보안 위험도 증가**: JWT 방식 사용 시 Refresh Token을 해싱하지 않아 토큰 탈취 시 위험성 증가
3. **기존 방식의 충분성**: 현재 RDB 기반 토큰 관리 방식으로도 충분하며, 향후 Redis 도입으로 성능 개선 가능
4. **개발 우선순위 조정**: 메인 페이지 조회 기능 및 테스트 코드 구현에 집중하는 것이 더 효율적

### 📁 주요 수정 파일
- `LoginResponse.java` - 빌더 패턴 추가
- `AuthConverter.java` - LoginResponse 생성 메서드 추가  
- `AuthController.java` - AccessToken 재발급 API 응답 수정
- `AuthService.java` - 토큰 재발급 비즈니스 로직 개선

## 👀 기타 더 이야기해볼 점
- 향후 성능 최적화가 필요한 시점에서 Redis 캐싱 도입을 통한 토큰 관리 개선 방안 검토 필요
- 현재 접근 방식이 보안성과 유지보수성 측면에서 더 안전한 선택임을 확인
- JWT Refresh Token의 장점(디버깅 용이성, userId 키값 활용)은 다른 방식으로도 충분히 달성 가능

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.