### PR TITLE
[BE - FIX] 프로필 이미지 변경이 DB에 반영 안되는 문제 해결

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -254,6 +254,7 @@ public class MemberService {
         member.updateGithubUrl(request.githubUrl());
     }
 
+    @Transactional
     public MemberResponseDto.ProfileImageChange changProfileImageUrl(MemberRequestDto.@Valid ProfileImageChange request) {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 프로필 이미지 변경이 DB에 반영 안되는 문제 해결

## 🔁 변경 사항
[[FIX] 프로필 이미지변경메서드에](https://github.com/100-hours-a-week/22-tenten-be/commit/b8431061c946900589e43664897182489be5d4cc) @Transactional[이 없어 더티체킹이 안되는 문제 해결](https://github.com/100-hours-a-week/22-tenten-be/commit/b8431061c946900589e43664897182489be5d4cc)

## 👀 기타 더 이야기해볼 점
- 원인
프로필 이미지변경메서드에 @Transactional이 없어 더티체킹적용 안되고 있었음

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.