### PR TITLE
[BE - FEAT] 마이페이지 조회시 사용될 게시물 조회 기능 구현

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -5,6 +5,7 @@ import com.kakaobase.snsapp.domain.members.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -81,13 +82,7 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Commen
     @Query("SELECT cl FROM CommentLike cl WHERE cl.member.id = :memberId")
     Page<CommentLike> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
-    /**
-     * 특정 댓글의 모든 좋아요를 삭제합니다.
-     * 댓글 삭제 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
-     *
-     * @param commentId 댓글 ID
-     * @return 삭제된 좋아요 수
-     */
+    @Modifying
     @Query("DELETE FROM CommentLike cl WHERE cl.comment.id = :commentId")
     int deleteByCommentId(@Param("commentId") Long commentId);
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -2,6 +2,7 @@
 package com.kakaobase.snsapp.domain.comments.repository;
 
 import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -56,6 +57,20 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("postId") Long postId,
             @Param("cursor") Long cursor,
             @Param("limit") int limit);
+
+    
+    //특정 유저가 작성한 댓글 조회
+    @Query("SELECT c FROM Comment c " +
+            "JOIN FETCH c.member " +
+            "JOIN FETCH c.post " +
+            "WHERE c.member.id = :memberId " +
+            "AND c.deletedAt IS NULL " +
+            "AND (:cursor IS NULL OR c.id < :cursor) " +
+            "ORDER BY c.createdAt DESC, c.id DESC")
+    List<Comment> findByMemberIdWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            Pageable pageable);
 
     /**
      * 특정 게시글의 댓글 수를 조회합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -5,6 +5,7 @@ import com.kakaobase.snsapp.domain.members.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -98,6 +99,7 @@ public interface RecommentLikeRepository extends JpaRepository<RecommentLike, Re
      * @param recommentIds 대댓글 ID 목록
      * @return 삭제된 좋아요 수
      */
