### PR TITLE
[BE - REFACOTR] AccessToken을 Cookie로 발급하도록 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.kakaobase.snsapp.domain.auth.controller;
 import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
 import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
 import com.kakaobase.snsapp.domain.auth.service.AuthService;
+import com.kakaobase.snsapp.domain.auth.util.CookieUtil;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,7 +12,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final CookieUtil cookieUtil;
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT 토큰을 발급합니다")
     @ApiResponses(value = {
@@ -46,7 +47,7 @@ public class AuthController {
     public ResponseEntity<CustomResponse<AuthResponseDto.UserAuthInfo>>  login(
             @Parameter(description = "로그인 정보", required = true)
             @Valid @RequestBody AuthRequestDto.Login request,
-            @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String providedRefreshToken,
+            @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String oldRefreshToken,
             @Parameter(hidden = true) @RequestHeader(value = "User-Agent", required = true) String userAgent
     ) {
 
@@ -55,11 +56,9 @@ public class AuthController {
         // 로그인 처리 및 토큰 발급
         AuthResponseDto.UserAuthInfo response = authService.login(request);
 
-        ResponseCookie refreshCookie = authService.getRefreshCookie(providedRefreshToken, userAgent);
+        ResponseCookie refreshCookie = authService.getRefreshCookie(response.memberId(), oldRefreshToken, userAgent);
 
-        String newRefreshToken = refreshCookie.getValue();
-
-        ResponseCookie accessTokenCookie = authService.getAccessTokenCookie(newRefreshToken);
+        ResponseCookie accessTokenCookie = authService.getAccessCookie();
 
         log.info("로그인 성공: {}", request.email());
 
@@ -85,13 +84,12 @@ public class AuthController {
     })
     @PostMapping("/tokens/refresh")
     public ResponseEntity<CustomResponse<AuthResponseDto.UserAuthInfo>> refreshToken(
-            @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String providedRefreshToken) {
+            @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String oldRefreshToken) {
 
         log.info("액세스 토큰 재발급 요청");
 
-        ResponseCookie accessTokenCookie = authService.getAccessTokenCookie(providedRefreshToken);
-
-        AuthResponseDto.UserAuthInfo response = authService.getUserInfo();
+        AuthResponseDto.UserAuthInfo response = authService.getUserInfo(oldRefreshToken);
+        ResponseCookie accessTokenCookie = authService.getAccessCookie();
 
         log.info("액세스 토큰 재발급 성공");
 
@@ -117,18 +115,18 @@ public class AuthController {
     })
     @DeleteMapping("/tokens")
     public ResponseEntity<CustomResponse<Void>> logout(
-            HttpServletResponse httpResponse,
-            @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String providedRefreshToken
+            @Parameter(hidden = true) @CookieValue(value = "kakaobase_refresh_token", required = false, defaultValue = "") String oldRefreshToken
             ) {
 
         log.info("로그아웃 요청 수신");
 
-        authService.logout(providedRefreshToken);
-        ResponseCookie emptyRefreshCookie = authService.logout(providedRefreshToken);
+        authService.logout(oldRefreshToken);
+        ResponseCookie emptyRefreshCookie = cookieUtil.createEmptyRefreshCookie();
+        ResponseCookie emptyAccessTokenCookie = cookieUtil.createEmptyAccessCookie();
 
         return ResponseEntity
                 .ok()
-                .header(HttpHeaders.SET_COOKIE, emptyRefreshCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, emptyRefreshCookie.toString(), emptyAccessTokenCookie.toString())
                 .body(CustomResponse.success("정상적으로 로그아웃되었습니다."));
 
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
@@ -4,7 +4,6 @@ import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
 import com.kakaobase.snsapp.domain.auth.entity.AuthToken;
 import com.kakaobase.snsapp.domain.auth.entity.RevokedRefreshToken;
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
-import com.kakaobase.snsapp.domain.members.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -73,18 +72,9 @@ public class AuthConverter {
         return new AuthResponseDto.TokenResponse(accessToken);
     }
 
-    /**
-     * 액세스 토큰만으로 응답 DTO를 생성합니다.
-     * 리프레시 토큰은 쿠키로 전송되므로 응답 본문에는 포함되지 않습니다.
-     *
-     * @param accessToken 액세스 토큰
-     * @return 토큰 응답 DTO
-     */
-    public AuthResponseDto.TokenResponse toAccessTokenOnlyResponseDto(String accessToken) {
-        return new AuthResponseDto.TokenResponse(accessToken);
-    }
 
     public AuthResponseDto.UserAuthInfo toUserAuthInfoDto(CustomUserDetails userDetails) {
+
         return AuthResponseDto.UserAuthInfo
                 .builder()
                 .memberId(Long.valueOf(userDetails.getId()))
@@ -93,15 +83,5 @@ public class AuthConverter {
                 .imageUrl(userDetails.getProfileImgUrl())
                 .build();
 
-    }
-
-    public AuthResponseDto.UserAuthInfo toUserAuthInfoDto(Member member) {
-        return AuthResponseDto.UserAuthInfo
-                .builder()
-                .memberId(member.getId())
-                .nickname(member.getNickname())
-                .className(member.getClassName())
-                .imageUrl(member.getProfileImgUrl())
-                .build();
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/converter/AuthConverter.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.domain.auth.converter;
 
-import com.kakaobase.snsapp.domain.auth.dto.AuthRequestDto;
 import com.kakaobase.snsapp.domain.auth.dto.AuthResponseDto;
 import com.kakaobase.snsapp.domain.auth.entity.AuthToken;
 import com.kakaobase.snsapp.domain.auth.entity.RevokedRefreshToken;
@@ -85,27 +84,24 @@ public class AuthConverter {
         return new AuthResponseDto.TokenResponse(accessToken);
     }
 
-    public AuthResponseDto.LoginResponse toLoginResponseDto(CustomUserDetails userDetails, String accessToken) {
-        return AuthResponseDto.LoginResponse
+    public AuthResponseDto.UserAuthInfo toUserAuthInfoDto(CustomUserDetails userDetails) {
+        return AuthResponseDto.UserAuthInfo
                 .builder()
                 .memberId(Long.valueOf(userDetails.getId()))
                 .nickname(userDetails.getNickname())
                 .className(userDetails.getClassName())
                 .imageUrl(userDetails.getProfileImgUrl())
-                .accessToken(accessToken)
                 .build();
 
     }
 
-    public AuthResponseDto.LoginResponse toLoginResponseDto(Member member, String accessToken) {
-        return AuthResponseDto.LoginResponse
+    public AuthResponseDto.UserAuthInfo toUserAuthInfoDto(Member member) {
+        return AuthResponseDto.UserAuthInfo
                 .builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .className(member.getClassName())
                 .imageUrl(member.getProfileImgUrl())
-                .accessToken(accessToken)
                 .build();
-
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/dto/AuthResponseDto.java
@@ -15,7 +15,7 @@ public class AuthResponseDto {
      */
     @Schema(description = "로그인 또는 토큰 재발급 성공 응답 DTO")
     @Builder
-    public record LoginResponse(
+    public record UserAuthInfo(
 
             @Schema(description = "로그인 유저의 memberId", example = "12...")
             @JsonProperty("member_id")
@@ -31,12 +31,7 @@ public class AuthResponseDto {
 
             @Schema(description = "유저의 프로필 이미지")
             @JsonProperty("image_url")
-            String imageUrl,
-
-            @Schema(description = "AccessToken (JWT 형식)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6...")
-            @JsonProperty("access_token")
-            String accessToken
-
+            String imageUrl
     ) {}
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/exception/AuthException.java
@@ -15,7 +15,7 @@ public class AuthException extends CustomException {
      *
      * @param errorCode 인증 에러 코드 (AuthErrorCode)
      */
-    public AuthException(AuthErrorCode errorCode) {
+    public AuthException(BaseErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.domain.auth.principal;
 
-import com.kakaobase.snsapp.domain.members.entity.Member;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -38,7 +37,7 @@ public class CustomUserDetails implements UserDetails {
         this.isEnabled = isEnabled;
     }
 
-    //로그인 시 사용
+    //로그인, 엑세스 토큰 재발급 시 사용
     public CustomUserDetails(String email, String password, String id, String role, String name, String className, String nickname, String  profileImgUrl, boolean isEnabled) {
         this.id = id;
         this.email = email;

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.auth.principal;
 
+import com.kakaobase.snsapp.domain.members.entity.Member;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.GrantedAuthority;
@@ -19,6 +20,7 @@ public class CustomUserDetails implements UserDetails {
 
     private transient String email;
     private transient String password;
+    private transient String name;
     private transient String nickname;
     private transient String profileImgUrl;
     private final String id;
@@ -37,11 +39,12 @@ public class CustomUserDetails implements UserDetails {
     }
 
     //로그인 시 사용
-    public CustomUserDetails(String email, String password, String id, String role, String className, String nickname, String  profileImgUrl, boolean isEnabled) {
+    public CustomUserDetails(String email, String password, String id, String role, String name, String className, String nickname, String  profileImgUrl, boolean isEnabled) {
+        this.id = id;
         this.email = email;
         this.password = password;
+        this.name = name;
         this.nickname = nickname;
-        this.id = id;
         this.role = role;
         this.className = className;
         this.profileImgUrl = profileImgUrl;

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetailsService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/principal/CustomUserDetailsService.java
@@ -47,6 +47,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 member.getPassword(),
                 member.getId().toString(),
                 member.getRole(),
+                member.getName(),
                 member.getClassName(),
                 member.getNickname(),
                 member.getProfileImgUrl(),

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/service/SecurityTokenManager.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/service/SecurityTokenManager.java
@@ -64,7 +64,7 @@ public class SecurityTokenManager {
     }
 
     /**
-     * 리프레시 토큰 검증 및 사용자 ID 반환
+     * 리프레시 토큰 검증
      */
     @Transactional
     public void validateRefreshToken(String rawToken) {

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/service/SecurityTokenManager.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/service/SecurityTokenManager.java
@@ -20,7 +20,6 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
-import java.util.List;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -67,25 +66,24 @@ public class SecurityTokenManager {
     /**
      * 리프레시 토큰 검증 및 사용자 ID 반환
      */
-    public Long validateRefreshTokenAndGetUserId(String rawToken) {
+    @Transactional
+    public void validateRefreshToken(String rawToken) {
         String hashedToken = hashToken(rawToken);
 
         // 1. 취소된 토큰인지 확인
-        if (isTokenRevoked(hashedToken)) {
+        if (revokedTokenRepository.existsByRefreshTokenHash(hashedToken)) {
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_REVOKED);
         }
 
         // 2. 토큰 조회
-        AuthToken tokenEntity = authTokenRepository.findByRefreshTokenHash(hashedToken)
+        AuthToken refreshToken = authTokenRepository.findByRefreshTokenHash(hashedToken)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID));
 
         // 3. 만료 확인
-        if (isTokenExpired(tokenEntity)) {
-            revokeToken(tokenEntity);
+        if (refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            revokeRefreshToken(rawToken);
             throw new AuthException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         }
-
-        return tokenEntity.getMemberId();
     }
 
     /**
@@ -101,57 +99,18 @@ public class SecurityTokenManager {
             return;
         }
 
-        AuthToken tokenEntity = authTokenRepository.findByRefreshTokenHash(hashedToken)
+        AuthToken refeshToken = authTokenRepository.findByRefreshTokenHash(hashedToken)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_INVALID, "해당 리프레시 토큰값을 DB에서 조회할 수 없음"));
 
-        revokeToken(tokenEntity);
-    }
-
-    /**
-     * 토큰 취소 처리 (내부 메서드)
-     */
-    @Transactional
-    public void revokeToken(AuthToken token) {
         // AuthConverter를 사용하여 취소된 토큰 엔티티 생성
         RevokedRefreshToken revokedToken = authConverter.toRevokedTokenEntity(
-                token.getRefreshTokenHash(),
-                token.getMemberId()
+                refeshToken.getRefreshTokenHash(),
+                refeshToken.getMemberId()
         );
 
         // 기존 토큰 삭제 및 취소 토큰 저장
-        authTokenRepository.delete(token);
+        authTokenRepository.delete(refeshToken);
         revokedTokenRepository.save(revokedToken);
-    }
-
-    /**
-     * 현재 토큰을 제외한 모든 토큰 취소
-     */
-    @Transactional
-    public void revokeAllTokensExcept(Long memberId, String currentRawToken) {
-        String currentHashedToken = hashToken(currentRawToken);
-        List<AuthToken> tokens = authTokenRepository.findAllByMemberId(memberId);
-
-        for (AuthToken token : tokens) {
-            if (!token.getRefreshTokenHash().equals(currentHashedToken)) {
-                revokeToken(token);
-            }
-        }
-    }
-
-
-
-    /**
-     * 토큰이 취소되었는지 확인
-     */
-    private boolean isTokenRevoked(String hashedToken) {
-        return revokedTokenRepository.existsByRefreshTokenHash(hashedToken);
-    }
-
-    /**
-     * 토큰 만료 여부 확인
-     */
-    private boolean isTokenExpired(AuthToken token) {
-        return token.getExpiresAt().isBefore(LocalDateTime.now());
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
@@ -51,6 +51,14 @@ public class CookieUtil {
         return createTokenToCookie(accessToken, accessTokenCookieName, accessTokenCookiePath, accessTokenExpiration);
     }
 
+    public ResponseCookie createEmptyAccessCookie() {
+        return createTokenToCookie("", accessTokenCookieName, accessTokenCookiePath, 1000L);
+    }
+
+    public ResponseCookie createEmptyRefreshCookie() {
+        return createTokenToCookie("", refreshTokenCookieName, refreshTokenCookiePath, 1000L);
+    }
+
     private ResponseCookie createTokenToCookie(String token, String tokenCookieName,String path,Long maxAge) {
         return ResponseCookie.from(tokenCookieName, token)
                 .path(path)
@@ -78,22 +86,5 @@ public class CookieUtil {
             }
         }
         return null;
-    }
-
-    /**
-     * 로그아웃 시 사용할 빈 리프레시 토큰 쿠키를 생성합니다.
-     * 생성된 쿠키는 즉시 만료되도록 설정됩니다.
-     *
-     * @return 만료된 쿠키
-     */
-    public ResponseCookie createEmptyRefreshCookie() {
-        return ResponseCookie.from(refreshTokenCookieName, "")
-                .maxAge(0) // 즉시 만료
-                .path(refreshTokenCookiePath)
-                .httpOnly(true)
-                .secure(secureCookie)
-                .domain(cookieDomain)
-                .build();
-
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/auth/util/CookieUtil.java
@@ -25,6 +25,15 @@ public class CookieUtil {
     @Value("${app.jwt.refresh.path}")
     private String refreshTokenCookiePath;
 
+    @Value("${app.jwt.access.token-name}")
+    private String accessTokenCookieName;
+
+    @Value("${app.jwt.access.expiration-time}")
+    private long accessTokenExpiration;
+
+    @Value("${app.jwt.access.path}")
+    private String accessTokenCookiePath;
+
     @Value("${app.jwt.secure}")
     private boolean secureCookie;
 
@@ -34,22 +43,24 @@ public class CookieUtil {
     @Value("${app.jwt.refresh.same-site}")
     private String cookieSameSite;
 
-    /**
-     * 리프레시 토큰을 담은 쿠키를 생성합니다.
-     * 생성된 쿠키는 JavaScript에서 접근할 수 없도록 HttpOnly로 설정
-     */
-    public ResponseCookie createRefreshTokenCookie(String refreshToken) {
-        return ResponseCookie.from(refreshTokenCookieName, refreshToken)
-                .path(refreshTokenCookiePath)
+    public ResponseCookie createRefreshTokenToCookie(String refreshToken) {
+        return createTokenToCookie(refreshToken, refreshTokenCookieName, refreshTokenCookiePath, refreshTokenExpiration);
+    }
+
+    public ResponseCookie createTokenToAccessCookie(String accessToken) {
+        return createTokenToCookie(accessToken, accessTokenCookieName, accessTokenCookiePath, accessTokenExpiration);
+    }
+
+    private ResponseCookie createTokenToCookie(String token, String tokenCookieName,String path,Long maxAge) {
+        return ResponseCookie.from(tokenCookieName, token)
+                .path(path)
                 .domain(cookieDomain)
-                .maxAge(refreshTokenExpiration / 1000)
+                .maxAge(maxAge / 1000)
                 .httpOnly(true)
                 .secure(secureCookie)
                 .sameSite(cookieSameSite)
                 .build();
     }
-
-
 
     /**
      * HTTP 요청의 쿠키에서 리프레시 토큰을 추출합니다.

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -81,7 +81,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         log.debug("JwtAuthenticationFilter 실행 - URI: {}, 메서드: {}", request.getRequestURI(), request.getMethod());
 
         // 요청에서 JWT 토큰 추출
-        String token = jwtUtil.resolveToken(request);
+        String token = jwtUtil.resolveTokenFromCookie(request);
         log.debug("추출된 토큰: {}", token != null ? "존재함 (길이: " + token.length() + ")" : "없음");
 
         // 토큰이 존재하고 현재 인증 정보가 없는 경우에만 처리

--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtUtil.java
@@ -4,11 +4,11 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -39,13 +39,18 @@ public class JwtUtil {
      * @param request HTTP 요청
      * @return 추출된 JWT 토큰 (존재하지 않으면 null)
      */
-    public String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
+    public String resolveTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("kakaobase_access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
         }
         return null;
     }
+
 
     /**
      * JWT 토큰에서 모든 클레임을 추출합니다.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,10 +51,12 @@ app:
     issuer: kakaobase
     audience: web
     access:
+      token-name: kakaobase_access_token
       expiration-time: 1800000 # 30분
+      path: /
     refresh:
-      expiration-time: 604800000 # 7일
       token-name: kakaobase_refresh_token
+      expiration-time: 604800000 # 7일
       path: api/auth/tokens
   s3:
     expiration-time: 300


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #127 

## 📌 개요
- Spring Boot 환경에서 JWT 기반 인증 시스템을 Cookie 방식으로 전면 개편
- AuthService의 아키텍처를 개선하여 코드 가독성과 유지보수성 향상
- AccessToken과 RefreshToken 모두 Cookie 기반으로 처리하도록 인증 로직 통합

## 🔁 변경 사항

### 🏗️ 아키텍처 개선
- **AuthService 리팩토링**: SecurityContext 조작을 private 메서드로 캡슐화하여 코드 중복 제거
- **SecurityTokenManager 책임 분리**: 토큰 유효성 검사는 AuthService에서, 토큰 해싱 처리는 SecurityTokenManager에서 담당
- **메서드 간 결합도 감소**: 직접 매개변수 전달 방식으로 암묵적 의존성 제거

### 🍪 Cookie 기반 인증 시스템 구축
- **설정 추가**: yml에 AccessToken용 cookie name, path 설정 추가
- **CookieUtil 개선**: AccessToken과 RefreshToken 쿠키 생성 로직 통합 및 재사용성 향상
- **JWT 토큰 추출 방식 변경**: Header 기반에서 Cookie 기반으로 전환

### 🔧 기능 개선 및 수정
- **CustomUserDetails 확장**: 로그인/토큰 재발급 시 필요한 name 필드 추가
- **응답 DTO 개선**: 로그인/AccessToken 재발급 시 사용되는 응답 DTO 네이밍 개선
- **로그인/토큰 재발급 API**: AccessToken을 쿠키로 주입하도록 로직 수정
- **예외 처리 개선**: AuthException이 상위 구현체를 받을 수 있도록 수정

### 🧹 코드 정리
- **불필요한 메서드 제거**: 중복되거나 사용되지 않는 헬퍼 메서드들 정리
- **주석 개선**: 변경된 메서드 용도에 맞는 적절한 주석 작성
- **빈 쿠키 발급 로직**: 기존 로직을 재활용하도록 개선

## 👀 기타 더 이야기해볼 점
- Cookie 기반 인증에서CSRF 보안 고려사항에 대한 추가 논의 필요(현재 Same-Site가 None인상태)
- AccessToken의 짧은 만료시간과 RefreshToken의 자동 갱신 로직 검토
- 현재 SecurityContext를 메서드 간 데이터 전달에 사용하던 방식을 개선했지만, 추가적인 책임 분리 가능성 검토

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.