### PR TITLE
[BE - FIX] 댓글 조회 응답에 post_id필드 추가

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
@@ -144,16 +144,18 @@ public class CommentConverter {
                         .isFollowed(isFollowing)
                         .build();
 
-        return new CommentResponseDto.CommentInfo(
-                comment.getId(),
-                userInfo,
-                comment.getContent(),
-                comment.getCreatedAt(),
-                comment.getLikeCount(),
-                comment.getRecommentCount(),
-                isMine,
-                isLiked
-        );
+        return CommentResponseDto.CommentInfo
+                .builder()
+                .id(comment.getId())
+                .PostId(comment.getPost().getId())
+                .user(userInfo)
+                .content(comment.getContent())
+                .created_at(comment.getCreatedAt())
+                .like_count(comment.getLikeCount())
+                .recomment_count(comment.getRecommentCount())
+                .is_mine(isMine)
+                .is_liked(isLiked)
+                .build();
     }
 
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/dto/CommentResponseDto.java
@@ -3,6 +3,7 @@ package com.kakaobase.snsapp.domain.comments.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +16,6 @@ import java.util.List;
  */
 @Schema(description = "댓글 관련 응답 DTO 클래스")
 public class CommentResponseDto {
-
 
     /**
      * 대댓글 정보 DTO
@@ -48,9 +48,14 @@ public class CommentResponseDto {
      * 댓글 정보 DTO
      */
     @Schema(description = "댓글 정보")
+    @Builder
     public record CommentInfo(
             @Schema(description = "댓글 ID", example = "101")
             Long id,
+
+            @Schema(description = "댓글이 달린 Post ID", example = "24")
+            @JsonProperty("post_id")
+            Long PostId,
 
             @Schema(description = "작성자 정보")
             MemberResponseDto.UserInfoWithFollowing user,

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -226,9 +226,6 @@ public class CommentService {
      * @return 대댓글 목록 응답 DTO
      */
     public CommentResponseDto.RecommentListResponse getRecommentsByCommentId(Long memberId, Long commentId, CommentRequestDto.RecommentPageRequest pageRequest) {
-        // 댓글 존재 확인
-        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
-                .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "해당 댓글을 찾을 수 없습니다."));
 
         // 페이지 설정
         int limit = pageRequest.limit() != null ? pageRequest.limit() : DEFAULT_PAGE_SIZE;
@@ -329,14 +326,12 @@ public class CommentService {
         boolean isFollowing = followRepository.existsByFollowerUserAndFollowingUser(follower, following);
 
         // CommentInfo 생성
-        CommentResponseDto.CommentInfo commentInfo = commentConverter.toCommentInfo(
+        return commentConverter.toCommentInfo(
                 comment,
                 isMine,
                 isLiked,
                 isFollowing
         );
-
-        return commentInfo;
     }
 
     /**


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #210

## 📌 개요
- 댓글 목록조회, 마이페이지 댓글조회, 댓글 상세조회 응답에 post_id필드 추가

## 🔁 변경 사항
[[FIX] 댓글 정보 반환Dto에 postId 추가](https://github.com/100-hours-a-week/22-tenten-be/commit/e3e1c33e5af4e098841c7c550f924edc203a7ff0)

[[REMOVE] 필요없는 메서드 제거](https://github.com/100-hours-a-week/22-tenten-be/commit/8a40c9bdea2d27e1f1e4d58afaaacddd396f1ad9)

[[REFACTOR] CommentInfo를 builder패턴으로 만들도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/50c1aae03ed0626508cc9cea7f51a1b23d4852e6)

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.