### PR TITLE
[BE - FIX] 소셜봇 대댓글 작성시 에러 수정 및 대댓글 작성시 recommentCount가 안올라가는 버그 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/BotRecommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/BotRecommentConverter.java
@@ -5,14 +5,16 @@ import com.kakaobase.snsapp.domain.comments.entity.Comment;
 import com.kakaobase.snsapp.domain.comments.entity.Recomment;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
+import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 
+@Component
 public class BotRecommentConverter {
 
-    public static BotRecommentRequestDto toRequestDto(
+    public BotRecommentRequestDto toRequestDto(
             Post post,
             Member postWriter,
             Comment comment,
@@ -22,7 +24,7 @@ public class BotRecommentConverter {
                 post.getId(),
                 new BotRecommentRequestDto.UserDto(
                         postWriter.getNickname(),
-                        postWriter.getClassName().toString()
+                        postWriter.getClassName()
                 ),
                 formatUtc(post.getCreatedAt().toInstant(ZoneOffset.UTC)),
                 post.getContent()
@@ -32,7 +34,7 @@ public class BotRecommentConverter {
                 .map(r -> new BotRecommentRequestDto.RecommentDto(
                         new BotRecommentRequestDto.UserDto(
                                 r.getMember().getNickname(),
-                                r.getMember().getClassName().toString()
+                                r.getMember().getClassName()
                         ),
                         formatUtc(r.getCreatedAt().toInstant(ZoneOffset.UTC)),
                         r.getContent()
@@ -43,7 +45,7 @@ public class BotRecommentConverter {
                 comment.getId(),
                 new BotRecommentRequestDto.UserDto(
                         comment.getMember().getNickname(),
-                        comment.getMember().getClassName().toString()
+                        comment.getMember().getClassName()
                 ),
                 formatUtc(comment.getCreatedAt().toInstant(ZoneOffset.UTC)),
                 comment.getContent(),
@@ -57,7 +59,7 @@ public class BotRecommentConverter {
         );
     }
 
-    private static String formatUtc(Instant instant) {
+    private String formatUtc(Instant instant) {
         // 마이크로초까지만 출력하고 Z 붙이기
         long seconds = instant.getEpochSecond();
         int micros = instant.getNano() / 1000;  // 나노초를 마이크로초로 변환

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
@@ -8,7 +8,7 @@ import com.kakaobase.snsapp.domain.comments.entity.Recomment;
 import com.kakaobase.snsapp.domain.comments.entity.RecommentLike;
 import com.kakaobase.snsapp.domain.comments.exception.CommentErrorCode;
 import com.kakaobase.snsapp.domain.comments.exception.CommentException;
-import com.kakaobase.snsapp.domain.comments.service.CommentCacheService;
+import com.kakaobase.snsapp.domain.comments.service.cache.CommentCacheService;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.posts.entity.Post;

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/converter/CommentConverter.java
@@ -119,36 +119,6 @@ public class CommentConverter {
     }
 
     /**
-     * 대댓글 엔티티를 대댓글 상세 정보 DTO로 변환
-     */
-    public CommentResponseDto.RecommentInfo toRecommentInfo(
-            Recomment recomment,
-            Long currentMemberId,
-            Set<Long> likedRecommentIds,
-            Set<Long> followingMemberIds
-    ) {
-
-        Member commentOwner = recomment.getMember();
-
-        var userInfo = MemberResponseDto.UserInfoWithFollowing.builder()
-                        .id(commentOwner.getId())
-                        .imageUrl(commentOwner.getProfileImgUrl())
-                        .nickname(commentOwner.getNickname())
-                        .isFollowed(followingMemberIds != null && followingMemberIds.contains(commentOwner.getId()))
-                        .build();
-
-        return new CommentResponseDto.RecommentInfo(
-                recomment.getId(),
-                userInfo,
-                recomment.getContent(),
-                recomment.getCreatedAt(),
-                recomment.getLikeCount(),
-                recomment.getMember().getId().equals(currentMemberId),
-                likedRecommentIds != null && likedRecommentIds.contains(recomment.getId())
-        );
-    }
-
-    /**
      * 댓글 좋아요 엔티티 생성
      */
     public CommentLike toCommentLikeEntity(Long memberId, Long commentId) {
@@ -181,35 +151,6 @@ public class CommentConverter {
         if (content.length() > 2000) {
             throw new CommentException(CommentErrorCode.CONTENT_LENGTH_EXCEEDED);
         }
-    }
-
-    /**
-     * 소셜봇용 대댓글 응답 DTO 생성
-     *
-     * 로그인 사용자 정보 없이 기본 정보만 포함합니다.
-     * 좋아요 수, is_mine, is_liked, is_followed 모두 false 또는 0으로 초기화됩니다.
-     *
-     * @param recomment 생성된 대댓글 엔티티
-     * @param bot       소셜봇 사용자
-     * @return 대댓글 응답 DTO
-     */
-    public CommentResponseDto.RecommentInfo toRecommentInfoForBot(Recomment recomment, Member bot) {
-        var userInfo = MemberResponseDto.UserInfoWithFollowing.builder()
-                        .id(bot.getId())
-                        .nickname(bot.getNickname())
-                        .imageUrl(bot.getProfileImgUrl())
-                        .isFollowed(false)
-                        .build();
-
-        return new CommentResponseDto.RecommentInfo(
-                recomment.getId(),
-                userInfo,
-                recomment.getContent(),
-                recomment.getCreatedAt(),
-                0L,       // like_count
-                false,   // is_mine
-                false    // is_liked
-        );
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/scheduler/CommentCacheSyncScheduler.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/scheduler/CommentCacheSyncScheduler.java
@@ -1,7 +1,7 @@
 package com.kakaobase.snsapp.domain.comments.scheduler;
 
 
-import com.kakaobase.snsapp.domain.comments.service.CommentCacheSyncService;
+import com.kakaobase.snsapp.domain.comments.service.cache.CommentCacheSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/BotRecommentService.java
@@ -31,7 +31,6 @@ public class BotRecommentService {
     private final MemberRepository memberRepository;
     private final WebClient webClient;
     private final CommentCacheService commentCacheService;
-    private final CommentRepository commentRepository;
     private final BotRecommentConverter botRecommentConverter;
 
     @Value("${ai.server.url}")

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentLikeService.java
@@ -11,6 +11,7 @@ import com.kakaobase.snsapp.domain.comments.repository.CommentLikeRepository;
 import com.kakaobase.snsapp.domain.comments.repository.CommentRepository;
 import com.kakaobase.snsapp.domain.comments.repository.RecommentLikeRepository;
 import com.kakaobase.snsapp.domain.comments.repository.RecommentRepository;
+import com.kakaobase.snsapp.domain.comments.service.cache.CommentCacheService;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -11,18 +11,19 @@ import com.kakaobase.snsapp.domain.comments.repository.CommentLikeRepository;
 import com.kakaobase.snsapp.domain.comments.repository.CommentRepository;
 import com.kakaobase.snsapp.domain.comments.repository.RecommentLikeRepository;
 import com.kakaobase.snsapp.domain.comments.repository.RecommentRepository;
+import com.kakaobase.snsapp.domain.comments.service.async.CommentAsyncService;
+import com.kakaobase.snsapp.domain.comments.service.cache.CommentCacheService;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
-import com.kakaobase.snsapp.domain.posts.service.PostCacheService;
+import com.kakaobase.snsapp.domain.posts.service.cache.PostCacheService;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,10 +46,10 @@ public class CommentService {
     private final CommentLikeRepository commentLikeRepository;
     private final EntityManager em;
 
-    private final BotRecommentService botRecommentService;
     private final PostRepository postRepository;
     private final CommentCacheService commentCacheService;
     private final RecommentLikeRepository recommentLikeRepository;
+    private final CommentAsyncService commentAsyncService;
 
     /**
      * 댓글을 생성합니다.
@@ -114,7 +115,7 @@ public class CommentService {
         // 게시물 작성자가 소셜봇이면 소셜봇 대댓글 로직 구현하도록
         if (post.getMember().getRole().equals("BOT")) {
             log.info("🤖 [Trigger] 소셜봇 게시글이므로 트리거 실행!");
-            botRecommentService.triggerAsync(post, savedComment);
+            commentAsyncService.triggerAsync(post, savedComment);
         } else {
             log.info("🙅 [Skip] 게시글 작성자가 소셜봇이 아님 → 트리거 생략");
         }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -22,6 +22,7 @@ import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/async/CommentAsyncService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/async/CommentAsyncService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/async/CommentAsyncService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/async/CommentAsyncService.java
@@ -1,0 +1,29 @@
+package com.kakaobase.snsapp.domain.comments.service.async;
+
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
+import com.kakaobase.snsapp.domain.comments.service.BotRecommentService;
+import com.kakaobase.snsapp.domain.posts.entity.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentAsyncService {
+
+    private final BotRecommentService botRecommentService;
+
+    @Async
+    public void triggerAsync(Post post, Comment comment) {
+        try {
+            log.info("🚀 [BotTrigger] 비동기 트리거 시작 - postId={}, commentId={}", post.getId(), comment.getId());
+            botRecommentService.handle(post, comment);
+            log.info("✅ [BotTrigger] 성공적으로 처리됨");
+        } catch (Exception e) {
+            log.error("❌ [BotTrigger] 실패 - reason: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/cache/CommentCacheService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/cache/CommentCacheService.java
@@ -1,4 +1,4 @@
-package com.kakaobase.snsapp.domain.comments.service;
+package com.kakaobase.snsapp.domain.comments.service.cache;
 
 
 import com.kakaobase.snsapp.domain.comments.dto.CommentResponseDto;

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/cache/CommentCacheSyncService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/cache/CommentCacheSyncService.java
@@ -1,4 +1,4 @@
-package com.kakaobase.snsapp.domain.comments.service;
+package com.kakaobase.snsapp.domain.comments.service.cache;
 
 import com.kakaobase.snsapp.domain.comments.util.CommentCacheUtil;
 import com.kakaobase.snsapp.global.common.redis.CacheRecord;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -8,6 +8,7 @@ import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.entity.PostImage;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.service.PostCacheService;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.redis.CacheRecord;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
@@ -33,10 +34,10 @@ public class PostConverter {
      * @param boardType 게시판 타입
      * @return 생성된 Post 엔티티
      */
-    public static Post toPost(
+    public Post toPost(
             PostRequestDto.PostCreateRequestDto requestDto,
             Member member,
-            Post.BoardType boardType) {
+            BoardType boardType) {
 
         return Post.builder()
                 .member(member)
@@ -50,7 +51,7 @@ public class PostConverter {
      * 게시글 이미지 엔티티를 생성합니다
      *
      */
-    public static PostImage toPostImage(
+    public PostImage toPostImage(
             Post post,
             Integer sortIndex,
             String imageUrl) {
@@ -101,15 +102,19 @@ public class PostConverter {
      * @return BoardType enum 값
      * @throws IllegalArgumentException 유효하지 않은 postType인 경우
      */
-    public static Post.BoardType toBoardType(String postType) {
+    public BoardType toBoardType(String postType) {
+        if(postType == null || postType.isBlank()){
+            log.error("잘못된 게시판 타입: {}", postType);
+            throw new PostException(GeneralErrorCode.INVALID_FORMAT, "postType");
+        }
+
         try {
             if ("all".equalsIgnoreCase(postType)) {
-                return Post.BoardType.ALL;
+                return BoardType.ALL;
             }
 
             // snake_case를 대문자와 underscore로 변환 (pangyo_1 -> PANGYO_1)
-            String enumFormat = postType.toUpperCase();
-            return Post.BoardType.valueOf(enumFormat);
+            return BoardType.valueOf(postType.toUpperCase());
         } catch (IllegalArgumentException e) {
             throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "postType");
         }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -7,7 +7,7 @@ import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.entity.PostImage;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
-import com.kakaobase.snsapp.domain.posts.service.PostCacheService;
+import com.kakaobase.snsapp.domain.posts.service.cache.PostCacheService;
 import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.redis.CacheRecord;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/dto/BotRequestDto.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/dto/BotRequestDto.java
@@ -19,13 +19,14 @@ public class BotRequestDto {
      * @param boardType 게시판 타입 (PANGYO_2 등)
      * @param posts 최근 5개 게시글 정보
      */
+    @Builder
     @Schema(description = "AI 서버 게시글 생성 요청")
     public record CreatePostRequest(
-            @Schema(description = "게시판 타입", example = "PANGYO_2", required = true)
+            @Schema(description = "게시판 타입", example = "PANGYO_2")
             @JsonProperty("board_type")
             String boardType,
 
-            @Schema(description = "최근 5개 게시글 목록", required = true)
+            @Schema(description = "최근 5개 게시글 목록")
             List<PostDto> posts
     ) { }
 
@@ -39,17 +40,16 @@ public class BotRequestDto {
     @Builder
     @Schema(description = "게시글 정보")
     public record PostDto(
-            @Schema(description = "게시글 작성자 정보", required = true)
+            @Schema(description = "게시글 작성자 정보")
             UserDto user,
 
-            @Schema(description = "게시글 작성 시각", example = "2025-04-27T10:30:32.311141Z", required = true)
+            @Schema(description = "게시글 작성 시각", example = "2025-04-27T10:30:32.311141Z")
             @JsonProperty("created_at")
             String createdAt,
 
-            @Schema(description = "게시글 내용", example = "좋은아침입니당", required = true)
+            @Schema(description = "게시글 내용", example = "좋은아침입니당")
             String content
-    ) {
-    }
+    ) {}
 
     /**
      * 사용자 정보 DTO
@@ -57,16 +57,16 @@ public class BotRequestDto {
      * @param nickname 사용자 닉네임
      * @param className 사용자 기수
      */
+    @Builder
     @Schema(description = "사용자 정보")
     public record UserDto(
-            @Schema(description = "사용자 닉네임", example = "hazel.kim", required = true)
+            @Schema(description = "사용자 닉네임", example = "hazel.kim")
             String nickname,
 
-            @Schema(description = "사용자 기수", example = "PANGYO_2", required = true)
+            @Schema(description = "사용자 기수", example = "PANGYO_2")
             @JsonProperty("class_name")
             String className
-    ) {
-    }
+    ) {}
 
     /**
      * AI 서버로부터의 게시글 생성 응답 DTO
@@ -120,7 +120,7 @@ public class BotRequestDto {
             @Schema(description = "에러 메시지", example = "전달받은 게시글이 5개 미만입니다.")
             String message,
 
-            @Schema(description = "에러 필드 목록", example = "[\"body\", \"board_type\"]", required = false)
+            @Schema(description = "에러 필드 목록", example = "[\"body\", \"board_type\"]")
             List<String> field
     ) {
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -1,6 +1,7 @@
 package com.kakaobase.snsapp.domain.posts.entity;
 
 import com.kakaobase.snsapp.domain.members.entity.Member;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -66,15 +67,6 @@ public class Post extends BaseSoftDeletableEntity {
         this.boardType = boardType;
         this.content = content;
         this.youtubeUrl = youtubeUrl;
-    }
-
-    public enum BoardType {
-        ALL,        // 전체 게시판
-        PANGYO_1,   // 판교 1기 게시판
-        PANGYO_2,   // 판교 2기 게시판
-        JEJU_1,     // 제주 1기 게시판
-        JEJU_2,     // 제주 2기 게시판
-        JEJU_3      // 제주 3기 게시판
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCounter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCounter.java
@@ -1,6 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.event;
 
-import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
@@ -22,7 +22,7 @@ public class PostCounter {
      *
      * <p>스레드 안전성을 위해 ConcurrentHashMap과 AtomicInteger를 사용합니다.</p>
      */
-    private final Map<Post.BoardType, AtomicInteger> counters = new ConcurrentHashMap<>();
+    private final Map<BoardType, AtomicInteger> counters = new ConcurrentHashMap<>();
 
     /**
      * 게시글 카운터 증가
@@ -32,7 +32,7 @@ public class PostCounter {
      * @param boardType 게시판 타입
      * @return 증가 후 카운터 값
      */
-    public int increment(Post.BoardType boardType) {
+    public int increment(BoardType boardType) {
         AtomicInteger counter = counters.computeIfAbsent(boardType, k -> new AtomicInteger(0));
         int newValue = counter.incrementAndGet();
         log.debug("카운터 증가 - boardType: {}, count: {}", boardType, newValue);
@@ -46,7 +46,7 @@ public class PostCounter {
      *
      * @param boardType 게시판 타입
      */
-    public void reset(Post.BoardType boardType) {
+    public void reset(BoardType boardType) {
         counters.computeIfAbsent(boardType, k -> new AtomicInteger(0)).set(0);
         log.debug("카운터 리셋 - boardType: {}", boardType);
     }
@@ -59,7 +59,7 @@ public class PostCounter {
      * @param boardType 게시판 타입
      * @return 현재 카운터 값
      */
-    public int getCount(Post.BoardType boardType) {
+    public int getCount(BoardType boardType) {
         AtomicInteger counter = counters.get(boardType);
         int count = (counter != null) ? counter.get() : 0;
         log.debug("카운터 조회 - boardType: {}, count: {}", boardType, count);

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCreatedEvent.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostCreatedEvent.java
@@ -1,6 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.event;
 
-import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
@@ -23,7 +23,7 @@ public class PostCreatedEvent extends ApplicationEvent {
     /**
      * 게시판 타입
      */
-    private final Post.BoardType boardType;
+    private final BoardType boardType;
 
     /**
      * 게시글 작성자 ID
@@ -43,7 +43,7 @@ public class PostCreatedEvent extends ApplicationEvent {
      * @param boardType 게시판 타입
      * @param memberId 작성자 ID
      */
-    public PostCreatedEvent(Object source, Long postId, Post.BoardType boardType, Long memberId) {
+    public PostCreatedEvent(Object source, Long postId, BoardType boardType, Long memberId) {
         super(source);
         this.postId = postId;
         this.boardType = boardType;
@@ -58,7 +58,7 @@ public class PostCreatedEvent extends ApplicationEvent {
      * @param boardType 게시판 타입
      * @param memberId 작성자 ID
      */
-    public PostCreatedEvent(Long postId, Post.BoardType boardType, Long memberId) {
+    public PostCreatedEvent(Long postId, BoardType boardType, Long memberId) {
         this(postId, postId, boardType, memberId);
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostEventListener.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/event/PostEventListener.java
@@ -1,7 +1,7 @@
 package com.kakaobase.snsapp.domain.posts.event;
 
-import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.service.BotPostService;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.constant.BotConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +37,7 @@ public class PostEventListener {
                 event.getPostId(), event.getBoardType(), event.getMemberId());
 
         try {
-            Post.BoardType boardType = event.getBoardType();
+            BoardType boardType = event.getBoardType();
 
             // 모든 게시글에 대해 카운터 증가
             int currentCount = postCounter.increment(boardType);

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.kakaobase.snsapp.domain.posts.repository;
 
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.repository.custom.PostCustomRepository;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -27,6 +28,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
      */
     long countByMemberId(Long memberId);
 
-    List<Post> findTop10ByBoardTypeOrderByCreatedAtDescIdDesc(Post.BoardType boardType);
+    List<Post> findTop10ByBoardTypeOrderByCreatedAtDescIdDesc(BoardType boardType);
 
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepository.java
@@ -1,7 +1,7 @@
 package com.kakaobase.snsapp.domain.posts.repository.custom;
 
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
-import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,7 +11,7 @@ public interface PostCustomRepository {
     Optional<PostResponseDto.PostDetails> findPostDetailById(Long postId, Long memberId);
 
     List<PostResponseDto.PostDetails> findByBoardTypeWithCursor(
-            Post.BoardType boardType,
+            BoardType boardType,
             Long cursor,
             int limit,
             Long memberId);

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.kakaobase.snsapp.domain.follow.entity.QFollow;
 import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
 import com.kakaobase.snsapp.domain.members.entity.QMember;
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
-import com.kakaobase.snsapp.domain.posts.entity.Post;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.domain.posts.entity.QPost;
 import com.kakaobase.snsapp.domain.posts.entity.QPostImage;
 import com.kakaobase.snsapp.domain.posts.entity.QPostLike;
@@ -94,7 +94,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     @Override
     public List<PostResponseDto.PostDetails> findByBoardTypeWithCursor(
-            Post.BoardType boardType,
+            BoardType boardType,
             Long cursor,
             int limit,
             Long memberId) {

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/scheduler/PostCacheSyncScheduler.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/scheduler/PostCacheSyncScheduler.java
@@ -1,7 +1,7 @@
 package com.kakaobase.snsapp.domain.posts.scheduler;
 
 
-import com.kakaobase.snsapp.domain.posts.service.PostCacheSyncService;
+import com.kakaobase.snsapp.domain.posts.service.cache.PostCacheSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -134,32 +134,20 @@ public class BotPostService {
      * AI 서버 요청 DTO 생성
      *
      * @param boardType 게시판 타입
-     * @param posts 최근 게시글 목록
      * @return AI 서버 요청 DTO
      */
-    private BotRequestDto.CreatePostRequest createBotRequest(Post.BoardType boardType, List<Post> posts) {
-        // 게시글 작성자들의 정보를 한 번에 조회
-        List<PostResponseDto.PostDetails> postDetails = postRepository.findByBoardTypeWithCursor(
-                boardType, null, 10, null);
-
-        // 2. PostDetails → BotRequestDto.PostDto 직접 변환
-        List<BotRequestDto.PostDto> botPosts = postDetails.stream()
-                .map(postDetail -> {
-                    MemberResponseDto.UserInfoWithFollowing user = postDetail.user();
-
-                    // ⚠N+1문제 발생
-                    String className = memberRepository.findById(user.id())
-                            .map(Member::getClassName)
-                            .orElse("미정");
-
-                    // ✅ 바로 DTO 생성
-                    return BotRequestDto.PostDto.builder()
-                            .user(new BotRequestDto.UserDto(user.nickname(), className))
-                            .createdAt(postDetail.createdAt().atZone(ZoneId.systemDefault()).toInstant().toString())
-                            .content(postDetail.content())
-                            .build();
-                })
-                .collect(Collectors.toList());
+    private BotRequestDto.CreatePostRequest createBotRequest(Post.BoardType boardType, List<Post> filteredPosts) {
+        // 게시글 리스트를 PostDto 리스트로 변환
+        List<BotRequestDto.PostDto> botPosts = filteredPosts.stream()
+                .map(post -> BotRequestDto.PostDto.builder()
+                        .user(BotRequestDto.UserDto.builder()
+                                .nickname(post.getMember().getNickname())
+                                .className(post.getMember().getClassName()) // enum을 문자열로 변환
+                                .build())
+                        .createdAt(post.getCreatedAt().toString()) // LocalDateTime을 ISO 8601 문자열로 변환
+                        .content(post.getContent())
+                        .build())
+                .toList();
 
         return new BotRequestDto.CreatePostRequest(boardType.name(), botPosts);
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.domain.posts.service;
 
-import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.dto.BotRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
@@ -30,7 +29,6 @@ public class BotPostService {
     private final PostService postService;
     private final PostRepository postRepository;
     private final WebClient webClient;
-    private final MemberRepository memberRepository;
 
     @Value("${ai.server.url}")
     private String aiServerUrl;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/BotPostService.java
@@ -1,13 +1,11 @@
 package com.kakaobase.snsapp.domain.posts.service;
 
-import com.kakaobase.snsapp.domain.members.dto.MemberResponseDto;
-import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.dto.BotRequestDto;
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
-import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.constant.BotConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,9 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import java.time.ZoneId;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * AI 봇의 게시글 관련 서비스
@@ -47,7 +43,7 @@ public class BotPostService {
      * @param boardType 게시판 타입
      */
     @Transactional
-    public void createBotPost(Post.BoardType boardType) {
+    public void createBotPost(BoardType boardType) {
         try {
             log.info("봇 게시글 생성 시작 - boardType: {}", boardType);
 
@@ -136,7 +132,7 @@ public class BotPostService {
      * @param boardType 게시판 타입
      * @return AI 서버 요청 DTO
      */
-    private BotRequestDto.CreatePostRequest createBotRequest(Post.BoardType boardType, List<Post> filteredPosts) {
+    private BotRequestDto.CreatePostRequest createBotRequest(BoardType boardType, List<Post> filteredPosts) {
         // 게시글 리스트를 PostDto 리스트로 변환
         List<BotRequestDto.PostDto> botPosts = filteredPosts.stream()
                 .map(post -> BotRequestDto.PostDto.builder()

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostLikeService.java
@@ -8,6 +8,7 @@ import com.kakaobase.snsapp.domain.posts.exception.PostErrorCode;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostLikeRepository;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.domain.posts.service.cache.PostCacheService;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;
 import com.kakaobase.snsapp.global.error.code.GeneralErrorCode;
 import jakarta.persistence.EntityManager;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -17,6 +17,7 @@ import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostImageRepository;
 import com.kakaobase.snsapp.domain.posts.repository.PostLikeRepository;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.redis.CacheRecord;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;
 import com.kakaobase.snsapp.global.common.s3.service.S3Service;
@@ -75,14 +76,7 @@ public class PostService {
             throw new PostException(PostErrorCode.INVALID_IMAGE_URL);
         }
 
-        Post.BoardType boardType;
-
-        try {
-            boardType = Post.BoardType.valueOf(postType);
-        } catch (IllegalArgumentException e) {
-            log.error("잘못된 게시판 타입: {}", postType);
-            throw new PostException(GeneralErrorCode.INVALID_FORMAT, "postType");
-        }
+        BoardType boardType = postConverter.toBoardType(postType);
 
         String youtubeUrl = requestDto.youtube_url();
 
@@ -168,7 +162,7 @@ public class PostService {
             throw new PostException(GeneralErrorCode.INVALID_QUERY_PARAMETER, "limit", "limit는 1 이상이어야 합니다.");
         }
 
-        Post.BoardType boardType = PostConverter.toBoardType(postType);
+        BoardType boardType = postConverter.toBoardType(postType.toUpperCase());
 
         // 2. 게시글 조회
         List<PostResponseDto.PostDetails> postDetails = postRepository.findByBoardTypeWithCursor(boardType, cursor, limit, currentMemberId);

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -17,6 +17,8 @@ import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostImageRepository;
 import com.kakaobase.snsapp.domain.posts.repository.PostLikeRepository;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
+import com.kakaobase.snsapp.domain.posts.service.async.YouTubeSummaryService;
+import com.kakaobase.snsapp.domain.posts.service.cache.PostCacheService;
 import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.redis.CacheRecord;
 import com.kakaobase.snsapp.global.common.redis.error.CacheException;
@@ -83,13 +85,13 @@ public class PostService {
         // 게시판 타입 변환
         Member proxyMember = em.find(Member.class, memberId);
         // 게시글 엔티티 생성
-        Post post = PostConverter.toPost(requestDto, proxyMember, boardType);
+        Post post = postConverter.toPost(requestDto, proxyMember, boardType);
 
         // 게시글 저장
         postRepository.save(post);
 
         if (StringUtils.hasText(requestDto.image_url())) {
-            PostImage postImage = PostConverter.toPostImage(post, 0, requestDto.image_url());
+            PostImage postImage = postConverter.toPostImage(post, 0, requestDto.image_url());
             postImageRepository.save(postImage);
         }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/async/YouTubeSummaryService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/async/YouTubeSummaryService.java
@@ -1,4 +1,4 @@
-package com.kakaobase.snsapp.domain.posts.service;
+package com.kakaobase.snsapp.domain.posts.service.async;
 
 import com.kakaobase.snsapp.domain.posts.dto.PostRequestDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
@@ -61,7 +61,6 @@ public class YouTubeSummaryService {
      * @return 요약된 내용
      * @throws PostException AI 서버 통신 실패 또는 요약 실패 시
      */
-    @Async
     public String getSummary(String youtubeUrl) {
         log.info("YouTube 요약 요청 시작 - URL: {}", youtubeUrl);
 
@@ -90,7 +89,7 @@ public class YouTubeSummaryService {
             throw new AiServerException("internal_server_error", "Ai서버에서 응답이 없습니다", e);
 
         } catch (Exception e) {
-            log.error("WebClientResponseException안터짐 에러코드: {}", e);
+            log.error("WebClientResponseException안터짐 에러코드: {}", e.getMessage());
             throw new PostException(GeneralErrorCode.INTERNAL_SERVER_ERROR, "요약도중 예기치못한 에러 발행");
         }
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/cache/PostCacheService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/cache/PostCacheService.java
@@ -1,4 +1,4 @@
-package com.kakaobase.snsapp.domain.posts.service;
+package com.kakaobase.snsapp.domain.posts.service.cache;
 
 import com.kakaobase.snsapp.domain.posts.dto.PostResponseDto;
 import com.kakaobase.snsapp.domain.posts.entity.Post;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/cache/PostCacheSyncService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/cache/PostCacheSyncService.java
@@ -1,4 +1,4 @@
-package com.kakaobase.snsapp.domain.posts.service;
+package com.kakaobase.snsapp.domain.posts.service.cache;
 
 import com.kakaobase.snsapp.domain.posts.util.PostCacheUtil;
 import com.kakaobase.snsapp.global.common.redis.CacheRecord;

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/util/BoardType.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/util/BoardType.java
@@ -1,0 +1,10 @@
+package com.kakaobase.snsapp.domain.posts.util;
+
+public enum BoardType {
+        ALL,        // 전체 게시판
+        PANGYO_1,   // 판교 1기 게시판
+        PANGYO_2,   // 판교 2기 게시판
+        JEJU_1,     // 제주 1기 게시판
+        JEJU_2,     // 제주 2기 게시판
+        JEJU_3      // 제주 3기 게시판
+}

--- a/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/s3/controller/S3Controller.java
@@ -1,6 +1,5 @@
 package com.kakaobase.snsapp.global.common.s3.controller;
 
-import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.global.common.response.CustomResponse;
 import com.kakaobase.snsapp.global.common.s3.service.S3Service;
 import com.kakaobase.snsapp.global.common.s3.dto.PresignedUrlResponseDto;
@@ -76,8 +75,7 @@ public class S3Controller {
             @RequestParam @NotBlank(message = "파일명은 필수입니다") String fileName,
             @RequestParam @Positive(message = "파일 크기는 0보다 커야 합니다") Long fileSize,
             @RequestParam @NotBlank(message = "MIME 타입은 필수입니다") String mimeType,
-            @RequestParam @NotBlank(message = "이미지 타입은 필수입니다") String type,
-            @RequestParam(required = false) Post.BoardType boardType
+            @RequestParam @NotBlank(message = "이미지 타입은 필수입니다") String type
     ) {
         // Presigned URL 생성 및 반환
         PresignedUrlResponseDto response = s3Service.generatePresignedUrl(fileName, fileSize, mimeType, type);

--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -3,7 +3,6 @@ package com.kakaobase.snsapp.global.security;
 import com.kakaobase.snsapp.domain.auth.principal.CustomUserDetails;
 import com.kakaobase.snsapp.domain.comments.repository.CommentRepository;
 import com.kakaobase.snsapp.domain.comments.repository.RecommentRepository;
-import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;

--- a/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/AccessChecker.java
@@ -170,19 +170,4 @@ public class AccessChecker {
                                 authority.equals("ROLE_FRONTEND_BOT")
                 );
     }
-
-    /**
-     * 문자열 형태의 postType을 BoardType enum으로 변환합니다.
-     *
-     * @param postType 게시판 타입 문자열
-     * @return BoardType enum 값
-     * @throws PostException 유효하지 않은 postType인 경우
-     */
-    public Post.BoardType convertToBoardType(String postType) {
-        try {
-            return PostConverter.toBoardType(postType);
-        } catch (IllegalArgumentException e) {
-            throw new PostException(GeneralErrorCode.RESOURCE_NOT_FOUND, "postType");
-        }
-    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,10 +9,6 @@ app:
       domain: ${COOKIE_DOMAIN}
       same-site: Lax
 
-server:
-  servlet:
-    context-path: /api
-
 logging:
   level:
     com.kakaobase.snsapp.domain.posts.scheduler: DEBUG


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #236 

## 📌 개요
- 소셜봇 게시글 요청 시 발생하는 NullPointerException 에러 해결
- BoardType enum 구조 개선 및 코드 구조 최적화
- 소셜봇 대댓글 생성 로직 개선

## 🔁 변경 사항

### 🐛 버그 수정
- **소셜봇 게시글 요청 시 NullPointerException 해결**
  - QueryDSL에서 null 값 처리 로직 개선
  - 이중 게시글 목록 조회 로직을 단일화하여 성능 향상


### ⚡ 성능 개선
- **소셜봇 대댓글 작성 최적화**
  - 캐싱을 통한 recommentCount 업데이트
  - 실패 시 벌크 업데이트로 폴백 처리
- **비동기 처리 개선**
  - @Transactional AOP 감지 문제 해결을 위해 Async 메서드를 별도 클래스로 분리

### 🔧 리팩토링
- **BoardType enum 외부 분리**
  - Post Entity 내부의 BoardType enum을 독립적인 클래스로 분리
  - 모든 `Post.BoardType` 참조를 `BoardType`으로 변경
- **서비스 패키지 구조 개선**
  - Post, Comment 도메인의 Service를 패키지별로 재구성
  - BotRecommentService 로직 재구성 및 모듈화
- **Converter 메서드 유효성 검증 강화**
  - toBoardType 메서드에 유효성 검증 로직 추가
  - static 메서드 제거하여 Spring Bean 주입 방식으로 변경

### 🧹 코드 정리
- **불필요한 코드 제거**
  - 사용되지 않는 BoardType 필드 삭제
  - 미사용 import문 및 메서드 정리
- **어노테이션 최적화**
  - BotRequestDto에 @Builder 추가
  - Swagger용 require 속성 제거
  - @Component 어노테이션을 통한 의존성 주입 방식 적용

### 🔧 환경 설정
- local 환경의 context-path 삭제

## 👀 기타 더 이야기해볼 점
- BoardType enum 분리로 인한 도메인 경계 명확화가 향후 확장성에 미칠 영향

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.