### PR TITLE
[BE - REFACTOR]  이메일 인증 로직을 Redis를 사용하도록 변경

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/common/email/service/EmailSender.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/email/service/EmailSender.java
@@ -49,19 +49,4 @@ public class EmailSender {
             throw new RuntimeException("Failed to send email", e);
         }
     }
-
-    private String getSubjectByPurpose(String purpose) {
-        return switch (purpose) {
-            case "sign-up" -> "[KakaoBase] 회원가입 인증 코드";
-            case "password-reset" -> "[KakaoBase] 비밀번호 재설정 인증 코드";
-            default -> "[KakaoBase] 인증 코드";
-        };
-    }
-
-    private String createEmailContent(String code, String purpose) {
-        Context context = new Context();
-        context.setVariable("code", code);
-        context.setVariable("purpose", purpose);
-        return templateEngine.process("verification-email", context);
-    }
 }

--- a/src/main/java/com/kakaobase/snsapp/global/config/RedisConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/RedisConfig.java
@@ -101,7 +101,7 @@ public class RedisConfig {
     }
 
     /**
-     * Embedded Redis 연결 팩토리 생성 (Connection Pool 포함)
+     * Embedded Redis 연결 팩토리 생성
      */
     private RedisConnectionFactory createEmbeddedRedisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #216

## 📌 개요
- 기존 HashMap으로 저장하던 이메일 인증 로직을 Redis를 사용하도록 수정

## 🔁 변경 사항
[[REFACTOR] 인증메일을 Redis기반으로 하도록 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/364c768d0fb9b231939dd7730b17b9dad3b0e47c)

[[REMOVE] 필요없는 메서드 제거](https://github.com/100-hours-a-week/22-tenten-be/commit/5b99c5f9c05a59e68417f30bfc0c207073d51f09)

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.