### PR TITLE
[BE - FEAT] 회원의 팔로우, 팔로잉 수에 캐싱 기능 추가 

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/FollowRepository.java
@@ -20,4 +20,14 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowCus
      * 특정 팔로우 관계 조회
      */
     Optional<Follow> findByFollowerUserAndFollowingUser(Member followerUser, Member followingUser);
+
+    /**
+     * 특정 Member가 다른 사람들을 팔로우한 관계들을 모두 삭제
+     */
+    Long deleteByFollowerUserId(Long followerUserId);
+
+    /**
+     * 특정 Member를 팔로우하는 관계들을 모두 삭제)
+     */
+    Long deleteByFollowingUserId(Long followingUserId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/custom/FollowCustomRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/custom/FollowCustomRepository.java
@@ -49,4 +49,37 @@ public interface FollowCustomRepository {
      * 특정 사용자의 팔로잉 수 조회
      */
     Long countFollowingsByFollowerUserId(Long followerUserId);
+
+    /**
+     * 특정 Member를 follower로 하는 모든 Follow 데이터 삭제
+     * (해당 Member가 다른 사람들을 팔로우한 관계들을 모두 삭제)
+     */
+    Long deleteByFollowerUserId(Long followerUserId);
+
+    /**
+     * 특정 Member를 following으로 하는 모든 Follow 데이터 삭제
+     * (해당 Member를 팔로우하는 관계들을 모두 삭제)
+     */
+    Long deleteByFollowingUserId(Long followingUserId);
+
+    /**
+     * 특정 유저를 팔로우한 모든 Member의 followingCount를 1씩 감소
+     * (특정 유저가 탈퇴할 때, 그 유저를 팔로우했던 사람들의 팔로잉 카운트 감소)
+     */
+    Long decrementFollowingCountForFollowersOf(Long followingUserId);
+
+    /**
+     * 특정 유저가 팔로잉한 모든 Member의 followerCount를 1씩 감소
+     * (특정 유저가 탈퇴할 때, 그 유저가 팔로우했던 사람들의 팔로워 카운트 감소)
+     */
+    Long decrementFollowerCountForFollowingsOf(Long followerUserId);
+
+    /**
+     * 회원 탈퇴 시 모든 팔로우 관계 정리 (4개 작업을 순차 실행)
+     * 1. 해당 유저를 팔로우한 사람들의 팔로잉 카운트 감소
+     * 2. 해당 유저가 팔로우한 사람들의 팔로워 카운트 감소
+     * 3. 해당 유저의 팔로잉 관계 삭제
+     * 4. 해당 유저의 팔로워 관계 삭제
+     */
+    void cleanupAllFollowRelationships(Long memberId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/repository/custom/FollowCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/repository/custom/FollowCustomRepositoryImpl.java
@@ -146,6 +146,90 @@ public class FollowCustomRepositoryImpl implements FollowCustomRepository {
                 .fetchOne();
     }
 
+    @Override
+    public void cleanupAllFollowRelationships(Long memberId) {
+        log.info("Starting cleanup of all follow relationships for member: {}", memberId);
+
+        // 1. 해당 유저를 팔로우한 사람들의 팔로잉 카운트 감소
+        Long decrementedFollowingCount = decrementFollowingCountForFollowersOf(memberId);
+        log.debug("Decremented following count for {} members", decrementedFollowingCount);
+
+        // 2. 해당 유저가 팔로우한 사람들의 팔로워 카운트 감소
+        Long decrementedFollowerCount = decrementFollowerCountForFollowingsOf(memberId);
+        log.debug("Decremented follower count for {} members", decrementedFollowerCount);
+
+        // 3. 해당 유저가 다른 사람들을 팔로우한 관계 삭제
+        Long deletedFollowingRelations = deleteByFollowerUserId(memberId);
+        log.debug("Deleted {} following relationships", deletedFollowingRelations);
+
+        // 4. 다른 사람들이 해당 유저를 팔로우한 관계 삭제
+        Long deletedFollowerRelations = deleteByFollowingUserId(memberId);
+        log.debug("Deleted {} follower relationships", deletedFollowerRelations);
+
+        log.info("Completed cleanup of all follow relationships for member: {} " +
+                        "(decremented: {} following, {} follower counts, deleted: {} following, {} follower relations)",
+                memberId, decrementedFollowingCount, decrementedFollowerCount,
+                deletedFollowingRelations, deletedFollowerRelations);
+    }
+
+    @Override
+    public Long deleteByFollowingUserId(Long followingUserId) {
+        log.info("Deleting all follow relationships where followingUserId = {}", followingUserId);
+
+        return queryFactory
+                .delete(follow)
+                .where(follow.followingUser.id.eq(followingUserId))
+                .execute();
+    }
+
+    @Override
+    public Long deleteByFollowerUserId(Long followerUserId) {
+        log.info("Deleting all follow relationships where followerUserId = {}", followerUserId);
+
+        return queryFactory
+                .delete(follow)
+                .where(follow.followerUser.id.eq(followerUserId))
+                .execute();
+    }
+
+    @Override
+    public Long decrementFollowingCountForFollowersOf(Long followingUserId) {
+        log.info("Decrementing followingCount for all followers of userId = {}", followingUserId);
+
+        return queryFactory
+                .update(QMember.member)
+                .set(QMember.member.followingCount, QMember.member.followingCount.subtract(1))
+                .where(
+                        QMember.member.id.in(
+                                queryFactory
+                                        .select(follow.followerUser.id)
+                                        .from(follow)
+                                        .where(follow.followingUser.id.eq(followingUserId))
+                        ),
+                        QMember.member.followingCount.gt(0) // 0보다 큰 경우에만 감소
+                )
+                .execute();
+    }
+
+    @Override
+    public Long decrementFollowerCountForFollowingsOf(Long followerUserId) {
+        log.info("Decrementing followerCount for all followings of userId = {}", followerUserId);
+
+        return queryFactory
+                .update(QMember.member)
+                .set(QMember.member.followerCount, QMember.member.followerCount.subtract(1))
+                .where(
+                        QMember.member.id.in(
+                                queryFactory
+                                        .select(follow.followingUser.id)
+                                        .from(follow)
+                                        .where(follow.followerUser.id.eq(followerUserId))
+                        ),
+                        QMember.member.followerCount.gt(0) // 0보다 큰 경우에만 감소
+                )
+                .execute();
+    }
+
     // === 헬퍼 메서드 ===
     private BooleanExpression cursorCondition(com.querydsl.core.types.dsl.NumberPath<Long> idPath, Long cursor) {
         return cursor != null ? idPath.gt(cursor) : null;

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/scheduler/FollowCacheSyncScehduler.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/scheduler/FollowCacheSyncScehduler.java
@@ -1,0 +1,20 @@
+package com.kakaobase.snsapp.domain.follow.scheduler;
+
+import com.kakaobase.snsapp.domain.follow.service.FollowCacheSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FollowCacheSyncScehduler {
+
+    private final FollowCacheSyncService followCacheSyncService;
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void syncPostCache() {
+        followCacheSyncService.syncCacheToDB();
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowCacheService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowCacheService.java
@@ -1,0 +1,87 @@
+package com.kakaobase.snsapp.domain.follow.service;
+
+import com.kakaobase.snsapp.domain.follow.util.FollowCacheUtil;
+import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
+import com.kakaobase.snsapp.global.common.redis.CacheRecord;
+import com.kakaobase.snsapp.global.common.redis.error.CacheException;
+import com.kakaobase.snsapp.global.common.redis.service.cacheService.AbstractCacheService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+public class FollowCacheService extends AbstractCacheService<CacheRecord.FollowStatsCache, Member> {
+    private static final String FOLLOW_CACHE_PREFIX = "follow:stats:";
+    private static final Duration CACHE_TTL = Duration.ofHours(24);
+    private final MemberRepository memberRepository;
+
+    public FollowCacheService(RedisTemplate<String, Object> redisTemplate,
+                              FollowCacheUtil cacheUtil,
+                              FollowCacheSyncService cacheSyncService,
+                              MemberRepository memberRepository) {
+        super(redisTemplate, cacheSyncService, cacheUtil);
+        this.memberRepository = memberRepository;
+    }
+
+    public void incrementFollowerCount(Long memberId) throws CacheException {
+        incrementField(memberId, "followerCount");
+    }
+
+    public void decrementFollowerCount(Long memberId) throws CacheException {
+        decrementField(memberId, "followerCount");
+    }
+
+    public void incrementFollowingCount(Long memberId) throws CacheException {
+        incrementField(memberId, "followingCount");
+    }
+
+    public void decrementFollowingCount(Long memberId) throws CacheException {
+        decrementField(memberId, "followingCount");
+    }
+
+    @Override
+    protected String generateCacheKey(Long id) {
+        return FOLLOW_CACHE_PREFIX + id;
+    }
+
+    @Override
+    protected Long extractId(Member member) {
+        return member.getId();
+    }
+
+    @Override
+    protected void saveFromDB(Long id) {
+        Member member = memberRepository.findById(id).orElse(null);
+        if(member == null) {
+            return;
+        }
+
+        var cacheData = CacheRecord.FollowStatsCache.builder()
+                .memberId(member.getId())
+                .followerCount(member.getFollowerCount())
+                .followingCount(member.getFollowingCount())
+                .build();
+
+        cacheUtil.save(generateCacheKey(id), cacheData);
+    }
+
+    @Override
+    protected void saveByEntity(Long id, Member member) {
+        var cacheData = CacheRecord.FollowStatsCache.builder()
+                .memberId(member.getId())
+                .followerCount(member.getFollowerCount())
+                .followingCount(member.getFollowingCount())
+                .build();
+
+        cacheUtil.save(generateCacheKey(id), cacheData);
+    }
+
+    @Override
+    protected Duration getTTL() {
+        return CACHE_TTL;
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowCacheSyncService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowCacheSyncService.java
@@ -1,0 +1,62 @@
+package com.kakaobase.snsapp.domain.follow.service;
+
+import com.kakaobase.snsapp.domain.follow.util.FollowCacheUtil;
+import com.kakaobase.snsapp.global.common.redis.CacheRecord;
+import com.kakaobase.snsapp.global.common.redis.service.cacheSyncService.AbstractCacheSyncService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@Slf4j
+@Service
+public class FollowCacheSyncService extends AbstractCacheSyncService<CacheRecord.FollowStatsCache> {
+    private static final String SYNC_QUEUE_KEY = "follows:need_sync";
+    private static final Duration CACHE_TTL = Duration.ofHours(24);
+
+    public FollowCacheSyncService(StringRedisTemplate redisTemplate,
+                                  FollowCacheUtil cacheUtil,
+                                  JdbcTemplate jdbcTemplate) {
+        super(redisTemplate, cacheUtil, jdbcTemplate);
+    }
+
+    @Override
+    protected String getSyncKey() {
+        return SYNC_QUEUE_KEY;
+    }
+
+    @Override
+    protected Duration getTTL() {
+        return CACHE_TTL;
+    }
+
+    @Override
+    protected Object[] extractSqlParameters(CacheRecord.FollowStatsCache cache) {
+        return new Object[]{
+                cache.followerCount(),
+                cache.followingCount(),
+                cache.memberId()
+        };
+    }
+
+    @Override
+    protected Object extractEntityId(CacheRecord.FollowStatsCache cache) {
+        return cache.memberId();
+    }
+
+    @Override
+    protected int[] executeJdbcBatchUpdate(List<Object[]> batchArgs) {
+        String sql = """
+            UPDATE members 
+            SET follower_count = ?, 
+                following_count = ?,
+                updated_at = NOW()
+            WHERE id = ? AND deleted_at IS NULL
+            """;
+
+        return jdbcTemplate.batchUpdate(sql, batchArgs);
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/service/FollowService.java
@@ -10,7 +10,9 @@ import com.kakaobase.snsapp.domain.follow.repository.FollowRepository;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
+import com.kakaobase.snsapp.global.common.redis.error.CacheException;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
+import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +28,8 @@ public class FollowService {
     private final FollowRepository followRepository;
     private final FollowConverter followConverter;
     private final MemberRepository memberRepository;
+    private final FollowCacheService followCacheService;
+    private final EntityManager em;
 
 
     @Transactional
@@ -37,42 +41,65 @@ public class FollowService {
             throw new FollowException(GeneralErrorCode.INVALID_FORMAT, "스스로를 팔로잉 할 수 없습니다");
         }
 
+        if(!memberRepository.existsById(targetUserId)) {
+            throw new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND,"userId");
+        }
+
         //팔로잉 신청한 사람
-        Member followerUser = memberRepository.findById(currentUserId)
-                .orElseThrow(()-> new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
-
-        //팔로잉 요청 받은 사람
-        Member followingUser = memberRepository.findById(targetUserId)
-                .orElseThrow(()-> new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "targetUserId"));
-
+        Member followerUser = em.getReference(Member.class, currentUserId);
+        //팔로우 신청 받은 사람
+        Member followingUser = em.getReference(Member.class, targetUserId);
+        
         if(followRepository.existsByFollowerUserAndFollowingUser(followerUser, followingUser)){
             throw new FollowException(FollowErrorCode.ALREADY_FOLLOWING);
         }
 
+        //캐싱 시도
+        try{
+            followCacheService.incrementFollowingCount(currentUserId);
+            followCacheService.incrementFollowerCount(targetUserId);
+        } catch (CacheException e) {
+            log.error(e.getMessage());
+            followerUser.incrementFollowingCount();
+            followingUser.incrementFollowerCount();
+        }
+
         Follow follow = followConverter.toFollowEntity(followerUser, followingUser);
         followRepository.save(follow);
-
-        followerUser.incrementFollowingCount();
-        followingUser.incrementFollowerCount();
     }
 
     @Transactional
     public void removeFollowing(Long targetUserId, CustomUserDetails userDetails){
 
+        Long currentUserId = Long.valueOf(userDetails.getId());
+
+        if(targetUserId.equals(currentUserId)) {
+            throw new FollowException(GeneralErrorCode.INVALID_FORMAT, "스스로를 언팔로잉 할 수 없습니다");
+        }
+
+        if(!memberRepository.existsById(targetUserId)) {
+            throw new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND,"userId");
+        }
+
         //팔로잉 신청한 사람
-        Member followerUser = memberRepository.findById(Long.valueOf(userDetails.getId()))
-                .orElseThrow(()-> new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "userId"));
-        //팔로잉 요청 받은 사람
-        Member followingUser = memberRepository.findById(targetUserId)
-                .orElseThrow(()-> new FollowException(GeneralErrorCode.RESOURCE_NOT_FOUND, "targetUserId"));
+        Member followerUser = em.getReference(Member.class, currentUserId);
+        //팔로우 신청 받은 사람
+        Member followingUser = em.getReference(Member.class, targetUserId);
 
         Follow follow = followRepository.findByFollowerUserAndFollowingUser(followerUser, followingUser)
                 .orElseThrow(()-> new FollowException(FollowErrorCode.ALREADY_UNFOLLOWING));
 
-        followRepository.delete(follow);
+        //캐싱 시도
+        try{
+            followCacheService.decrementFollowingCount(currentUserId);
+            followCacheService.decrementFollowerCount(targetUserId);
+        } catch (CacheException e) {
+            log.error(e.getMessage());
+            followerUser.decrementFollowingCount();
+            followingUser.decrementFollowerCount();
+        }
 
-        followerUser.decrementFollowingCount();
-        followingUser.decrementFollowerCount();
+        followRepository.delete(follow);
     }
 
 

--- a/src/main/java/com/kakaobase/snsapp/domain/follow/util/FollowCacheUtil.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/follow/util/FollowCacheUtil.java
@@ -1,0 +1,26 @@
+package com.kakaobase.snsapp.domain.follow.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kakaobase.snsapp.global.common.redis.CacheRecord;
+import com.kakaobase.snsapp.global.common.redis.util.AbstractCacheUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class FollowCacheUtil extends AbstractCacheUtil<CacheRecord.FollowStatsCache> {
+
+    public FollowCacheUtil(RedisTemplate<String, Object> redisTemplate,
+                           ObjectMapper objectMapper,
+                           RedissonClient redissonClient) {
+        super(redisTemplate, objectMapper, redissonClient);
+    }
+
+    @Override
+    protected Class<CacheRecord.FollowStatsCache> getType() {
+        return CacheRecord.FollowStatsCache.class;
+    }
+
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/members/converter/MemberConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/converter/MemberConverter.java
@@ -1,8 +1,11 @@
 package com.kakaobase.snsapp.domain.members.converter;
 
+import com.kakaobase.snsapp.domain.follow.service.FollowCacheService;
 import com.kakaobase.snsapp.domain.members.dto.MemberRequestDto;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.global.common.redis.CacheRecord;
+import com.kakaobase.snsapp.global.common.redis.error.CacheException;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import com.kakaobase.snsapp.global.error.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ import java.util.stream.Collectors;
 public class MemberConverter {
 
     private final PasswordEncoder passwordEncoder;
+    private final FollowCacheService followCacheService;
 
     /**
      * 회원가입 요청 DTO를 Member 엔티티로 변환합니다.
@@ -79,20 +83,37 @@ public class MemberConverter {
     }
 
     public MemberResponseDto.Mypage toMypage(Member member, Long postCount, Boolean isMe, boolean isFollowing) {
-        return MemberResponseDto.Mypage
-                .builder()
-                .id(member.getId())
-                .name(member.getName())
-                .nickname(member.getNickname())
-                .imageUrl(member.getProfileImgUrl())
-                .githubUrl(member.getGithubUrl())
-                .className(member.getClassName())
-                .postCount(postCount)
-                .followerCount(member.getFollowerCount())
-                .followingCount(member.getFollowingCount())
-                .isMe(isMe)
-                .isFollowed(isFollowing)
-                .build();
-
+        try {
+            CacheRecord.FollowStatsCache cacheData = followCacheService.findBy(member.getId());
+            return MemberResponseDto.Mypage
+                    .builder()
+                    .id(member.getId())
+                    .name(member.getName())
+                    .nickname(member.getNickname())
+                    .imageUrl(member.getProfileImgUrl())
+                    .githubUrl(member.getGithubUrl())
+                    .className(member.getClassName())
+                    .postCount(postCount)
+                    .followerCount(cacheData.followerCount())
+                    .followingCount(cacheData.followingCount())
+                    .isMe(isMe)
+                    .isFollowed(isFollowing)
+                    .build();
+        } catch (CacheException e) {
+            return MemberResponseDto.Mypage
+                    .builder()
+                    .id(member.getId())
+                    .name(member.getName())
+                    .nickname(member.getNickname())
+                    .imageUrl(member.getProfileImgUrl())
+                    .githubUrl(member.getGithubUrl())
+                    .className(member.getClassName())
+                    .postCount(postCount)
+                    .followerCount(member.getFollowerCount())
+                    .followingCount(member.getFollowingCount())
+                    .isMe(isMe)
+                    .isFollowed(isFollowing)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/dto/MemberResponseDto.java
@@ -84,11 +84,11 @@ public class MemberResponseDto {
             
             @Schema(description = "회원의 팔로워 수", example = "14")
             @JsonProperty("follower_count")
-            Integer followerCount,
+            Long followerCount,
 
             @Schema(description = "회원의 팔로잉 수", example = "55")
             @JsonProperty("following_count")
-            Integer followingCount,
+            Long followingCount,
 
             @Schema(description = "본인 여부", example = "true")
             @JsonProperty("is_me")

--- a/src/main/java/com/kakaobase/snsapp/domain/members/entity/Member.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/entity/Member.java
@@ -72,11 +72,11 @@ public class Member extends BaseSoftDeletableEntity {
 
     @Column(name = "following_count", nullable = false)
     @ColumnDefault("0")
-    private Integer followingCount = 0;
+    private Long followingCount = 0L;
 
     @Column(name = "follower_count", nullable = false)
     @ColumnDefault("0")
-    private Integer followerCount = 0;
+    private Long followerCount = 0L;
 
     @Builder
     public Member(String email, String name, String nickname, String password, ClassName className, String githubUrl) {
@@ -146,7 +146,7 @@ public class Member extends BaseSoftDeletableEntity {
     }
 
 
-    public void updateFollowingCount(Integer followingCount) {
+    public void updateFollowingCount(Long followingCount) {
         this.followingCount = followingCount;
     }
 
@@ -166,7 +166,7 @@ public class Member extends BaseSoftDeletableEntity {
         }
     }
 
-    public void updateFollowerCount(Integer followerCount) {
+    public void updateFollowerCount(Long followerCount) {
         this.followerCount = followerCount;
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/members/repository/MemberRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/repository/MemberRepository.java
@@ -56,15 +56,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      */
     List<Member> findByIdIn(List<Long> ids);
 
-    /**
-     * 특정 회원의 프로필 정보와 팔로우 통계를 조회합니다.
-     * 필요한 컬럼만 선택하여 성능을 최적화합니다.
-     *
-     * @param id 회원 ID
-     * @return 회원 프로필 정보
-     */
-    @Query("SELECT m FROM Member m WHERE m.id = :id")
-    Optional<Member> findProfileById(@Param("id") Long id);
 
     /**
      * 여러 회원 ID로 회원 목록을 조회합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -259,20 +259,18 @@ public class MemberService {
             Long id = member.getId();
 
             // 팔로잉 카운트 동기화
-            Integer newFollowingCount = followingCounts.getOrDefault(id, 0L).intValue();
+            Long newFollowingCount = followingCounts.getOrDefault(id, 0L);
             if (!member.getFollowingCount().equals(newFollowingCount)) {
                 member.updateFollowingCount(newFollowingCount);
             }
 
             // 팔로워 카운트 동기화
-            Integer newFollowerCount = followerCounts.getOrDefault(id, 0L).intValue();
+            Long newFollowerCount = followerCounts.getOrDefault(id, 0L);
             if (!member.getFollowerCount().equals(newFollowerCount)) {
                 member.updateFollowerCount(newFollowerCount);
             }
         });
     }
-
-
 
     private Long getCurrentUserId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/members/service/MemberService.java
@@ -135,8 +135,10 @@ public class MemberService {
             throw new MemberException(MemberErrorCode.EMAIL_VERIFICATION_FAILED);
         }
 
+        followRepository.cleanupAllFollowRelationships(member.getId());
+
         // Member 엔티티 삭제
-        member.softDelete();
+        memberRepository.delete(member);
 
     }
 

--- a/src/main/java/com/kakaobase/snsapp/global/common/redis/CacheRecord.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/redis/CacheRecord.java
@@ -29,9 +29,12 @@ public class CacheRecord {
             Long commentId,
             Long likeCount,
             Long recommentCount
-    ) {
-        public static CommentStatsCache createDefault(Long commentId) {
-            return new CommentStatsCache(commentId, 0L, 0L);
-        }
-    }
+    ) {}
+
+    @Builder
+    public record FollowStatsCache(
+            Long memberId,
+            Long followerCount,
+            Long followingCount
+    ) {}
 }

--- a/src/main/java/com/kakaobase/snsapp/global/common/redis/error/CacheErrorCode.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/redis/error/CacheErrorCode.java
@@ -9,11 +9,10 @@ public enum CacheErrorCode{
 
     LOCK_ERROR("락 수행중 예외 발생"),
     LOCK_ACQUISITION_FAIL("락 수행중 예외 발생"),
-    CACHING_ERROR("캐시 생성중 에러 발생"),
+    CREATE_CACHE_ERROR("캐시 생성중 에러 발생"),
     CACHE_ALREADY_EXISTS("이미 존재하는 캐시에 생성 시도"),
     SYNC_ERROR("캐시 동기화 중 에러 발생"),
-    FIELD_UPDATE_ERROR("필드 업데이트 중 오류 발생"),
-    EX("그외");
+    FIELD_UPDATE_ERROR("필드 업데이트 중 오류 발생");
 
     private final String message;
 }

--- a/src/test/java/com/kakaobase/snsapp/domain/members/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/kakaobase/snsapp/domain/members/repository/MemberRepositoryTest.java
@@ -330,35 +330,6 @@ class MemberRepositoryTest {
 
     // === 프로필 조회 테스트 ===
 
-    @Test
-    @DisplayName("프로필 정보를 조회할 수 있다")
-    void findProfileById_WithValidId_ReturnsProfile() {
-        // given
-        Long validId = testMember.getId();
-
-        // when
-        Optional<Member> result = memberRepository.findProfileById(validId);
-
-        // then
-        assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(validId);
-        assertThat(result.get().getNickname()).isNotNull();
-        assertThat(result.get().getEmail()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 ID로 프로필 조회 시 빈 Optional을 반환한다")
-    void findProfileById_WithNonExistentId_ReturnsEmpty() {
-        // given
-        Long nonExistentId = 999999L;
-
-        // when
-        Optional<Member> result = memberRepository.findProfileById(nonExistentId);
-
-        // then
-        assertThat(result).isEmpty();
-    }
-
 
     // === 데이터 무결성 및 이메일 인증 연동 테스트 ===
 


### PR DESCRIPTION
# 팔로우 시스템 캐싱 및 회원 탈퇴 시 데이터 정리 기능 구현

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #231

## 📌 개요
- 팔로워/팔로잉 수 조회 성능 최적화를 위한 Redis 캐싱 시스템 구현
- 회원 탈퇴 시 팔로우 관계 및 관련 카운트를 일괄 정리하는 기능 구현
- DB와 캐시 간 데이터 일관성 보장을 위한 동기화 스케줄러 구현

## 🔁 변경 사항

### 🚀 캐싱 시스템 구현
- **FollowCacheUtil**: Redis를 활용한 팔로워/팔로잉 수 캐싱 유틸리티 구현
- **FollowCacheService**: Look-aside 패턴으로 캐시 우선 조회 로직 구현
- **FollowCacheSyncService**: DB와 캐시 간 데이터 동기화 서비스 구현
- **스케줄러**: 주기적으로 캐시 데이터를 DB에 동기화하는 배치 작업 구현

### 🔧 데이터 타입 최적화
- Member Entity 및 관련 DTO의 `followingCount`, `followerCount` 타입을 `Integer`에서 `Long`으로 변경
- 대규모 사용자 환경에서의 확장성 고려

### 🗑️ 회원 탈퇴 시 데이터 정리
- **FollowCustomRepository**에 회원 탈퇴 시 필요한 메서드들 구현:
  - `deleteByFollowerUserId()`: 특정 회원이 팔로우한 모든 관계 삭제
  - `deleteByFollowingUserId()`: 특정 회원을 팔로우하는 모든 관계 삭제
  - `decrementFollowingCountForFollowersOf()`: 탈퇴 회원을 팔로우했던 사용자들의 팔로잉 수 감소
  - `decrementFollowerCountForFollowingsOf()`: 탈퇴 회원이 팔로우했던 사용자들의 팔로워 수 감소
  - `cleanupAllFollowRelationships()`: 위 4가지 작업을 순차적으로 처리하는 통합 메서드

### 🎯 성능 최적화
- QueryDSL을 활용한 대량 데이터 처리로 N+1 문제 해결
- 단일 쿼리로 여러 회원의 카운트를 일괄 업데이트하여 성능 향상
- 트랜잭션을 통한 데이터 일관성 보장

### 🧹 코드 정리
- MemberRepository에서 사용되지 않는 메서드 삭제
- 에러 메시지의 변수명을 직관적으로 수정

## 👀 기타 더 이야기해볼 점
- **회원탈퇴시 캐싱된 FollowerCount와 FollowingCount값과 DB의 값 정합성 불일치 가능성 존재**
- 캐시 무효화 전략 및 캐시 만료 시간 정책 검토 필요
- 대량의 팔로우 관계를 가진 인플루언서급 사용자 탈퇴 시 성능 영향도 모니터링 필요
- Redis 클러스터 환경에서의 캐시 일관성 고려사항

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.