### PR TITLE
[BE - FIX] 댓글, 대댓글 삭제 에러 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
@@ -281,7 +281,7 @@ public class CommentController {
     ) {
         Long memberId = Long.valueOf(userDetails.getId());
         commentService.deleteRecomment(memberId, recommentId);
-        return CustomResponse.success("좋아요가 성공적으로 취소되었습니다.", null);
+        return CustomResponse.success("대댓글이 삭제되었습니다.", null);
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -82,18 +82,10 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Commen
     @Query("SELECT cl FROM CommentLike cl WHERE cl.member.id = :memberId")
     Page<CommentLike> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
+
     @Modifying
     @Query("DELETE FROM CommentLike cl WHERE cl.comment.id = :commentId")
     int deleteByCommentId(@Param("commentId") Long commentId);
-
-    /**
-     * 특정 회원의 모든 좋아요를 삭제합니다.
-     * 회원 탈퇴 시 관련 좋아요도 함께 삭제하는 데 사용됩니다.
-     *
-     * @param memberId 회원 ID
-     */
-    @Query("DELETE FROM CommentLike cl WHERE cl.member.id = :memberId")
-    void deleteByMemberId(@Param("memberId") Long memberId);
 
     /**
      * 특정 댓글에 좋아요를 누른 회원을 커서 기반으로 조회합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -26,6 +26,10 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.id = :id AND c.deletedAt IS NULL")
     Optional<Comment> findByIdAndDeletedAtIsNull(@Param("id") Long id);
 
+    //특정 회원이 해당 게시글을 작성했는 지 확인
+    //삭제시 권한확인용
+    boolean existsByIdAndMember_Id(Long id, Long memberId);
+
     /**
      * 특정 댓글을 ID와 회원 ID로 조회합니다.
      * 댓글의 소유자 확인에 사용됩니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -89,6 +89,7 @@ public interface RecommentLikeRepository extends JpaRepository<RecommentLike, Re
      * @param recommentId 대댓글 ID
      * @return 삭제된 좋아요 수
      */
+    @Modifying
     @Query("DELETE FROM RecommentLike rl WHERE rl.recomment.id = :recommentId")
     int deleteByRecommentId(@Param("recommentId") Long recommentId);
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -3,6 +3,7 @@ package com.kakaobase.snsapp.domain.comments.repository;
 
 import com.kakaobase.snsapp.domain.comments.entity.Recomment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -83,4 +84,8 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
     List<Long> findLikedRecommentIds(
             @Param("recommentIds") List<Long> recommentIds,
             @Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("UPDATE Recomment r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.comment.id = :commentId AND r.deletedAt IS NULL")
+    int softDeleteRecommentsByCommentId(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 @Repository
 public interface RecommentRepository extends JpaRepository<Recomment, Long> {
 
+    boolean existsByIdAndMember_Id(Long recommentId, Long memberId);
+
     /**
      * 특정 대댓글을 ID로 조회합니다. 삭제된 대댓글은 포함하지 않습니다.
      *
@@ -24,17 +26,6 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
      */
     @Query("SELECT r FROM Recomment r WHERE r.id = :id AND r.deletedAt IS NULL")
     Optional<Recomment> findByIdAndDeletedAtIsNull(@Param("id") Long id);
-
-    /**
-     * 특정 대댓글을 ID와 회원 ID로 조회합니다.
-     * 대댓글의 소유자 확인에 사용됩니다.
-     *
-     * @param id 대댓글 ID
-     * @param memberId 회원 ID
-     * @return 대댓글 (Optional)
-     */
-    @Query("SELECT r FROM Recomment r WHERE r.id = :id AND r.member.id = :memberId AND r.deletedAt IS NULL")
-    Optional<Recomment> findByIdAndMemberId(@Param("id") Long id, @Param("memberId") Long memberId);
 
     /**
      * 특정 댓글의 대댓글을 모두 조회합니다. (댓글 목록 조회 시 사용)
@@ -76,16 +67,6 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long> {
             @Param("commentId") Long commentId,
             @Param("cursor") Long cursor,
             @Param("limit") int limit);
-
-    /**
-     * 특정 댓글의 대댓글 수를 조회합니다.
-     * 삭제되지 않은 대댓글만 계산합니다.
-     *
-     * @param commentId 댓글 ID
-     * @return 대댓글 수
-     */
-    @Query("SELECT COUNT(r) FROM Recomment r WHERE r.comment.id = :commentId AND r.deletedAt IS NULL")
-    long countByCommentIdAndDeletedAtIsNull(@Param("commentId") Long commentId);
 
     /**
      * 특정 대댓글들의 좋아요 상태를 한번에 조회합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -153,15 +153,10 @@ public class CommentService {
         commentLikeService.deleteAllCommentLikesByCommentId(commentId);
 
         // 댓글에 달린 모든 대댓글 삭제 (삭제된 것 포함)
-        List<Recomment> recomments = recommentRepository.findAllByCommentId(commentId);
-        for (Recomment recomment : recomments) {
-            commentLikeService.deleteAllRecommentLikesByRecommentId(recomment.getId());
-            recommentRepository.delete(recomment);
-        }
+        recommentRepository.softDeleteRecommentsByCommentId(commentId);
 
         // 댓글 삭제 (Soft Delete)
         comment.softDelete();
-        commentRepository.save(comment);
 
         log.info("댓글 삭제 완료: 댓글 ID={}, 삭제자 ID={}", commentId, memberId);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -175,7 +175,7 @@ public class CommentService {
     @Transactional
     public void deleteRecomment(Long memberId, Long recommentId) {
         // 대댓글 조회
-        Recomment recomment = recommentRepository.findById(recommentId)
+        Recomment recomment = recommentRepository.findByIdAndDeletedAtIsNull(recommentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId", "해당 대댓글을 찾을 수 없습니다."));
 
         // 대댓글의 좋아요 삭제

--- a/src/main/java/com/kakaobase/snsapp/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/kakaobase/snsapp/global/error/handler/GlobalExceptionHandler.java
@@ -5,8 +5,10 @@ import com.kakaobase.snsapp.global.error.code.BaseErrorCode;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import com.kakaobase.snsapp.global.error.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -126,6 +128,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(GeneralErrorCode.INVALID_QUERY_PARAMETER.getStatus())
                 .body(GeneralErrorCode.INVALID_QUERY_PARAMETER.getErrorResponse());
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<CustomResponse<Void>> handleAuthorizationDenied(AuthorizationDeniedException e) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(CustomResponse.failure(GeneralErrorCode.FORBIDDEN.getError(), GeneralErrorCode.FORBIDDEN.getMessage()));
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -5,6 +5,7 @@ import com.kakaobase.snsapp.domain.comments.entity.Recomment;
 import com.kakaobase.snsapp.domain.comments.exception.CommentException;
 import com.kakaobase.snsapp.domain.comments.repository.CommentRepository;
 import com.kakaobase.snsapp.domain.comments.repository.RecommentRepository;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
@@ -29,6 +30,7 @@ public class AccessChecker {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final RecommentRepository recommentRepository;
+    private final MemberRepository memberRepository;
 
     /**
      * 사용자가 특정 게시판에 접근할 권한이 있는지 검증합니다.
@@ -87,19 +89,9 @@ public class AccessChecker {
 
         // 사용자 ID 확인
         Long memberId = Long.valueOf(userDetails.getId());
-        if (memberId == null) {
-            return false;
-        }
-
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND,"postId"));
-
-        if(!post.getMember().getId().equals(memberId)) {
-            throw new CustomException(GeneralErrorCode.FORBIDDEN);
-        }
 
         // 게시글 조회
-        return true;
+        return postRepository.existsByIdAndMemberId(postId, memberId);
     }
 
     /**
@@ -126,7 +118,7 @@ public class AccessChecker {
         }
 
         // 댓글 조회
-        return commentRepository.findByIdAndMemberId(commentId, memberId).isPresent();
+        return commentRepository.existsByIdAndMember_Id(commentId, memberId);
     }
 
     /**
@@ -164,15 +156,7 @@ public class AccessChecker {
             return false;
         }
 
-        Recomment recomment = recommentRepository.findById(recommentId)
-                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "recommentId"));
-
-        if(!recomment.getMember().getId().equals(memberId)) {
-            throw new CustomException(GeneralErrorCode.FORBIDDEN);
-        }
-
-
-        return true;
+        return recommentRepository.existsByIdAndMember_Id(recommentId, memberId);
     }
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #201

## 📌 개요
- 댓글, 대댓글 삭제 시 발생하는 `@Modifying` 누락으로 인한 에러를 해결하고, AccessChecker의 성능을 개선했습니다.
- Query 실행 시 `getResultList()` 또는 `getSingleResult()`로 DELETE/UPDATE 쿼리를 실행하려 할 때 발생하는 에러를 수정했습니다.
- 권한 확인 로직을 `find` 메서드에서 `exist` 메서드로 변경하여 성능을 향상시켰습니다.

## 🔁 변경 사항

### 🐛 버그 수정
- **[FIX] 대댓글의 좋아요 일괄 삭제 Query에 @Modifying추가**
  - DELETE 쿼리에 누락된 `@Modifying` 어노테이션 추가
  - `java.lang.IllegalStateException` 에러 해결
  
- **[FIX] 대댓글 삭제시 출력되는 메세지를 올바르게 수정**
  - 삭제 완료 메시지가 정확히 표시되도록 수정
  
- **[FIX] 대댓글 삭제시 SoftDelete된 데이터는 조회하지 않도록 수정**
  - `WHERE deleted_at IS NULL` 조건 추가로 이미 삭제된 데이터 제외

### ✨ 기능 추가
- **[FEAT] 특정 댓글, 대댓글이 특정 사용자가 작성한 것인지 확인하는 exist메서드 추가**
  - `existsByIdAndMember_Id` 메서드 구현
  - 권한 확인용 최적화된 쿼리 제공
  
- **[FEAT] 특정 CommentId와 연관된 Recomment를 SoftDelete하는 메서드 구현**
  - `softDeleteRecommentsByCommentId` 메서드 추가
  - 댓글 삭제 시 연관된 대댓글들도 함께 처리

### 🔧 리팩토링
- **[REFACTOR] AccessChecker가 find가 아니라 exist 메서드를 통해 권한 확인을 하도록 수정**
  - 성능 개선: 전체 엔티티 조회 → 존재 여부만 확인
  - 메모리 사용량 감소 및 쿼리 속도 향상
  
- **[REFACTOR] @PreAuthorize에서 예외 발생시 이를 처리하는 handler메서드 추가**
  - 예외 처리 로직 개선으로 사용자 경험 향상
  
- **[REFACTOR] Comment삭제 시 Recomment가 SoftDelete 되도록 메서드 수정**
  - 데이터 일관성 보장
  - 댓글-대댓글 간 참조 무결성 유지

### 🧹 정리
- **[REMOVE] 사용되지 않는 메서드 제거**
  - 코드 정리 및 유지보수성 향상

## 👀 기타 더 이야기해볼 점

### 에러 해결
```
Caused by: java.lang.IllegalStateException:
Query executed via 'getResultList()' or 'getSingleResult()' must be a 'select' query
[DELETE FROM RecommentLike rl WHERE rl.recomment.id = :recommentId]
```
- **원인**: UPDATE/DELETE 쿼리에 `@Modifying` 어노테이션 누락
- **해결**: 모든 데이터 변경 쿼리에 `@Modifying` 추가

### 데이터 일관성 개선
- 댓글 삭제 시 연관된 대댓글들도 자동으로 SoftDelete 처리
- 삭제된 데이터는 조회에서 자동 제외되도록 조건 추가

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.