### PR TITLE
[BE - FEAT] 헬스체크를 위한 Spring Boot Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     //implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     //AWS
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2") // BOM

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/tokens", "/auth/tokens/refresh").permitAll()
                         .requestMatchers("/users/email/verification-requests").permitAll()
                         .requestMatchers("/users/email/verification").permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers(HttpMethod.POST, "/users").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/users").authenticated()
                         // 그 외 모든 요청은 인증 필요

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -40,7 +40,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/users/email/verification-requests",
             "/users/email/verification",
             "/swagger-ui/**",
-            "/v3/api-docs/**"
+            "/v3/api-docs/**",
+            "/actuator/health"
     );
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,15 @@ app:
 ai:
   server:
     url: ${AI_SERVER_URL}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+  health:
+    defaults:
+      enabled: false


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #200 

## 📌 개요
- Spring Boot 애플리케이션에서 /actuator/health 엔드포인트를 활성화하여 헬스체크용 API 제공 필요
- 운영 환경 배포 시 LB(로드밸런서) 헬스체크를 위함

## 🔁 변경 사항
[[FEAT] Spring Boot Actuator 의존성 및 health endpoint 설정 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/5072a6162111b13b4b85b9b302796c0fde5e9e70)

[[CHORE] /actuator/health 접근을 위한 SecurityConfig 및 JWT 필터 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/4f38bfd31f4e8b1e818fae25c45613b71c8fb571)

@1026hz
## 👀 기타 더 이야기해볼 점
http://localhost:8080/actuator/health 테스트 완료
<img width="398" alt="스크린샷 2025-06-10 오전 12 21 54" src="https://github.com/user-attachments/assets/94d136f9-c9df-4ea8-8151-b59f589c0bc3" />


## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.