### PR TITLE
Feat/#188 get mainpage info

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -58,7 +58,7 @@ public class MemberController {
     @GetMapping("/{userId}")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public CustomResponse<MemberResponseDto.Mypage> getUserMyPage(
-            @Parameter(description = "프로필 이미지 수정 요청", required = true)
+            @Parameter(description = "조회할 유저의 id", required = true)
             @PathVariable Long userId
     ) {
         MemberResponseDto.Mypage response = memberService.getMypageInfo(userId);

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -48,6 +48,24 @@ public class MemberController {
         return CustomResponse.success("회원가입이 완료되었습니다.");
     }
 
+    @Operation(summary = "유저 마이페이지 조회", description = "특정 회원의 마이페이지에 필요한 정보를 반환합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 마이페이지 조회에 성공하였습니다",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 되지 않음"),
+            @ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없음")
+    })
+    @GetMapping("/{userId}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public CustomResponse<MemberResponseDto.Mypage> getUserMyPage(
+            @Parameter(description = "프로필 이미지 수정 요청", required = true)
+            @PathVariable Long userId
+    ) {
+        MemberResponseDto.Mypage response = memberService.getMypageInfo(userId);
+
+        return CustomResponse.success("유저 마이페이지 조회에 성공하였습니다", response);
+    }
+
     @Operation(summary = "비밀번호 수정", description = "회원의 비밀번호를 수정합니다")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "비밀번호 수정성공",

--- a/src/main/java/com/kakaobase/snsapp/domain/members/converter/MemberConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/converter/MemberConverter.java
@@ -101,4 +101,21 @@ public class MemberConverter {
                 .imageUrl(member.getProfileImgUrl())
                 .build();
     }
+
+    public MemberResponseDto.Mypage toMypage(Member member, Long postCount, Boolean isMe, boolean isFollowing) {
+        return MemberResponseDto.Mypage
+                .builder()
+                .id(member.getId())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .imageUrl(member.getProfileImgUrl())
+                .className(member.getClassName())
+                .postCount(postCount)
+                .followerCount(member.getFollowerCount())
+                .followingCount(member.getFollowingCount())
+                .isMe(isMe)
+                .isFollowed(isFollowing)
+                .build();
+
+    }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
@@ -98,5 +98,46 @@ public class MemberResponseDto {
             @Schema(description = "팔로우 여부", example = "false")
             @JsonProperty("is_followed")
             boolean isFollowed
+    ) {}
+
+    @Schema(description = "마이페이지 조회 회원 정보 DTO")
+    @Builder
+    public record Mypage(
+            @Schema(description = "회원 ID", example = "10")
+            Long id,
+
+            @Schema(description = "회원 이름", example = "홍길동")
+            String name,
+
+            @Schema(description = "회원 닉네임", example = "gildong.hond")
+            String nickname,
+
+            @Schema(description = "회원 프로필 이미지 URL", example = "https://cdn.service.com/img1.jpg", nullable = true)
+            @JsonProperty("image_url")
+            String imageUrl,
+
+            @Schema(description = "기수명", example = "PANGYO_1")
+            @JsonProperty("class_name")
+            String className,
+
+            @Schema(description = "회원이 작성한 게시글 수", example = "10")
+            @JsonProperty("post_cont")
+            int postCount,
+            
+            @Schema(description = "회원의 팔로워 수", example = "14")
+            @JsonProperty("follower_count")
+            int followerCount,
+
+            @Schema(description = "회원의 팔로잉 수", example = "55")
+            @JsonProperty("following_count")
+            int followingCount,
+
+            @Schema(description = "본인 여부", example = "true")
+            @JsonProperty("is_me")
+            boolean isMe,
+
+            @Schema(description = "팔로우 여부", example = "false")
+            @JsonProperty("is_followed")
+            boolean isFollowed
     ){}
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
@@ -122,15 +122,15 @@ public class MemberResponseDto {
 
             @Schema(description = "회원이 작성한 게시글 수", example = "10")
             @JsonProperty("post_cont")
-            int postCount,
+            Long postCount,
             
             @Schema(description = "회원의 팔로워 수", example = "14")
             @JsonProperty("follower_count")
-            int followerCount,
+            Integer followerCount,
 
             @Schema(description = "회원의 팔로잉 수", example = "55")
             @JsonProperty("following_count")
-            int followingCount,
+            Integer followingCount,
 
             @Schema(description = "본인 여부", example = "true")
             @JsonProperty("is_me")

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -57,6 +57,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 
     /**
+     * 특정 회원이 작성한 게시글 수를 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 회원이 작성한 게시글 수
+     */
+    long countByMemberId(Long memberId);
+
+    /**
      * 게시글 좋아요 수를 증가시킵니다.
      *
      * @param postId 게시글 ID


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #188

## 📌 개요
- 메인페이지 조회 시 회원정보를 반환하는 기능을 구현

## 🔁 변경 사항
- **Controller**: 회원 마이페이지 정보 반환 API 엔드포인트 추가
- **DTO**: 마이페이지 정보 응답을 위한 DTO 구현 및 타입 변경
- **Service**: 마이페이지 정보 조회 비즈니스 로직 구현
- **Repository**: 특정 회원의 게시물 수 반환 메서드 추가
- **Converter**: 응답 DTO 변환 로직 추가

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.