+    @Modifying
     @Query("DELETE FROM RecommentLike rl WHERE rl.recomment.id IN :recommentIds")
     int deleteByRecommentIdIn(@Param("recommentIds") List<Long> recommentIds);
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
@@ -73,7 +73,7 @@ public class BotRecommentService {
             Post post = comment.getPost();
 
             // 2. 게시글 작성자 정보 조회
-            BotRecommentRequestDto.UserInfo postAuthorInfo = memberService.getMemberBotInfo(post.getMemberId());
+            BotRecommentRequestDto.UserInfo postAuthorInfo = memberService.getMemberBotInfo(post.getMember().getId());
 
             // 3. 대댓글 목록 조회 (큰 limit 사용)
             CommentRequestDto.RecommentPageRequest pageRequest =

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
@@ -42,7 +42,7 @@ public class BotRecommentService {
         Member bot = memberRepository.findFirstByRole(Member.Role.BOT)
                 .orElseThrow(() -> new IllegalStateException("소셜봇 계정이 없습니다."));
 
-        Member writer = memberRepository.findById(post.getMemberId())
+        Member writer = memberRepository.findById(post.getMember().getId())
                 .orElseThrow(() -> new IllegalStateException("작성자 조회 실패"));
 
         List<Recomment> recomments = recommentRepository.findByCommentId(comment.getId());

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -103,7 +103,7 @@ public class CommentService {
         CommentCreatedEvent event = new CommentCreatedEvent(
                 savedComment.getId(),
                 postId,
-                post.getMemberId(),  // 게시글 작성자 ID
+                post.getMember().getId(),  // 게시글 작성자 ID
                 memberId,  // 댓글 작성자 ID
                 savedComment.getContent(),
                 savedComment.getCreatedAt()

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -117,7 +117,7 @@ public class CommentService {
         log.debug("댓글 생성 이벤트 발행: {}", event);
 
         // 게시물 작성자가 소셜봇이면 소셜봇 대댓글 로직 구현하도록
-        if (post.getMemberId() == 1213) {
+        if (post.getMember().getId() == 1213) {
             log.info("🤖 [Trigger] 소셜봇 게시글이므로 트리거 실행!");
             botRecommentService.triggerAsync(post, savedComment);
         } else {

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.kakaobase.snsapp.domain.members.controller;
 
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
+import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
+import com.kakaobase.snsapp.domain.comments.service.CommentService;
 import com.kakaobase.snsapp.domain.members.dto.MemberRequestDto;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.service.MemberService;
@@ -37,6 +39,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final PostService postService;
+    private final CommentService commentService;
 
     @Operation(summary = "회원가입", description = "새로운 회원을 등록합니다")
     @ApiResponses(value = {
@@ -86,6 +89,21 @@ public class MemberController {
         Long memberId = Long.valueOf(userDetails.getId());
 
         List<PostResponseDto.PostDetails> response = postService.getUserPostList(limit, cursor, memberId);
+
+        return CustomResponse.success("유저 게시글이조회에 성공하였습니다",response);
+    }
+
+    @GetMapping("/{userId}/comments")
+    @Operation(summary = "유저가 작성한 게시글 목록 조회", description = "유저가 작성한 게시글 목록을 조회합니다.")
+    public CustomResponse<List<CommentResponseDto.CommentInfo>> getUserComments(
+            @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
+            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        Long memberId = Long.valueOf(userDetails.getId());
+
+        List<CommentResponseDto.CommentInfo> response = commentService.getUserCommentList(limit, cursor, memberId);
 
         return CustomResponse.success("유저 게시글이조회에 성공하였습니다",response);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -94,10 +94,10 @@ public class MemberController {
     }
 
     @GetMapping("/{userId}/comments")
-    @Operation(summary = "유저가 작성한 게시글 목록 조회", description = "유저가 작성한 게시글 목록을 조회합니다.")
+    @Operation(summary = "유저가 작성한 댓글 목록 조회", description = "유저가 작성한 댓글 목록을 조회합니다.")
     public CustomResponse<List<CommentResponseDto.CommentInfo>> getUserComments(
-            @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
-            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor,
+            @Parameter(description = "한 페이지에 표시할 댓글 수") @RequestParam(defaultValue = "12") int limit,
+            @Parameter(description = "마지막으로 조회한 댓글 ID") @RequestParam(required = false) Long cursor,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
 
@@ -105,7 +105,22 @@ public class MemberController {
 
         List<CommentResponseDto.CommentInfo> response = commentService.getUserCommentList(limit, cursor, memberId);
 
-        return CustomResponse.success("유저 게시글이조회에 성공하였습니다",response);
+        return CustomResponse.success("유저 댓글 조회에 성공하였습니다",response);
+    }
+
+    @GetMapping("/{userId}/liked-posts")
+    @Operation(summary = "유저가 좋아요한 게시글 목록 조회", description = "유저가 좋아요한 게시글 목록을 조회합니다.")
+    public CustomResponse<List<PostResponseDto.PostDetails>> getLikedPosts(
+            @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
+            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+
+        Long memberId = Long.valueOf(userDetails.getId());
+
+        List<PostResponseDto.PostDetails> response = postService.getLikedPostList(limit, cursor, memberId);
+
+        return CustomResponse.success("좋아요한 게시글 목록이 정상적으로 조회되었습니다",response);
     }
 
     @Operation(summary = "비밀번호 수정", description = "회원의 비밀번호를 수정합니다")

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
@@ -50,7 +50,7 @@ public class PostController {
     @GetMapping("/{postType}")
     @Operation(summary = "게시글 목록 조회", description = "게시판 유형별로 게시글 목록을 조회합니다.")
     @PreAuthorize("@accessChecker.hasAccessToBoard(#postType, authentication.principal)")
-    public ResponseEntity<PostResponseDto.PostListResponse> getPosts(
+    public CustomResponse<List<PostResponseDto.PostDetails>> getPosts(
             @Parameter(description = "게시판 유형") @PathVariable String postType,
             @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
             @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor,
@@ -59,24 +59,24 @@ public class PostController {
 
         Long memberId = Long.valueOf(userDetails.getId());
 
-        PostResponseDto.PostListResponse response = postService.getPostList(postType, limit, cursor, memberId);
+        List<PostResponseDto.PostDetails> response = postService.getPostList(postType, limit, cursor, memberId);
 
-        return ResponseEntity.ok(response);
+        return CustomResponse.success("게시글을 불러오는데 성공하였습니다", response);
     }
 
     @GetMapping("/{postType}/{postId}")
     @Operation(summary = "게시글 상세 조회", description = "게시글의 상세 정보를 조회합니다.")
     @PreAuthorize("@accessChecker.hasAccessToBoard(#postType, authentication.principal)")
-    public ResponseEntity<PostResponseDto.PostDetailResponse> getPostDetail(
+    public CustomResponse<PostResponseDto.PostDetails> getPostDetail(
             @Parameter(description = "게시판 유형") @PathVariable String postType,
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long memberId = Long.valueOf(userDetails.getId());
 
-        PostResponseDto.PostDetailResponse response = postService.getPostDetail(postId, memberId);
+        PostResponseDto.PostDetails response = postService.getPostDetail(postId, memberId);
 
-        return ResponseEntity.ok(response);
+        return CustomResponse.success("게시글 상세 정보를 불러왔습니다.", response);
     }
 
     /**
@@ -85,7 +85,7 @@ public class PostController {
     @PostMapping("/{postType}")
     @Operation(summary = "게시글 생성", description = "새 게시글을 생성합니다.")
     @PreAuthorize("@accessChecker.hasAccessToBoard(#postType, authentication.principal)")
-    public ResponseEntity<PostResponseDto.PostCreateResponse> createPost(
+    public CustomResponse<PostResponseDto.PostDetails> createPost(
             @Parameter(description = "게시판 유형") @PathVariable String postType,
             @Valid @RequestBody PostRequestDto.PostCreateRequestDto requestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -107,18 +107,9 @@ public class PostController {
         Post.BoardType boardType = PostConverter.toBoardType(postType);
 
         // 게시글 생성
-        Post createdPost = postService.createPost(boardType, requestDto, memberId);
+        PostResponseDto.PostDetails response = postService.createPost(boardType, requestDto, memberId);;
 
-        // 작성자 정보 조회
-        Map<String, String> userInfo = postService.getMemberInfo(memberId);
-
-        String ImageUrl = requestDto.image_url();
-
-        // 응답 생성
-        PostResponseDto.PostCreateResponse response = PostConverter.toPostCreateResponse(
-                createdPost, userInfo, ImageUrl,false);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return CustomResponse.success("게시글이 작성되었습니다.", response);
     }
 
     /**
@@ -127,7 +118,7 @@ public class PostController {
     @DeleteMapping("/{postType}/{postId}")
     @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
     @PreAuthorize("@accessChecker.hasAccessToBoard(#postType, authentication.principal) and @accessChecker.isPostOwner(#postId, authentication.principal)")
-    public ResponseEntity<PostResponseDto.PostDeleteResponse> deletePost(
+    public CustomResponse<?> deletePost(
             @Parameter(description = "게시판 유형") @PathVariable String postType,
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -138,10 +129,7 @@ public class PostController {
         // 게시글 삭제
         postService.deletePost(postId, memberId);
 
-        // 응답 생성
-        PostResponseDto.PostDeleteResponse response = PostConverter.toPostDeleteResponse();
-
-        return ResponseEntity.ok(response);
+        return CustomResponse.success("게시글이 삭제되었습니다");
     }
 
     /**
@@ -149,7 +137,7 @@ public class PostController {
      */
     @PostMapping("/{postId}/likes")
     @Operation(summary = "게시글 좋아요 추가", description = "게시글에 좋아요를 추가합니다.")
-    public ResponseEntity<PostResponseDto.PostLikeResponse> addLike(
+    public CustomResponse<?> addLike(
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails
             ) {
@@ -159,10 +147,7 @@ public class PostController {
         // 좋아요 추가
         postLikeService.addLike(postId, memberId);
 
-        // 응답 생성
-        PostResponseDto.PostLikeResponse response = PostConverter.toPostLikeResponse(true);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return CustomResponse.success("좋아요가 성공적으로 등록되었습니다");
     }
 
     /**
@@ -170,7 +155,7 @@ public class PostController {
      */
     @DeleteMapping("/{postId}/likes")
     @Operation(summary = "게시글 좋아요 취소", description = "게시글 좋아요를 취소합니다.")
-    public ResponseEntity<PostResponseDto.PostLikeResponse> removeLike(
+    public CustomResponse<?> removeLike(
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails
             ) {
@@ -180,10 +165,7 @@ public class PostController {
         // 좋아요 취소
         postLikeService.removeLike(postId, memberId);
 
-        // 응답 생성
-        PostResponseDto.PostLikeResponse response = PostConverter.toPostLikeResponse(false);
-
-        return ResponseEntity.ok(response);
+        return CustomResponse.success("좋아요가 성공적으로 취소되었습니다");
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -67,7 +67,7 @@ public class PostConverter {
                 .build();
     }
 
-    private List<PostResponseDto.PostDetails> convertToPostListItems(List<Post> posts, Long currentMemberId) {
+    public List<PostResponseDto.PostDetails> convertToPostListItems(List<Post> posts, Long currentMemberId) {
         if (posts.isEmpty()) {
             return Collections.emptyList();
         }
@@ -114,7 +114,7 @@ public class PostConverter {
     }
 
     public PostResponseDto.PostDetails convertToPostDetail(Post post, Long currentMemberId,
-                                                            Map<Long, String> imageMap,
+                                                            String imageUrl,
                                                             Boolean isLiked,
                                                             Boolean isFollowed) {
         Member member = post.getMember();
@@ -123,7 +123,7 @@ public class PostConverter {
                 post.getId(),
                 convertToUserInfo(member, currentMemberId, isFollowed),
                 post.getContent(),
-                imageMap.get(post.getId()), // 첫 번째 이미지 URL
+                imageUrl, // 첫 번째 이미지 URL
                 post.getYoutubeUrl(),
                 post.getYoutubeSummary(),
                 post.getCreatedAt(),

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -1,54 +1,50 @@
 package com.kakaobase.snsapp.domain.posts.converter;
 
+import com.kakaobase.snsapp.domain.follow.repository.FollowRepository;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.entity.PostImage;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
+import com.kakaobase.snsapp.domain.posts.repository.PostImageRepository;
+import com.kakaobase.snsapp.domain.posts.repository.PostLikeRepository;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * Post 도메인의 Entity와 DTO 간 변환을 담당하는 Converter 클래스
  */
 @Component
+@RequiredArgsConstructor
 public class PostConverter {
 
-    /**
-     * PostListItem 목록을 목록 응답 DTO로 변환합니다.
-     *
-     * @param items 게시글 목록 아이템
-     * @param message 응답 메시지
-     * @return 게시글 목록 응답 DTO
-     */
-    public static PostResponseDto.PostListResponse toPostListResponse(
-            List<PostResponseDto.PostListItem> items,
-            String message) {
-
-        return new PostResponseDto.PostListResponse(message, items);
-    }
+    private final MemberRepository memberRepository;
+    private final PostImageRepository postImageRepository;
+    private final FollowRepository followRepository;
+    private final PostLikeRepository postLikeRepository;
 
     /**
      * 게시글 생성 요청 DTO를 Post 엔티티로 변환합니다.
      *
      * @param requestDto 게시글 생성 요청 DTO
-     * @param memberId 작성자 ID
+     * @param member 작성자 객체
      * @param boardType 게시판 타입
      * @return 생성된 Post 엔티티
      */
     public static Post toPost(
             PostRequestDto.PostCreateRequestDto requestDto,
-            Long memberId,
+            Member member,
             Post.BoardType boardType) {
 
         return Post.builder()
-                .memberId(memberId)
+                .member(member)
                 .boardType(boardType)
                 .content(requestDto.content())
                 .youtubeUrl(requestDto.youtube_url())
@@ -71,173 +67,149 @@ public class PostConverter {
                 .build();
     }
 
-    /**
-     * Post 엔티티를 상세 응답 DTO로 변환합니다.
-     *
-     * @param post 게시글 엔티티
-     * @param userInfo 작성자 정보 (닉네임, 프로필 이미지 등)
-     * @param isMine 본인 게시글 여부
-     * @param isLiked 좋아요 여부
-     * @param isFollowing 작성자 팔로우 여부
-     * @return 게시글 상세 응답 DTO
-     */
-    public static PostResponseDto.PostDetailResponse toPostDetailResponse(
-            Post post,
-            Map<String, String> userInfo,
-            List<PostImage> postImages,
-            boolean isMine,
-            boolean isLiked,
-            boolean isFollowing) {
-
-        // 사용자 정보 생성
-        PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
-                post.getMemberId(),
-                userInfo.get("nickname"),
-                userInfo.get("imageUrl"),
-                isFollowing
-        );
-
-        // 이미지 URL 가져오기 (첫 번째 이미지만 사용)
-        String imageUrl = postImages.isEmpty() ? null : postImages.get(0).getImgUrl();
-
-
-        // 상세 정보 생성
-        PostResponseDto.PostDetail data = new PostResponseDto.PostDetail(
-                post.getId(),
-                user,
-                post.getContent(),
-                imageUrl,
-                post.getYoutubeUrl(),
-                post.getYoutubeSummary(),
-                post.getCreatedAt(),
-                post.getLikeCount(),
-                post.getCommentCount(),
-                isMine,
-                isLiked
-        );
-
-        return new PostResponseDto.PostDetailResponse(
-                "게시글 상세 정보를 불러왔습니다.",
-                data
-        );
-    }
-
-    /**
-     * Post 엔티티를 목록 아이템 DTO로 변환합니다.
-     *
-     * @param post 게시글 엔티티
-     * @param userInfo 작성자 정보
-     * @param isLiked 좋아요 여부
-     * @param isFollowing 팔로우 여부
-     * @param isMine 본인 게시글 여부
-     * @return 게시글 목록 아이템 DTO
-     */
-    public static PostResponseDto.PostListItem toPostListItem(
-            Post post,
-            Map<String, String> userInfo,
-            String imageUrl,
-            boolean isLiked,
-            boolean isFollowing,
-            boolean isMine) {
-
-        // 사용자 정보 없을 경우 예외 처리
-        if (userInfo == null) {
-            throw new IllegalStateException("사용자 정보를 찾을 수 없습니다: " + post.getMemberId());
+    private List<PostResponseDto.PostDetails> convertToPostListItems(List<Post> posts, Long currentMemberId) {
+        if (posts.isEmpty()) {
+            return Collections.emptyList();
         }
 
-        // UserInfo DTO 생성
-        PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
-                post.getMemberId(),
-                userInfo.get("nickname"),
-                userInfo.get("imageUrl"),
-                isFollowing
-        );
+        // 1. ID 추출
+        List<Long> postIds = posts.stream().map(Post::getId).toList();
+        List<Long> memberIds = posts.stream()
+                .map(post -> post.getMember().getId())
+                .distinct()
+                .toList();
 
-        return new PostResponseDto.PostListItem(
+        // 2. 배치로 추가 데이터 조회 (기존 Repository 메서드 활용)
+        Map<Long, String> postImageMap = getFirstImagesByPostIds(postIds);
+        Set<Long> likedPostIds = currentMemberId != null ?
+                getLikedPostIds(currentMemberId, postIds) : Collections.emptySet();
+        Set<Long> followedMemberIds = currentMemberId != null ?
+                getFollowedMemberIds(currentMemberId, memberIds) : Collections.emptySet();
+
+        // 3. 각 Post를 PostListItem으로 변환
+        return posts.stream()
+                .map(post -> convertToPostDetail(post, currentMemberId, postImageMap, likedPostIds, followedMemberIds))
+                .toList();
+    }
+
+    private PostResponseDto.PostDetails convertToPostDetail(Post post, Long currentMemberId,
+                                                            Map<Long, String> imageMap,
+                                                            Set<Long> likedPostIds,
+                                                            Set<Long> followedMemberIds) {
+        Member member = post.getMember();
+
+        return new PostResponseDto.PostDetails(
                 post.getId(),
-                user,
+                convertToUserInfo(member, currentMemberId, followedMemberIds),
                 post.getContent(),
-                imageUrl,
+                imageMap.get(post.getId()), // 첫 번째 이미지 URL
                 post.getYoutubeUrl(),
                 post.getYoutubeSummary(),
                 post.getCreatedAt(),
                 post.getLikeCount(),
                 post.getCommentCount(),
-                isMine,
+                currentMemberId != null && currentMemberId.equals(member.getId()), // isMine
+                likedPostIds.contains(post.getId()) // isLiked
+        );
+    }
+
+    public PostResponseDto.PostDetails convertToPostDetail(Post post, Long currentMemberId,
+                                                            Map<Long, String> imageMap,
+                                                            Boolean isLiked,
+                                                            Boolean isFollowed) {
+        Member member = post.getMember();
+
+        return new PostResponseDto.PostDetails(
+                post.getId(),
+                convertToUserInfo(member, currentMemberId, isFollowed),
+                post.getContent(),
+                imageMap.get(post.getId()), // 첫 번째 이미지 URL
+                post.getYoutubeUrl(),
+                post.getYoutubeSummary(),
+                post.getCreatedAt(),
+                post.getLikeCount(),
+                post.getCommentCount(),
+                currentMemberId != null && currentMemberId.equals(member.getId()), // isMine
                 isLiked
         );
     }
 
     /**
-     * Post 엔티티를 생성 응답 DTO로 변환합니다.
-     *
-     * @param post 생성된 게시글 엔티티
-     * @param userInfo 작성자 정보 (닉네임, 프로필 이미지 등)
-     * @param isFollowing 작성자 팔로우 여부
-     * @return 게시글 생성 응답 DTO
+     * Member를 UserInfoWithFollowing으로 변환
      */
-    public static PostResponseDto.PostCreateResponse toPostCreateResponse(
-            Post post,
-            Map<String, String> userInfo,
-            String imageUrl,
-            boolean isFollowing) {
+    private MemberResponseDto.UserInfoWithFollowing convertToUserInfo(Member member, Long currentMemberId, Set<Long> followedMemberIds) {
+        return MemberResponseDto.UserInfoWithFollowing.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .imageUrl(member.getProfileImgUrl())
+                .isFollowed(currentMemberId != null && followedMemberIds.contains(member.getId()))
+                .build();
+    }
 
-        // 사용자 정보 생성
-        PostResponseDto.UserInfo user = new PostResponseDto.UserInfo(
-                post.getMemberId(),
-                userInfo.get("nickname"),
-                userInfo.get("imageUrl"),
-                isFollowing
-        );
-
-        // 상세 정보 생성
-        PostResponseDto.PostDetail data = new PostResponseDto.PostDetail(
-                post.getId(),
-                user,
-                post.getContent(),
-                imageUrl,
-                post.getYoutubeUrl(),
-                post.getYoutubeSummary(),
-                post.getCreatedAt(),
-                post.getLikeCount(),
-                post.getCommentCount(),
-                true, // 본인 게시글이므로 true
-                false // 생성 시점에는 좋아요를 누르지 않았으므로 false
-        );
-
-        return new PostResponseDto.PostCreateResponse(
-                "게시글이 작성되었습니다.",
-                data
-        );
+    private MemberResponseDto.UserInfoWithFollowing convertToUserInfo(Member member, Long currentMemberId, boolean isFollowed) {
+        return MemberResponseDto.UserInfoWithFollowing.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .imageUrl(member.getProfileImgUrl())
+                .isFollowed(isFollowed)
+                .build();
     }
 
     /**
-     * 게시글 삭제 응답 DTO를 생성합니다.
-     *
-     * @return 게시글 삭제 응답 DTO
+     * 게시글들의 첫 번째 이미지 조회 (기존 PostImageRepository 메서드 활용)
      */
-    public static PostResponseDto.PostDeleteResponse toPostDeleteResponse() {
-        return new PostResponseDto.PostDeleteResponse(
-                "게시글이 삭제되었습니다.",
-                null
-        );
+    private Map<Long, String> getFirstImagesByPostIds(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // 기존 PostImageRepository.findFirstImagesByPostIds() 사용
+        List<PostImage> firstImages = postImageRepository.findFirstImagesByPostIds(postIds);
+
+        return firstImages.stream()
+                .collect(Collectors.toMap(
+                        postImage -> postImage.getPost().getId(),
+                        PostImage::getImgUrl
+                ));
+    }
+
+
+    /**
+     * 현재 회원이 좋아요한 게시글 ID들 조회 (기존 PostLikeRepository 메서드 활용)
+     */
+    private Set<Long> getLikedPostIds(Long memberId, List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        // 기존 PostLikeRepository.findPostIdsByMemberIdAndPostIdIn() 사용
+        List<Long> likedIds = postLikeRepository.findPostIdsByMemberIdAndPostIdIn(memberId, postIds);
+        return new HashSet<>(likedIds);
     }
 
     /**
-     * 게시글 좋아요 응답 DTO를 생성합니다.
-     *
-     * @param isAdd 좋아요 추가 여부 (true: 추가, false: 취소)
-     * @return 게시글 좋아요 응답 DTO
+     * 현재 회원이 팔로우한 회원 ID들 조회 (기존 FollowRepository 메서드 활용)
      */
-    public static PostResponseDto.PostLikeResponse toPostLikeResponse(boolean isAdd) {
-        String message = isAdd
-                ? "좋아요가 성공적으로 등록되었습니다."
-                : "좋아요가 성공적으로 취소되었습니다.";
+    private Set<Long> getFollowedMemberIds(Long currentMemberId, List<Long> memberIds) {
+        if (memberIds.isEmpty()) {
+            return Collections.emptySet();
+        }
 
-        return new PostResponseDto.PostLikeResponse(
-                message,
-                null
-        );
+        // 현재 회원 Entity 조회
+        Member currentMember = memberRepository.findById(currentMemberId)
+                .orElse(null);
+
+        if (currentMember == null) {
+            return Collections.emptySet();
+        }
+
+        // 기존 FollowRepository.findFollowingUserIdsByFollowerUser() 사용
+        Set<Long> allFollowedIds = followRepository.findFollowingUserIdsByFollowerUser(currentMember);
+
+        // memberIds와 교집합만 반환 (성능 최적화)
+        return allFollowedIds.stream()
+                .filter(memberIds::contains)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -259,15 +231,5 @@ public class PostConverter {
         } catch (IllegalArgumentException e) {
             throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "postType");
         }
-    }
-
-    /**
-     * BoardType enum을 문자열 형태의 postType으로 변환합니다.
-     *
-     * @param boardType BoardType enum 값
-     * @return 게시판 타입 문자열
-     */
-    public static String toPostType(Post.BoardType boardType) {
-        return boardType.name().toLowerCase();
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/PostResponseDto.java
@@ -1,93 +1,25 @@
 package com.kakaobase.snsapp.domain.posts.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
 
 /**
  * 게시글 도메인의 응답 DTO를 관리하는 통합 클래스
  */
 public class PostResponseDto {
 
-    /**
-     * 게시글 상세 정보 응답 DTO
-     */
-    @Schema(description = "게시글 상세 정보 응답")
-    public record PostDetailResponse(
-            @Schema(description = "응답 메시지", example = "게시글 상세 정보를 불러왔습니다.")
-            String message,
-
-            @Schema(description = "응답 데이터")
-            PostDetail data
-    ) {}
-
-    @Schema(description = "게시글 상세 정보")
-    public record PostDetail(
-            @Schema(description = "게시글 ID", example = "123")
-            Long id,
-
-            @Schema(description = "작성자 정보")
-            UserInfo user,
-
-            @Schema(description = "게시글 내용", example = "오늘도 Typescript 공부 중입니다.")
-            String content,
-
-            @Schema(description = "이미지 URL", example = "https://s3.../uploads/dev.jpg")
-            @JsonProperty("image_url")
-            String imageUrl,
-
-            @Schema(description = "유튜브 URL", example = "https://www.youtube.com/watch?v=abcd1234")
-            @JsonProperty("youtube_url")
-            String youtubeUrl,
-
-            @Schema(description = "유튜브 요약", example = "이 영상은 타입스크립트의 제네릭에 대해 설명합니다.")
-            @JsonProperty("youtube_summary")
-            String youtubeSummary,
-
-            @Schema(description = "생성 시간", example = "2024-04-23T12:34:56Z")
-            @JsonProperty("created_at")
-            LocalDateTime createdAt,
-
-            @Schema(description = "좋아요 수", example = "5")
-            @JsonProperty("like_count")
-            Integer likeCount,
-
-            @Schema(description = "댓글 수", example = "12")
-            @JsonProperty("comment_count")
-            Integer commentCount,
-
-            @Schema(description = "본인 게시글 여부", example = "true")
-            @JsonProperty("is_mine")
-            Boolean isMine,
-
-            @Schema(description = "좋아요 여부", example = "true")
-            @JsonProperty("is_liked")
-            Boolean isLiked
-    ) {}
-
-    /**
-     * 게시글 목록 조회 응답 DTO
-     */
-    @Schema(description = "게시글 목록 조회 응답")
-    public record PostListResponse(
-            @Schema(description = "응답 메시지", example = "게시글을 불러오는데 성공하였습니다")
-            String message,
-
-            @Schema(description = "게시글 목록 데이터")
-            List<PostListItem> data
-    ) {}
-
     @Schema(description = "게시글 목록 아이템")
-    public record PostListItem(
+    @Builder
+    public record PostDetails(
             @Schema(description = "게시글 ID", example = "123")
             Long id,
 
             @Schema(description = "작성자 정보")
-            UserInfo user,
+            MemberResponseDto.UserInfoWithFollowing user,
 
             @Schema(description = "게시글 내용", example = "이벤트 버블링 헷갈릴 때는...")
             String content,
@@ -123,67 +55,8 @@ public class PostResponseDto {
             @Schema(description = "좋아요 여부", example = "false")
             @JsonProperty("is_liked")
             Boolean isLiked
-
-//            @Schema(description = "좋아요 누른 사용자 목록", example = "[\"backend.sam\", \"choi.dan\"]")
-//            @JsonProperty("who_liked")
-//            List<String> whoLiked
     ) {}
 
-    /**
-     * 사용자 정보 DTO
-     */
-    @Schema(description = "사용자 정보")
-    public record UserInfo(
-            @Schema(description = "사용자 ID", example = "7")
-            Long id,
-
-            @Schema(description = "닉네임", example = "frontend.kim")
-            String nickname,
-
-            @Schema(description = "프로필 이미지 URL", example = "https://s3.../avatar.png")
-            @JsonProperty("image_url")
-            String imageUrl,
-
-            @Schema(description = "팔로우 여부", example = "true")
-            @JsonProperty("is_following")
-            Boolean isFollowing
-    ) {}
-
-    /**
-     * 게시글 생성 응답 DTO
-     */
-    @Schema(description = "게시글 생성 응답")
-    public record PostCreateResponse(
-            @Schema(description = "응답 메시지", example = "게시글이 작성되었습니다.")
-            String message,
-
-            @Schema(description = "생성된 게시글 정보")
-            PostDetail data
-    ) {}
-
-    /**
-     * 게시글 삭제 응답 DTO
-     */
-    @Schema(description = "게시글 삭제 응답")
-    public record PostDeleteResponse(
-            @Schema(description = "응답 메시지", example = "게시글이 삭제되었습니다.")
-            String message,
-
-            @Schema(description = "데이터", example = "null")
-            Object data
-    ) {}
-
-    /**
-     * 게시글 좋아요 응답 DTO
-     */
-    @Schema(description = "게시글 좋아요 응답")
-    public record PostLikeResponse(
-            @Schema(description = "응답 메시지", example = "좋아요가 성공적으로 등록되었습니다.")
-            String message,
-
-            @Schema(description = "데이터", example = "null")
-            Object data
-    ) {}
 
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.entity;
 
+import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -37,8 +38,9 @@ public class Post extends BaseSoftDeletableEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "board_type", nullable = false, length = 20)
     @Enumerated(EnumType.STRING)
@@ -61,8 +63,8 @@ public class Post extends BaseSoftDeletableEntity {
 
 
     @Builder
-    public Post(Long memberId, BoardType boardType, String content, String youtubeUrl) {
-        this.memberId = memberId;
+    public Post(Member member, BoardType boardType, String content, String youtubeUrl) {
+        this.member = member;
         this.boardType = boardType;
         this.content = content;
         this.youtubeUrl = youtubeUrl;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -20,35 +20,6 @@ import java.util.Optional;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    /**
-     * 특정 회원이 작성한 게시글을 최신순으로 조회합니다.
-     *
-     * @param memberId 회원 ID
-     * @param pageable 페이지네이션 정보
-     * @return 회원이 작성한 게시글 목록 (페이지네이션 적용)
-     */
-    Page<Post> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
-
-    /**
-     * 특정 회원이 작성한 특정 게시판의 게시글을 최신순으로 조회합니다.
-     *
-     * @param memberId 회원 ID
-     * @param boardType 게시판 타입
-     * @param pageable 페이지네이션 정보
-     * @return 회원이 작성한 특정 게시판의 게시글 목록 (페이지네이션 적용)
-     */
-    Page<Post> findByMemberIdAndBoardTypeOrderByCreatedAtDesc(
-            Long memberId, Post.BoardType boardType, Pageable pageable);
-
-    /**
-     * 특정 게시판의 게시글을 최신순으로 조회합니다.
-     *
-     * @param boardType 게시판 타입
-     * @param pageable 페이지네이션 정보
-     * @return 특정 게시판의 게시글 목록 (페이지네이션 적용)
-     */
-    Page<Post> findByBoardTypeOrderByCreatedAtDesc(Post.BoardType boardType, Pageable pageable);
-
 
     /**
      * 특정 게시글이 특정 사용자가 작성했는지 확인
@@ -64,65 +35,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      */
     long countByMemberId(Long memberId);
 
-    /**
-     * 게시글 좋아요 수를 증가시킵니다.
-     *
-     * @param postId 게시글 ID
-     */
-    @Modifying
-    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :postId")
-    void increaseLikeCount(@Param("postId") Long postId);
-
-    /**
-     * 게시글 좋아요 수를 감소시킵니다.
-     *
-     * @param postId 게시글 ID
-     */
-    @Modifying
-    @Query("UPDATE Post p SET p.likeCount = CASE WHEN p.likeCount > 0 THEN p.likeCount - 1 ELSE 0 END WHERE p.id = :postId")
-    void decreaseLikeCount(@Param("postId") Long postId);
-
-    /**
-     * 게시글 댓글 수를 증가시킵니다.
-     *
-     * @param postId 게시글 ID
-     */
-    @Modifying
-    @Query("UPDATE Post p SET p.commentCount = p.commentCount + 1 WHERE p.id = :postId")
-    void increaseCommentCount(@Param("postId") Long postId);
-
-    /**
-     * 게시글 댓글 수를 감소시킵니다.
-     *
-     * @param postId 게시글 ID
-     */
-    @Modifying
-    @Query("UPDATE Post p SET p.commentCount = CASE WHEN p.commentCount > 0 THEN p.commentCount - 1 ELSE 0 END WHERE p.id = :postId")
-    void decreaseCommentCount(@Param("postId") Long postId);
-
-    /**
-     * 제목이나 내용에 특정 키워드가 포함된 게시글을 검색합니다.
-     *
-     * @param keyword 검색 키워드
-     * @param pageable 페이지네이션 정보
-     * @return 검색 결과 게시글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT p FROM Post p WHERE p.content LIKE %:keyword%")
-    Page<Post> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
-
-    /**
-     * 특정 게시판에서 제목이나 내용에 특정 키워드가 포함된 게시글을 검색합니다.
-     *
-     * @param boardType 게시판 타입
-     * @param keyword 검색 키워드
-     * @param pageable 페이지네이션 정보
-     * @return 검색 결과 게시글 목록 (페이지네이션 적용)
-     */
-    @Query("SELECT p FROM Post p WHERE p.boardType = :boardType AND p.content LIKE %:keyword%")
-    Page<Post> searchByBoardTypeAndKeyword(
-            @Param("boardType") Post.BoardType boardType,
-            @Param("keyword") String keyword,
-            Pageable pageable);
 
     /**
      * 특정 게시판의 최신 게시글을 생성일시와 ID 기준으로 내림차순 정렬하여 조회합니다.
@@ -132,16 +44,41 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      * @return 최신 게시글 목록
      */
     @Query(value = "SELECT p FROM Post p WHERE p.boardType = :boardType AND p.deletedAt IS NULL ORDER BY p.createdAt DESC, p.id DESC LIMIT :limit")
-    List<Post> findTopNByBoardTypeOrderByCreatedAtDescIdDesc(@Param("boardType") Post.BoardType boardType, @Param("limit") int limit);
+    List<Post> findTopNByBoardTypeOrderByCreatedAtDescIdDesc(
+            @Param("boardType") Post.BoardType boardType,
+            @Param("limit") int limit);
 
     /**
-     * 특정 게시판에서 주어진 ID보다 작은 게시글을 ID 기준으로 내림차순 정렬하여 조회합니다.
-     *
-     * @param boardType 게시판 유형
-     * @param cursor 마지막으로 조회한 게시글 ID
-     * @param limit 조회할 게시글 수
-     * @return 다음 페이지 게시글 목록
+     * 특정 게시판 타입에서 cursor 기반으로 게시글 목록을 조회합니다.
+     * 최신 게시글부터 내림차순으로 정렬되며, cursor보다 작은 id를 가진 게시글을 조회합니다.
      */
-    @Query(value = "SELECT p FROM Post p WHERE p.boardType = :boardType AND p.id < :cursor AND p.deletedAt IS NULL ORDER BY p.id DESC LIMIT :limit")
-    List<Post> findByBoardTypeAndIdLessThanOrderByIdDesc(@Param("boardType") Post.BoardType boardType, @Param("cursor") Long cursor, @Param("limit") int limit);
+    @Query(value = "SELECT p.* FROM posts p " +
+            "WHERE p.board_type = :boardType " +
+            "AND p.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR p.id < :cursor) " +
+            "ORDER BY p.created_at DESC, p.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Post> findByBoardTypeWithCursor(
+            @Param("boardType") String boardType,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+    /**
+     * 특정 회원의 게시글을 cursor 기반으로 조회합니다.
+     * 최신 게시글부터 내림차순으로 정렬되며, cursor보다 작은 id를 가진 게시글을 조회합니다.
+     */
+    @Query(value = "SELECT p.* FROM posts p " +
+            "WHERE p.member_id = :memberId " +
+            "AND p.deleted_at IS NULL " +
+            "AND (:cursor IS NULL OR p.id < :cursor) " +
+            "ORDER BY p.created_at DESC, p.id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Post> findByMemberIdWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            @Param("limit") int limit);
+
+
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -66,17 +66,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      * 특정 회원의 게시글을 cursor 기반으로 조회합니다.
      * 최신 게시글부터 내림차순으로 정렬되며, cursor보다 작은 id를 가진 게시글을 조회합니다.
      */
-    @Query(value = "SELECT p.* FROM posts p " +
-            "WHERE p.member_id = :memberId " +
-            "AND p.deleted_at IS NULL " +
+    @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.member " +
+            "WHERE p.member.id = :memberId " +
             "AND (:cursor IS NULL OR p.id < :cursor) " +
-            "ORDER BY p.created_at DESC, p.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
+            "ORDER BY p.createdAt DESC, p.id DESC")
     List<Post> findByMemberIdWithCursor(
             @Param("memberId") Long memberId,
             @Param("cursor") Long cursor,
-            @Param("limit") int limit);
-
-
+            Pageable pageable);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -55,6 +55,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p " +
             "JOIN FETCH p.member " +  // JPA 연관관계 활용
             "WHERE p.boardType = :boardType " +
+            "AND p.deletedAt IS NULL " +
             "AND (:cursor IS NULL OR p.id < :cursor) " +
             "ORDER BY p.createdAt DESC, p.id DESC")
     List<Post> findByBoardTypeWithCursor(
@@ -69,6 +70,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p " +
             "JOIN FETCH p.member " +
             "WHERE p.member.id = :memberId " +
+            "AND p.deletedAt IS NULL " +
             "AND (:cursor IS NULL OR p.id < :cursor) " +
             "ORDER BY p.createdAt DESC, p.id DESC")
     List<Post> findByMemberIdWithCursor(

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -77,4 +77,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("memberId") Long memberId,
             @Param("cursor") Long cursor,
             Pageable pageable);
+
+    /**
+     * 특정 유저가 좋아요한 게시글을 조회
+     */
+    @Query("SELECT p FROM Post p " +
+            "WHERE EXISTS (SELECT 1 FROM PostLike pl WHERE pl.id.memberId = :memberId AND pl.id.postId = p.id) " +
+            "AND p.deletedAt IS NULL " +
+            "AND (:cursor IS NULL OR p.id < :cursor) " +
+            "ORDER BY p.createdAt DESC, p.id DESC")
+    List<Post> findLikedPostsByMemberIdWithCursor(
+            @Param("memberId") Long memberId,
+            @Param("cursor") Long cursor,
+            Pageable pageable);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -52,17 +52,15 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      * 특정 게시판 타입에서 cursor 기반으로 게시글 목록을 조회합니다.
      * 최신 게시글부터 내림차순으로 정렬되며, cursor보다 작은 id를 가진 게시글을 조회합니다.
      */
-    @Query(value = "SELECT p.* FROM posts p " +
-            "WHERE p.board_type = :boardType " +
-            "AND p.deleted_at IS NULL " +
+    @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.member " +  // JPA 연관관계 활용
+            "WHERE p.boardType = :boardType " +
             "AND (:cursor IS NULL OR p.id < :cursor) " +
-            "ORDER BY p.created_at DESC, p.id DESC " +
-            "LIMIT :limit",
-            nativeQuery = true)
+            "ORDER BY p.createdAt DESC, p.id DESC")
     List<Post> findByBoardTypeWithCursor(
-            @Param("boardType") String boardType,
+            @Param("boardType") Post.BoardType boardType,
             @Param("cursor") Long cursor,
-            @Param("limit") int limit);
+            Pageable pageable);
 
     /**
      * 특정 회원의 게시글을 cursor 기반으로 조회합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -7,10 +7,14 @@ import com.kakaobase.snsapp.domain.posts.dto.BotRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
 import com.kakaobase.snsapp.global.common.constant.BotConstants;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -31,8 +35,11 @@ import java.util.stream.Collectors;
 public class BotPostService {
 
     private final PostService postService;
+    private final PostRepository postRepository;
     private final WebClient webClient;
     private final MemberRepository memberRepository;
+    private final EntityManager em;
+    private final PostConverter postConverter;
 
     @Value("${ai.server.url}")
     private String aiServerUrl;
@@ -43,77 +50,101 @@ public class BotPostService {
      * <p>최근 5개 게시글을 기반으로 AI 서버에 요청하여 봇 게시글을 생성합니다.</p>
      *
      * @param boardType 게시판 타입
-     * @return 생성된 봇 게시글 응답 (null일 수 있음)
      */
     @Transactional
-    public PostResponseDto.PostCreateResponse createBotPost(Post.BoardType boardType) {
+    public void createBotPost(Post.BoardType boardType) {
         try {
             log.info("봇 게시글 생성 시작 - boardType: {}", boardType);
 
             // 1. 최근 게시글 조회 (봇 게시글 필터링을 위해 여유있게 10개 조회)
-            List<Post> recentPosts = postService.findByCursor(boardType, 10, null);
+            List<Post> recentPosts = findRecentPosts(boardType, 10);
             log.info("조회된 최근 게시글 수: {}", recentPosts.size());
 
-            // ArrayList로 초기화 (최종 반환 타입은 List 인터페이스)
-            List<Post> filteredPosts = new ArrayList<>();
-
-            // 봇이 작성하지 않은 게시글만 필터링
-            int botPostCount = 0;
-            for (Post post : recentPosts) {
-                if (!post.getMemberId().equals(BotConstants.BOT_MEMBER_ID)) {
-                    filteredPosts.add(post);
-                    log.debug("일반 게시글 추가: id={}, content={}, createdAt={}",
-                            post.getId(), post.getContent(), post.getCreatedAt());
-
-
-                    if (filteredPosts.size() == 5) {
-                        log.info("5개의 일반 게시글 필터링 완료. 반복 중단");
-                        break;
-                    }
-                } else {
-                    botPostCount++;
-                    log.debug("봇 게시글 필터링 제외: id={}, content={}", post.getId(), post.getContent());
-                }
-            }
-
-            log.info("필터링 결과 - 총 게시글: {}, 봇 게시글: {}, 일반 게시글: {}",
-                    recentPosts.size(), botPostCount, filteredPosts.size());
-
+            // 2. 봇이 작성하지 않은 게시글만 필터링하여 5개 선택
+            List<Post> filteredPosts = filterNonBotPosts(recentPosts);
 
             if (filteredPosts.size() < 5) {
                 log.warn("게시글이 5개 미만입니다. 봇 게시글 생성을 건너뜁니다. - count: {}", filteredPosts.size());
-                return null;
+                return;
             }
 
+            // 3. 오래된 순으로 정렬
             Collections.reverse(filteredPosts);
+            logFilteredPosts(filteredPosts);
 
-            log.debug("역순 정렬 후 게시글 순서(오래된순):");
-            for (int i = 0; i < filteredPosts.size(); i++) {
-                Post post = filteredPosts.get(i);
-                log.debug("  {}. id={}, content={}, createdAt={}",
-                        i+1, post.getId(), post.getContent(), post.getCreatedAt());
-            }
-
-            log.info("AI에게 전송할 5개 게시글 준비 완료 (오래된순)");
-
-
-            // 2. AI 서버 요청 DTO 생성
+            // 4. AI 서버 요청 DTO 생성
             BotRequestDto.CreatePostRequest request = createBotRequest(boardType, filteredPosts);
 
-            // 3. AI 서버 호출
+            // 5. AI 서버 호출
             BotRequestDto.AiPostResponse aiResponse = callAiServer(request);
 
-            // 4. 봇 게시글 저장 및 클라이언트 응답 생성
-            PostResponseDto.PostCreateResponse clientResponse = saveBotPost(aiResponse);
+            // 6. 봇 게시글 저장
+            saveBotPost(aiResponse);
 
             log.info("봇 게시글 생성 완료 - boardType: {}", boardType);
-            return clientResponse;
 
         } catch (Exception e) {
             log.error("봇 게시글 생성 실패 - boardType: {}", boardType, e);
-            // 실패해도 카운터는 리셋되어야 하므로 예외를 전파하지 않음
-            return null;
         }
+    }
+
+    /**
+     * 최근 게시글을 조회합니다.
+     *
+     * @param boardType 게시판 타입
+     * @param limit 조회할 게시글 수
+     * @return 최근 게시글 목록
+     */
+    private List<Post> findRecentPosts(Post.BoardType boardType, int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        return postRepository.findByBoardTypeWithCursor(boardType, null, pageable);
+    }
+
+    /**
+     * 봇이 작성하지 않은 게시글만 필터링합니다.
+     *
+     * @param recentPosts 최근 게시글 목록
+     * @return 필터링된 게시글 목록 (최대 5개)
+     */
+    private List<Post> filterNonBotPosts(List<Post> recentPosts) {
+        List<Post> filteredPosts = new ArrayList<>();
+        int botPostCount = 0;
+
+        for (Post post : recentPosts) {
+            if (!post.getMember().getId().equals(BotConstants.BOT_MEMBER_ID)) {
+                filteredPosts.add(post);
+                log.debug("일반 게시글 추가: id={}, content={}, createdAt={}",
+                        post.getId(), post.getContent(), post.getCreatedAt());
+
+                if (filteredPosts.size() == 5) {
+                    log.info("5개의 일반 게시글 필터링 완료. 반복 중단");
+                    break;
+                }
+            } else {
+                botPostCount++;
+                log.debug("봇 게시글 필터링 제외: id={}, content={}", post.getId(), post.getContent());
+            }
+        }
+
+        log.info("필터링 결과 - 총 게시글: {}, 봇 게시글: {}, 일반 게시글: {}",
+                recentPosts.size(), botPostCount, filteredPosts.size());
+
+        return filteredPosts;
+    }
+
+    /**
+     * 필터링된 게시글 목록을 로깅합니다.
+     *
+     * @param filteredPosts 필터링된 게시글 목록
+     */
+    private void logFilteredPosts(List<Post> filteredPosts) {
+        log.debug("역순 정렬 후 게시글 순서(오래된순):");
+        for (int i = 0; i < filteredPosts.size(); i++) {
+            Post post = filteredPosts.get(i);
+            log.debug("  {}. id={}, content={}, createdAt={}",
+                    i + 1, post.getId(), post.getContent(), post.getCreatedAt());
+        }
+        log.info("AI에게 전송할 5개 게시글 준비 완료 (오래된순)");
     }
 
     /**
@@ -125,18 +156,16 @@ public class BotPostService {
      */
     private BotRequestDto.CreatePostRequest createBotRequest(Post.BoardType boardType, List<Post> posts) {
         // 게시글 작성자들의 정보를 한 번에 조회
-        Map<Long, Map<String, String>> memberInfoMap = postService.getMemberInfoByPosts(posts);
+        Map<Long, Map<String, String>> memberInfoMap = getMemberInfoByPosts(posts);
 
         List<BotRequestDto.PostDto> botPosts = posts.stream()
                 .map(post -> {
-                    Map<String, String> memberInfo = memberInfoMap.get(post.getMemberId());
+                    Map<String, String> memberInfo = memberInfoMap.get(post.getMember().getId());
                     if (memberInfo == null) {
-                        throw new IllegalStateException("회원 정보를 찾을 수 없습니다. memberId: " + post.getMemberId());
+                        throw new IllegalStateException("회원 정보를 찾을 수 없습니다. memberId: " + post.getMember().getId());
                     }
 
-
-                    Optional<Member> member = memberRepository.findById(post.getMemberId());
-                    String className  = member.get().getClassName();
+                    String className = post.getMember().getClassName();
                     log.debug("게시글 작성자 정보: {}, {}", memberInfo.get("nickname"), className);
 
                     return new BotRequestDto.PostDto(
@@ -151,6 +180,24 @@ public class BotPostService {
                 .collect(Collectors.toList());
 
         return new BotRequestDto.CreatePostRequest(boardType.name(), botPosts);
+    }
+
+    /**
+     * 게시글 목록으로부터 작성자들의 정보를 조회합니다.
+     *
+     * @param posts 게시글 목록
+     * @return 회원 ID를 키로 하는 회원 정보 맵
+     */
+    private Map<Long, Map<String, String>> getMemberInfoByPosts(List<Post> posts) {
+        Set<Long> memberIds = posts.stream()
+                .map(post -> post.getMember().getId())
+                .collect(Collectors.toSet());
+
+        return memberIds.stream()
+                .collect(Collectors.toMap(
+                        memberId -> memberId,
+                        postService::getMemberInfo
+                ));
     }
 
     /**
@@ -177,15 +224,14 @@ public class BotPostService {
      * 봇 게시글 저장
      *
      * @param aiResponse AI 서버 응답
-     * @return 게시글 생성 응답 DTO
      */
-    private PostResponseDto.PostCreateResponse saveBotPost(BotRequestDto.AiPostResponse aiResponse) {
+    private void saveBotPost(BotRequestDto.AiPostResponse aiResponse) {
         BotRequestDto.AiResponseData data = aiResponse.data();
 
         PostRequestDto.PostCreateRequestDto requestDto = new PostRequestDto.PostCreateRequestDto(
                 data.content(),
-                null,
-                null
+                null,  // image_url
+                null   // youtube_url
         );
 
         // AI 응답 데이터를 사용하여 게시글 생성
@@ -197,14 +243,7 @@ public class BotPostService {
             throw new RuntimeException("잘못된 게시판 타입", e);
         }
 
-
-        // PostService를 통해 게시글 생성
-        Post socialBotPost = postService.createPost(boardType, requestDto, BotConstants.BOT_MEMBER_ID);
-
-        // 봇 멤버 정보 조회
-        Map<String, String> botMemberInfo = postService.getMemberInfo(BotConstants.BOT_MEMBER_ID);
-
-        // PostConverter를 사용하여 응답 생성
-        return PostConverter.toPostCreateResponse(socialBotPost, botMemberInfo, null, false);
+        // PostService를 통해 게시글 생성 (PostResponseDto.PostDetails 반환)
+        postService.createPost(boardType, requestDto, BotConstants.BOT_MEMBER_ID);
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
@@ -56,14 +56,13 @@ public class PostLikeService {
         }
 
         Member proxyMember = em.getReference(Member.class, memberId);
-        Post proxyPost = em.getReference(Post.class, postId);
 
         // 좋아요 엔티티 생성 및 저장
-        PostLike postLike = new PostLike(proxyMember, proxyPost);
+        PostLike postLike = new PostLike(proxyMember, post);
         postLikeRepository.save(postLike);
 
         // 게시글 좋아요 수 증가
-        postRepository.increaseLikeCount(postId);
+        post.increaseLikeCount();
 
         log.info("게시글 좋아요 추가 완료: 게시글 ID={}, 회원 ID={}", postId, memberId);
     }
@@ -89,7 +88,7 @@ public class PostLikeService {
         postLikeRepository.delete(postLike);
 
         // 게시글 좋아요 수 감소
-        postRepository.decreaseLikeCount(postId);
+        post.decreaseLikeCount();
 
         log.info("게시글 좋아요 취소 완료: 게시글 ID={}, 회원 ID={}", postId, memberId);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -190,6 +190,9 @@ public class PostService {
         return reponse;
     }
 
+    /**
+     * 유저가 작성한 게시글 조회
+     */
     public List<PostResponseDto.PostDetails> getUserPostList(int limit, Long cursor, Long currentMemberId) {
         // 1. 유효성 검증
         if (limit < 1) {
@@ -208,6 +211,23 @@ public class PostService {
 
     }
 
+    public List<PostResponseDto.PostDetails> getLikedPostList(int limit, Long cursor, Long currentMemberId) {
+        // 1. 유효성 검증
+        if (limit < 1) {
+            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
+        }
+
+        Pageable pageable = PageRequest.of(0, limit);
+
+        // 3. 게시글 조회
+        List<Post> posts = postRepository.findLikedPostsByMemberIdWithCursor(currentMemberId, cursor, pageable);
+
+        // 3. PostListItem으로 변환
+        List<PostResponseDto.PostDetails> reponse = postConverter.convertToPostListItems(posts, currentMemberId);
+
+        return reponse;
+    }
+
     /**
      * 회원 ID로 회원 정보를 조회합니다.
      *
@@ -217,7 +237,6 @@ public class PostService {
     public Map<String, String> getMemberInfo(Long memberId) {
         return memberService.getMemberInfo(memberId);
     }
-
 
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -190,6 +190,24 @@ public class PostService {
         return reponse;
     }
 
+    public List<PostResponseDto.PostDetails> getUserPostList(int limit, Long cursor, Long currentMemberId) {
+        // 1. 유효성 검증
+        if (limit < 1) {
+            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
+        }
+
+        Pageable pageable = PageRequest.of(0, limit);
+
+        // 3. 게시글 조회
+        List<Post> posts = postRepository.findByMemberIdWithCursor(currentMemberId, cursor, pageable);
+
+        // 3. PostListItem으로 변환
+        List<PostResponseDto.PostDetails> reponse = postConverter.convertToPostListItems(posts, currentMemberId);
+
+        return reponse;
+
+    }
+
     /**
      * 회원 ID로 회원 정보를 조회합니다.
      *

--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -94,7 +94,7 @@ public class AccessChecker {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND,"postId"));
 
-        if(!post.getMemberId().equals(memberId)) {
+        if(!post.getMember().getId().equals(memberId)) {
             throw new CustomException(GeneralErrorCode.FORBIDDEN);
         }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [X] 기능 추가
- [x] 버그 수정
- [X] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #192 

## 📌 개요
- Post 엔티티의 객체 그래프 구조 개선 및 Service 계층 리팩토링
- 마이페이지에서 사용자의 활동 내역 조회 기능 구현 (작성 게시글, 작성 댓글, 좋아요한 게시글)
- 불필요한 DTO 및 메서드 정리를 통한 코드 최적화
- 댓글 삭제시 에러문제 해결

## 🔁 변경 사항

### 🔧 **리팩토링**
[[[REFACTOR] MemberId를 생성자로 받는것에서 Member객체 자체를 받도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/304c2ad)](https://github.com/100-hours-a-week/22-tenten-be/commit/304c2ad)
[[[REFACTOR] 변경된 Post에 맞게 Service로직 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/3baca1d)](https://github.com/100-hours-a-week/22-tenten-be/commit/3baca1d)
[[[REMOVE] 객체 정보수정로직은 Entity메서드 사용을 위해 관련 메서드, 사용되지 않는 메서드 삭제](https://github.com/100-hours-a-week/22-tenten-be/commit/de5d207)](https://github.com/100-hours-a-week/22-tenten-be/commit/de5d207)
[[[REMOVE] 객체 정보수정로직은 Entity메서드 사용하도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/3cc0464)](https://github.com/100-hours-a-week/22-tenten-be/commit/3cc0464)
[[[REMOVE] 응답 dto를 필수적인 요소만 남기고 삭제](https://github.com/100-hours-a-week/22-tenten-be/commit/bf97091)](https://github.com/100-hours-a-week/22-tenten-be/commit/bf97091)
[[[REFATCOR] 응답 dto를 생성하는 Converter메서드 구현, 기존로직 삭제](https://github.com/100-hours-a-week/22-tenten-be/commit/e597336)](https://github.com/100-hours-a-week/22-tenten-be/commit/e597336)
[[[REFATCOR] 기존 findByBoardTypeWithCursor를 JPQL을 사용하도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/3ead351)](https://github.com/100-hours-a-week/22-tenten-be/commit/3ead351)
[[[REFACTOR] Controller의 응답을 ResponseEntity가 아닌 CustomResponse로 응답하도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/80b9427)](https://github.com/100-hours-a-week/22-tenten-be/commit/80b9427)
[[[REFACTOR] 변경된 PostEntity에 맞게 메서드 수정, 필요없는 메서드 제거](https://github.com/100-hours-a-week/22-tenten-be/commit/934fe6a)](https://github.com/100-hours-a-week/22-tenten-be/commit/934fe6a)
[[[REFACTOR] 변경된 PostEntity와 PostService에 맞게 메서드 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/65be300)](https://github.com/100-hours-a-week/22-tenten-be/commit/65be300)

### ✨ **신규 기능**
[[[FEAT] 특정 회원의 게시글 조회 api구현](https://github.com/100-hours-a-week/22-tenten-be/commit/3d43e7a)](https://github.com/100-hours-a-week/22-tenten-be/commit/3d43e7a)
[[[FEAT] 특정 회원의 게시글 조회 메서드 구현](https://github.com/100-hours-a-week/22-tenten-be/commit/d01cfb1)](https://github.com/100-hours-a-week/22-tenten-be/commit/d01cfb1)
[[[FEAT] Service계층에 특정 회원의 게시글 조회 비즈니스 로직 구현](https://github.com/100-hours-a-week/22-tenten-be/commit/e41dc60)](https://github.com/100-hours-a-week/22-tenten-be/commit/e41dc60)
[[[FEAT] 특정 유저가 작성한 댓글 조회 메서드 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/6324ac1)](https://github.com/100-hours-a-week/22-tenten-be/commit/6324ac1)
[[[FEAT] 특정 유저가 작성한 댓글 조회 api추가](https://github.com/100-hours-a-week/22-tenten-be/commit/80945bf)](https://github.com/100-hours-a-week/22-tenten-be/commit/80945bf)
[[[FEAT] Service 계층의 특정 유저가 작성한 댓글 조회 비즈니스 로직 구현](https://github.com/100-hours-a-week/22-tenten-be/commit/f03f23a)](https://github.com/100-hours-a-week/22-tenten-be/commit/f03f23a)
[[[FEAT] 회원이 좋아요누른 게시글 조회 api추가](https://github.com/100-hours-a-week/22-tenten-be/commit/dc12123)](https://github.com/100-hours-a-week/22-tenten-be/commit/dc12123)
[[[FEAT] Repository에 회원이 좋아요누른 게시글 조회 메서드 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/bd47ce7)](https://github.com/100-hours-a-week/22-tenten-be/commit/bd47ce7)
[[[FEAT] Service계층에 회원이 좋아요누른 게시글 조회 비즈니스 로직 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/5888cb1)](https://github.com/100-hours-a-week/22-tenten-be/commit/5888cb1)

### 🐛 **버그 수정**
[[[FIX] PostDetails메서드를 public으로 변경](https://github.com/100-hours-a-week/22-tenten-be/commit/16a7e94)](https://github.com/100-hours-a-week/22-tenten-be/commit/16a7e94)
[[[FIX] 게시글 조회에 삭제된 게시글은 제외하는 기능 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/445ebff)](https://github.com/100-hours-a-week/22-tenten-be/commit/445ebff)
[[[FIX] 댓글 삭제시 댓글과 관련된 좋아요 삭제 메서드에 @Modifying추가](https://github.com/100-hours-a-week/22-tenten-be/commit/cbdf3e0)](https://github.com/100-hours-a-week/22-tenten-be/commit/cbdf3e0)
[[[REFACTOR] 소셜봇 대댓글 기능 구현PR 병합](https://github.com/100-hours-a-week/22-tenten-be/commit/6ea2d32)](https://github.com/100-hours-a-week/22-tenten-be/commit/6ea2d32)
[[[FIX] 소셜봇 대댓글 기능 메서드가 바뀐 Post Entity에 맞도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/latest)](https://github.com/100-hours-a-week/22-tenten-be/commit/latest)

## 🎯 주요 변경 내용

### **1. Post 엔티티 객체 그래프 개선**
- Member ID를 직접 받는 방식에서 Member 객체 자체를 받도록 변경
- JPA 연관관계 매핑을 통한 객체지향적 설계 개선
- N+1 문제 방지를 위한 JOIN FETCH 적용

### **2. Service 계층 리팩토링**
- 변경된 Post 엔티티에 맞는 비즈니스 로직 수정
- 엔티티 자체 메서드 활용으로 응집도 향상
- 불필요한 메서드 제거 및 코드 최적화

### **3. 마이페이지 기능 구현**
- **작성 게시글 조회**: 사용자가 작성한 게시글 목록 조회 (커서 기반 페이징)
- **작성 댓글 조회**: 사용자가 작성한 댓글 목록 조회 (커서 기반 페이징)
- **좋아요한 게시글 조회**: 사용자가 좋아요한 게시글 목록 조회 (커서 기반 페이징)

### **4. JPQL 최적화**
- 기존 QueryDSL에서 JPQL로 변경하여 성능 최적화
- EXISTS 서브쿼리를 활용한 복합키 매핑 이슈 해결
- 삭제된 게시글 자동 필터링 적용

### **5. 응답 구조 개선**
- 불필요한 DTO 제거 및 필수 요소만 유지
- Converter 패턴 도입으로 일관된 응답 구조
- ResponseEntity → CustomResponse로 응답 방식 통일

## 👀 기타 더 이야기해볼 점

1. **PostLike 엔티티의 복합키 구조**: `@EmbeddedId`와 연관관계 객체 동시 사용으로 인한 JPQL 제약사항이 있어 EXISTS 서브쿼리 방식으로 해결했습니다.

2. **성능 최적화**: JOIN FETCH를 통한 N+1 문제 방지 및 인덱스 활용을 고려한 쿼리 설계를 했습니다.

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
- [X] JPQL 매핑 이슈를 해결했어요.
- [X] 커서 기반 페이징이 정상 동작해요.