### PR TITLE
[BE - FIX] 마이페이지 조회가 현재유저를 기반으로 조회되는 로직을 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -14,13 +14,13 @@ import com.kakaobase.snsapp.domain.follow.repository.FollowRepository;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
 import com.kakaobase.snsapp.domain.posts.service.PostService;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -276,8 +276,12 @@ public class CommentService {
     @Transactional(readOnly = true)
     public List<CommentResponseDto.CommentInfo> getUserCommentList(int limit, Long cursor, Long memberId) {
 
-        if(memberRepository.existsById(memberId)) {
+        if(!memberRepository.existsById(memberId)) {
             throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId");
+        }
+
+        if (limit < 1) {
+            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit");
         }
 
         Pageable pageable = PageRequest.of(0, limit);

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -81,14 +81,11 @@ public class MemberController {
     @GetMapping("/{userId}/posts")
     @Operation(summary = "유저가 작성한 게시글 목록 조회", description = "유저가 작성한 게시글 목록을 조회합니다.")
     public CustomResponse<List<PostResponseDto.PostDetails>> getUserPosts(
+            @Parameter(description = "조회할 유저id") @PathVariable Long userId,
             @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
-            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor
     ) {
-
-        Long memberId = Long.valueOf(userDetails.getId());
-
-        List<PostResponseDto.PostDetails> response = postService.getUserPostList(limit, cursor, memberId);
+        List<PostResponseDto.PostDetails> response = postService.getUserPostList(limit, cursor, userId);
 
         return CustomResponse.success("유저 게시글이조회에 성공하였습니다",response);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/controller/MemberController.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.domain.members.controller;
 
-import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
 import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;
 import com.kakaobase.snsapp.domain.comments.service.CommentService;
 import com.kakaobase.snsapp.domain.members.dto.MemberRequestDto;
@@ -20,9 +19,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -93,14 +90,12 @@ public class MemberController {
     @GetMapping("/{userId}/comments")
     @Operation(summary = "유저가 작성한 댓글 목록 조회", description = "유저가 작성한 댓글 목록을 조회합니다.")
     public CustomResponse<List<CommentResponseDto.CommentInfo>> getUserComments(
+            @Parameter(description = "조회할 유저id") @PathVariable Long userId,
             @Parameter(description = "한 페이지에 표시할 댓글 수") @RequestParam(defaultValue = "12") int limit,
-            @Parameter(description = "마지막으로 조회한 댓글 ID") @RequestParam(required = false) Long cursor,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @Parameter(description = "마지막으로 조회한 댓글 ID") @RequestParam(required = false) Long cursor
     ) {
 
-        Long memberId = Long.valueOf(userDetails.getId());
-
-        List<CommentResponseDto.CommentInfo> response = commentService.getUserCommentList(limit, cursor, memberId);
+        List<CommentResponseDto.CommentInfo> response = commentService.getUserCommentList(limit, cursor, userId);
 
         return CustomResponse.success("유저 댓글 조회에 성공하였습니다",response);
     }
@@ -108,14 +103,12 @@ public class MemberController {
     @GetMapping("/{userId}/liked-posts")
     @Operation(summary = "유저가 좋아요한 게시글 목록 조회", description = "유저가 좋아요한 게시글 목록을 조회합니다.")
     public CustomResponse<List<PostResponseDto.PostDetails>> getLikedPosts(
+            @Parameter(description = "조회할 유저id") @PathVariable Long userId,
             @Parameter(description = "한 페이지에 표시할 게시글 수") @RequestParam(defaultValue = "12") int limit,
-            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @Parameter(description = "마지막으로 조회한 게시글 ID") @RequestParam(required = false) Long cursor
     ) {
 
-        Long memberId = Long.valueOf(userDetails.getId());
-
-        List<PostResponseDto.PostDetails> response = postService.getLikedPostList(limit, cursor, memberId);
+        List<PostResponseDto.PostDetails> response = postService.getLikedPostList(limit, cursor, userId);
 
         return CustomResponse.success("좋아요한 게시글 목록이 정상적으로 조회되었습니다",response);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -67,7 +67,7 @@ public class PostConverter {
                 .build();
     }
 
-    public List<PostResponseDto.PostDetails> convertToPostListItems(List<Post> posts, Long currentMemberId) {
+    public List<PostResponseDto.PostDetails> convertToPostListItems(List<Post> posts, Long memberId) {
         if (posts.isEmpty()) {
             return Collections.emptyList();
         }
@@ -81,14 +81,14 @@ public class PostConverter {
 
         // 2. 배치로 추가 데이터 조회 (기존 Repository 메서드 활용)
         Map<Long, String> postImageMap = getFirstImagesByPostIds(postIds);
-        Set<Long> likedPostIds = currentMemberId != null ?
-                getLikedPostIds(currentMemberId, postIds) : Collections.emptySet();
-        Set<Long> followedMemberIds = currentMemberId != null ?
-                getFollowedMemberIds(currentMemberId, memberIds) : Collections.emptySet();
+        Set<Long> likedPostIds = memberId != null ?
+                getLikedPostIds(memberId, postIds) : Collections.emptySet();
+        Set<Long> followedMemberIds = memberId != null ?
+                getFollowedMemberIds(memberId, memberIds) : Collections.emptySet();
 
         // 3. 각 Post를 PostListItem으로 변환
         return posts.stream()
-                .map(post -> convertToPostDetail(post, currentMemberId, postImageMap, likedPostIds, followedMemberIds))
+                .map(post -> convertToPostDetail(post, memberId, postImageMap, likedPostIds, followedMemberIds))
                 .toList();
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -1,7 +1,9 @@
 package com.kakaobase.snsapp.domain.posts.service;
 
+import com.kakaobase.snsapp.domain.comments.exception.CommentException;
 import com.kakaobase.snsapp.domain.follow.repository.FollowRepository;
 import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.members.service.MemberService;
 import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
@@ -51,6 +53,7 @@ public class PostService {
     private final FollowRepository followRepository;
     private final EntityManager em;
     private final PostConverter postConverter;
+    private final MemberRepository memberRepository;
 
     /**
      * 게시글을 생성합니다.
@@ -204,19 +207,23 @@ public class PostService {
 
     }
 
-    public List<PostResponseDto.PostDetails> getLikedPostList(int limit, Long cursor, Long currentMemberId) {
-        // 1. 유효성 검증
+    public List<PostResponseDto.PostDetails> getLikedPostList(int limit, Long cursor, Long memberId) {
+
+        if(!memberRepository.existsById(memberId)){
+            throw new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId");
+        }
+
         if (limit < 1) {
-            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
+            throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit");
         }
 
         Pageable pageable = PageRequest.of(0, limit);
 
         // 3. 게시글 조회
-        List<Post> posts = postRepository.findLikedPostsByMemberIdWithCursor(currentMemberId, cursor, pageable);
+        List<Post> posts = postRepository.findLikedPostsByMemberIdWithCursor(memberId, cursor, pageable);
 
         // 3. PostListItem으로 변환
-        return postConverter.convertToPostListItems(posts, currentMemberId);
+        return postConverter.convertToPostListItems(posts, memberId);
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -188,7 +188,7 @@ public class PostService {
     /**
      * 유저가 작성한 게시글 조회
      */
-    public List<PostResponseDto.PostDetails> getUserPostList(int limit, Long cursor, Long currentMemberId) {
+    public List<PostResponseDto.PostDetails> getUserPostList(int limit, Long cursor, Long memberId) {
         // 1. 유효성 검증
         if (limit < 1) {
             throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
@@ -197,10 +197,10 @@ public class PostService {
         Pageable pageable = PageRequest.of(0, limit);
 
         // 3. 게시글 조회
-        List<Post> posts = postRepository.findByMemberIdWithCursor(currentMemberId, cursor, pageable);
+        List<Post> posts = postRepository.findByMemberIdWithCursor(memberId, cursor, pageable);
 
         // 3. PostListItem으로 변환
-        return postConverter.convertToPostListItems(posts, currentMemberId);
+        return postConverter.convertToPostListItems(posts, memberId);
 
     }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- 특정 유저의 게시글 조회, 댓글 조회, 좋아요한 게시글 조회를 현재 유저가 아닌 path param을 통해 받도록 수정

## 🔁 변경 사항
[[FIX] 마이페이지 조회가 현재 유저Id가아닌 path param을 기반으로 조회하도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/2877a19e9f8448fc6865fc7aa962325b4139fcda)

[[FIX] 마이페이지 댓글조회, 좋아요 게시글 조회를 path param의 userId를 통해 조회하도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/662ae662ed21f07cde118b820fedf759a2b6d749)

[[STYLE] 좋아요 게시글 조회 매개변수를 적절하게 변경](https://github.com/100-hours-a-week/22-tenten-be/commit/bd28f2b4ae8e6fa6b91e9f15967780f620387cea)

[[FIX] 좋아요 게시글 조회 매개변수를 적절하게 변경, 유효성 검사 메서드 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/241ca8bba6623f47b144ffa45f44daf00280fa40)

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.