### PR TITLE
[BE - FIX] 게시글, 댓글 삭제시 500에러 문제 발생 해결

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
@@ -31,6 +32,7 @@ import java.util.List;
         }
 )
 @Getter
+@SQLDelete(sql = "UPDATE comments SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at IS NULL")
 public class Comment extends BaseSoftDeletableEntity {

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * 댓글 정보를 담는 엔티티
@@ -59,7 +59,7 @@ public class Comment extends BaseSoftDeletableEntity {
     private Long recommentCount = 0L;
 
     @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
-    private List<Recomment> recomments = new ArrayList<>();
+    private Set<Recomment> recomments = new HashSet<>();
 
     /**
      * 댓글 생성을 위한 생성자

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Recomment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Recomment.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 /**
@@ -25,6 +26,7 @@ import org.hibernate.annotations.Where;
         }
 )
 @Getter
+@SQLDelete(sql = "UPDATE recomments SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at IS NULL")
 public class Recomment extends BaseSoftDeletableEntity {

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -58,20 +58,17 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Commen
      * 특정 댓글의 모든 좋아요를 삭제
      *
      * @param commentId 댓글 ID
-     * @return 삭제된 레코드 수
      */
     @Modifying
     @Query("DELETE FROM CommentLike cl WHERE cl.comment.id = :commentId")
     void deleteByCommentId(@Param("commentId") Long commentId);
 
     /**
-     * 특정 게시글과 연관된 모든 댓글의 좋아요를 직접 하드 삭제
-     * JOIN을 통해 한 번의 쿼리로 처리
+     * 특정 댓글목록의 모든 좋아요를 삭제
      *
-     * @param postId 게시글 ID
-     * @return 삭제된 좋아요 수
+     * @param commentIds 댓글 ID의 List
      */
     @Modifying
-    @Query("DELETE FROM CommentLike cl WHERE cl.comment.post.id = :postId")
-    void deleteByPostId(@Param("postId") Long postId);
+    @Query("DELETE FROM CommentLike cl WHERE cl.comment.id IN :commentIds")
+    void deleteByCommentIdIn(@Param("commentIds") List<Long> commentIds);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -40,21 +40,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Commen
     boolean existsByMemberIdAndCommentId(Long memberId, Long commentId);
 
     /**
-     * 특정 사용자가 좋아요를 누른 댓글 ID 목록을 일괄 조회
-     *
-     * @param memberId 사용자 ID
-     * @param commentIds 확인할 댓글 ID 목록
-     * @return 좋아요를 누른 댓글 ID Set
-     */
-    @Query("SELECT cl.id.commentId FROM CommentLike cl " +
-            "WHERE cl.id.memberId = :memberId " +
-            "AND cl.id.commentId IN :commentIds")
-    Set<Long> findLikedCommentIdsByMemberAndComments(
-            @Param("memberId") Long memberId,
-            @Param("commentIds") List<Long> commentIds
-    );
-
-    /**
      * 특정 댓글의 모든 좋아요를 삭제
      *
      * @param commentId 댓글 ID
@@ -62,13 +47,4 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Commen
     @Modifying
     @Query("DELETE FROM CommentLike cl WHERE cl.comment.id = :commentId")
     void deleteByCommentId(@Param("commentId") Long commentId);
-
-    /**
-     * 특정 댓글목록의 모든 좋아요를 삭제
-     *
-     * @param commentIds 댓글 ID의 List
-     */
-    @Modifying
-    @Query("DELETE FROM CommentLike cl WHERE cl.comment.id IN :commentIds")
-    void deleteByCommentIdIn(@Param("commentIds") List<Long> commentIds);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentLikeRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * 댓글 좋아요 엔티티에 대한 데이터 액세스 객체

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -18,21 +18,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
     //특정 회원이 해당 게시글을 작성했는 지 확인
     //삭제시 권한확인용
     boolean existsByIdAndMember_Id(Long id, Long memberId);
-
-    /**
-     * 특정 게시글과 연관된 모든 댓글을 소프트 삭제 처리합니다.
-     * 게시글이 삭제될 때 해당 게시글의 모든 댓글을 함께 삭제합니다.
-     *
-     * @param postId 삭제할 게시글 ID
-     */
-    @Modifying
-    @Query("UPDATE Comment c SET c.deletedAt = CURRENT_TIMESTAMP WHERE c.post.id = :postId AND c.deletedAt IS NULL")
-    void deleteByPostId(@Param("postId") Long postId);
-
-    /**
-     * 특정 댓글의 RecommentCount수를 1증가시키는 벌크 업데이트 메서드
-     */
-    @Modifying
-    @Query("UPDATE Comment c SET c.recommentCount = c.recommentCount + 1 WHERE c.id = :commentId")
-    int incrementRecommentCount(@Param("commentId") Long commentId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/CommentRepository.java
@@ -4,9 +4,6 @@ package com.kakaobase.snsapp.domain.comments.repository;
 import com.kakaobase.snsapp.domain.comments.entity.Comment;
 import com.kakaobase.snsapp.domain.comments.repository.custom.CommentCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -54,10 +54,6 @@ public interface RecommentLikeRepository extends JpaRepository<RecommentLike, Re
     @Query("DELETE FROM RecommentLike rl WHERE rl.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);
 
-    @Modifying
-    @Query("DELETE FROM RecommentLike rl WHERE rl.recomment.id IN :recommentIds")
-    void deleteByRecommentIdIn(@Param("recommentIds") List<Long> recommentIds);
-
     /**
      * 특정 댓글의 모든 대댓글에 대한 좋아요를 삭제합니다.
      * 댓글 삭제 시 해당 댓글의 모든 대댓글 좋아요도 함께 삭제하는 데 사용됩니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 /**

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentLikeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -53,6 +54,9 @@ public interface RecommentLikeRepository extends JpaRepository<RecommentLike, Re
     @Query("DELETE FROM RecommentLike rl WHERE rl.member.id = :memberId")
     void deleteByMemberId(@Param("memberId") Long memberId);
 
+    @Modifying
+    @Query("DELETE FROM RecommentLike rl WHERE rl.recomment.id IN :recommentIds")
+    void deleteByRecommentIdIn(@Param("recommentIds") List<Long> recommentIds);
 
     /**
      * 특정 댓글의 모든 대댓글에 대한 좋아요를 삭제합니다.

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -24,7 +24,6 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long>, Rec
      * 댓글이 삭제될 때 해당 댓글의 모든 대댓글을 함께 삭제합니다.
      *
      * @param commentId 삭제할 댓글 ID
-     * @return 삭제 처리된 대댓글 수
      */
     @Modifying
     @Query("UPDATE Recomment r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.comment.id = :commentId AND r.deletedAt IS NULL")

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/RecommentRepository.java
@@ -31,17 +31,6 @@ public interface RecommentRepository extends JpaRepository<Recomment, Long>, Rec
     void deleteByCommentId(@Param("commentId") Long commentId);
 
     /**
-     * 특정 게시글과 연관된 모든 대댓글을 소프트 삭제 처리합니다.
-     * 게시글이 삭제될 때 해당 게시글의 모든 댓글의 대댓글을 함께 삭제합니다.
-     *
-     * @param postId 삭제할 게시글 ID
-     * @return 삭제 처리된 대댓글 수
-     */
-    @Modifying
-    @Query("UPDATE Recomment r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.comment.post.id = :postId AND r.deletedAt IS NULL")
-    void deleteByPostId(@Param("postId") Long postId);
-
-    /**
      * 특정 댓글의 대댓글을 모두 조회합니다. (댓글 목록 조회 시 사용)
      * 삭제되지 않은 대댓글만 조회하며, 생성 시간 오름차순으로 정렬합니다.
      *

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/CommentCustomRepositoryImpl.java
@@ -134,7 +134,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                         comment.post.id.eq(postId)
                                 .and(cursor != null ? comment.id.lt(cursor) : null)
                 )
-                .orderBy(comment.createdAt.desc(), comment.id.desc())
+                .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .limit(limit)
                 .fetch();
     }
@@ -197,7 +197,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                         comment.member.id.eq(authorMemberId)
                                 .and(cursor != null ? comment.id.lt(cursor) : null)
                 )
-                .orderBy(comment.createdAt.desc(), comment.id.desc())
+                .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .limit(limit)
                 .fetch();
     }
@@ -269,7 +269,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                 .where(
                         cursor != null ? comment.id.lt(cursor) : null
                 )
-                .orderBy(comment.createdAt.desc(), comment.id.desc())
+                .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .limit(limit)
                 .fetch();
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/RecommentCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/RecommentCustomRepositoryImpl.java
@@ -130,7 +130,7 @@ public class RecommentCustomRepositoryImpl implements RecommentCustomRepository 
                         recomment.comment.id.eq(commentId)
                                 .and(cursor != null ? recomment.id.lt(cursor) : null)
                 )
-                .orderBy(recomment.createdAt.desc(), recomment.id.desc())
+                .orderBy(recomment.createdAt.asc(), recomment.id.asc())
                 .limit(limit)
                 .fetch();
     }
@@ -191,7 +191,7 @@ public class RecommentCustomRepositoryImpl implements RecommentCustomRepository 
                         recomment.member.id.eq(authorMemberId)
                                 .and(cursor != null ? recomment.id.lt(cursor) : null)
                 )
-                .orderBy(recomment.createdAt.desc(), recomment.id.desc())
+                .orderBy(recomment.createdAt.asc(), recomment.id.asc())
                 .limit(limit)
                 .fetch();
     }
@@ -261,7 +261,7 @@ public class RecommentCustomRepositoryImpl implements RecommentCustomRepository 
                 .where(
                         cursor != null ? recomment.id.lt(cursor) : null
                 )
-                .orderBy(recomment.createdAt.desc(), recomment.id.desc())
+                .orderBy(recomment.createdAt.asc(), recomment.id.asc())
                 .limit(limit)
                 .fetch();
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/controller/PostController.java
@@ -94,14 +94,11 @@ public class PostController {
     @PreAuthorize("@accessChecker.isPostOwner(#postId, authentication.principal)")
     public CustomResponse<Void> deletePost(
             @Parameter(description = "게시판 유형") @PathVariable String postType,
-            @Parameter(description = "게시글 ID") @PathVariable Long postId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @Parameter(description = "게시글 ID") @PathVariable Long postId
             ) {
 
-        Long memberId = Long.valueOf(userDetails.getId());
-
         // 게시글 삭제
-        postService.deletePost(postId, memberId);
+        postService.deletePost(postId);
 
         return CustomResponse.success("게시글이 삭제되었습니다");
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -1,5 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.entity;
 
+import com.kakaobase.snsapp.domain.comments.entity.Comment;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.posts.util.BoardType;
 import com.kakaobase.snsapp.global.common.entity.BaseSoftDeletableEntity;
@@ -8,7 +9,9 @@ import lombok.*;
 import org.hibernate.annotations.Where;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 게시글 정보를 담는 엔티티
@@ -118,4 +121,11 @@ public class Post extends BaseSoftDeletableEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     @OrderBy("sortIndex ASC")
     private final List<PostImage> postImages = new ArrayList<>();
+
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private final Set<Comment> comments = new HashSet<>();
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private final Set<PostLike> postLikes = new HashSet<>();
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -30,17 +30,6 @@ import java.util.Set;
                         columnList = "board_type, deleted_at, created_at DESC, id DESC")
         }
 )
-@NamedEntityGraph(
-        name = "Post.withCommentsAndRecomments",
-        attributeNodes = @NamedAttributeNode(
-                value = "comments",
-                subgraph = "comments-subgraph"
-        ),
-        subgraphs = @NamedSubgraph(
-                name = "comments-subgraph",
-                attributeNodes = @NamedAttributeNode("recomments")
-        )
-)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at IS NULL")

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/entity/Post.java
@@ -30,6 +30,17 @@ import java.util.Set;
                         columnList = "board_type, deleted_at, created_at DESC, id DESC")
         }
 )
+@NamedEntityGraph(
+        name = "Post.withCommentsAndRecomments",
+        attributeNodes = @NamedAttributeNode(
+                value = "comments",
+                subgraph = "comments-subgraph"
+        ),
+        subgraphs = @NamedSubgraph(
+                name = "comments-subgraph",
+                attributeNodes = @NamedAttributeNode("recomments")
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at IS NULL")

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostLikeRepository.java
@@ -4,9 +4,10 @@ import com.kakaobase.snsapp.domain.posts.entity.PostLike;
 import com.kakaobase.snsapp.domain.posts.repository.custom.PostLikeCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -25,11 +26,9 @@ public interface PostLikeRepository extends JpaRepository<PostLike, PostLike.Pos
      */
     boolean existsByMemberIdAndPostId(Long memberId, Long postId);
 
-    /**
-     * 특정 게시글의 모든 좋아요 삭제 - JPA 메서드명
-     */
     @Modifying
-    void deleteByPostId(Long postId);
+    @Query("DELETE FROM PostLike pl WHERE pl.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 
     /**
      * 특정 회원의 모든 좋아요 삭제 - JPA 메서드명

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -3,14 +3,10 @@ package com.kakaobase.snsapp.domain.posts.repository;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.repository.custom.PostCustomRepository;
 import com.kakaobase.snsapp.domain.posts.util.BoardType;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * 게시글 엔티티에 대한 데이터 액세스 객체
@@ -33,9 +29,4 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     long countByMemberId(Long memberId);
 
     List<Post> findTop10ByBoardTypeOrderByCreatedAtDescIdDesc(BoardType boardType);
-
-    @EntityGraph("Post.withCommentsAndRecomments")  // 1단계에서 정의한 그래프 사용
-    @Query("SELECT p FROM Post p WHERE p.id = :postId AND p.deletedAt IS NULL")
-    Optional<Post> findByIdWithCommentsAndRecomments(@Param("postId") Long postId);
-
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/PostRepository.java
@@ -3,10 +3,14 @@ package com.kakaobase.snsapp.domain.posts.repository;
 import com.kakaobase.snsapp.domain.posts.entity.Post;
 import com.kakaobase.snsapp.domain.posts.repository.custom.PostCustomRepository;
 import com.kakaobase.snsapp.domain.posts.util.BoardType;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 게시글 엔티티에 대한 데이터 액세스 객체
@@ -29,5 +33,9 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
     long countByMemberId(Long memberId);
 
     List<Post> findTop10ByBoardTypeOrderByCreatedAtDescIdDesc(BoardType boardType);
+
+    @EntityGraph("Post.withCommentsAndRecomments")  // 1단계에서 정의한 그래프 사용
+    @Query("SELECT p FROM Post p WHERE p.id = :postId AND p.deletedAt IS NULL")
+    Optional<Post> findByIdWithCommentsAndRecomments(@Param("postId") Long postId);
 
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepository.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepository.java
@@ -27,4 +27,6 @@ public interface PostCustomRepository {
             Long cursor,
             int limit,
             Long currentMemberId);
+
+    void deletePost(Long postId);
 }

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/service/PostService.java
@@ -1,10 +1,6 @@
 package com.kakaobase.snsapp.domain.posts.service;
 
-import com.kakaobase.snsapp.domain.comments.entity.Comment;
-import com.kakaobase.snsapp.domain.comments.entity.Recomment;
 import com.kakaobase.snsapp.domain.comments.exception.CommentException;
-import com.kakaobase.snsapp.domain.comments.repository.CommentLikeRepository;
-import com.kakaobase.snsapp.domain.comments.repository.RecommentLikeRepository;
 import com.kakaobase.snsapp.domain.members.entity.Member;
 import com.kakaobase.snsapp.domain.members.repository.MemberRepository;
 import com.kakaobase.snsapp.domain.posts.converter.PostConverter;
@@ -16,7 +12,6 @@ import com.kakaobase.snsapp.domain.posts.event.PostCreatedEvent;
 import com.kakaobase.snsapp.domain.posts.exception.PostErrorCode;
 import com.kakaobase.snsapp.domain.posts.exception.PostException;
 import com.kakaobase.snsapp.domain.posts.repository.PostImageRepository;
-import com.kakaobase.snsapp.domain.posts.repository.PostLikeRepository;
 import com.kakaobase.snsapp.domain.posts.repository.PostRepository;
 import com.kakaobase.snsapp.domain.posts.service.async.YouTubeSummaryService;
 import com.kakaobase.snsapp.domain.posts.service.cache.PostCacheService;
@@ -35,9 +30,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 /**
  * 게시글 관련 비즈니스 로직을 처리하는 서비스
@@ -56,9 +49,6 @@ public class PostService {
     private final PostConverter postConverter;
     private final MemberRepository memberRepository;
     private final PostCacheService postCacheService;
-    private final CommentLikeRepository commentLikeRepository;
-    private final RecommentLikeRepository recommentLikeRepository;
-    private final PostLikeRepository postLikeRepository;
 
     /**
      * 게시글을 생성합니다.

--- a/src/main/java/com/kakaobase/snsapp/global/common/entity/BaseSoftDeletableEntity.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/entity/BaseSoftDeletableEntity.java
@@ -6,7 +6,6 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
-import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -24,7 +23,6 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-@SQLDelete(sql = "UPDATE posts SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @FilterDef(name = "deletedFilter", defaultCondition = "deleted_at IS NULL")
 @Filter(name = "deletedFilter")
 public abstract class BaseSoftDeletableEntity extends BaseUpdateTimeEntity {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>PR 템플릿</h1>
<h2>📍 PR 타입 (하나 이상 선택)</h2>
<ul>
<li>[x] 기능 추가</li>
<li>[ ] 버그 수정</li>
<li>[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트</li>
<li>[ ] 기타 사소한 수정</li>
</ul>
<h2>❗️ 관련 이슈 링크</h2>
<p>Close #</p>
<h2>📌 개요</h2>
<p>게시글 삭제 시 연관된 모든 데이터(댓글, 대댓글, 좋아요, 이미지)를 안전하게 삭제하는 기능을 구현했습니다. 복잡한 연관관계와 SoftDelete/HardDelete 혼재 상황을 고려하여 QueryDSL을 활용한 벌크 연산으로 성능과 안정성을 보장하도록 구현하였습니다.</p>
<h2>🔁 변경 사항</h2>
<h3>게시글 삭제 기능 구현</h3>
<ul>
<li><strong>PostDeleteService</strong>: 게시글 삭제 비즈니스 로직 구현</li>
<li><strong>PostCustomRepository</strong>: QueryDSL 기반 벌크 삭제 연산 구현</li>
<li><strong>삭제 순서</strong>: FK 제약조건을 고려한 안전한 삭제 순서 적용
<pre><code>RecommentLike → Recomment → CommentLike → Comment → PostLike → PostImage → Post
</code></pre></li>
</ul>
<h3>기술적 구현 사항</h3>
<ul>
<li><strong>QueryDSL</strong>: 복잡한 연관관계 삭제를 위한 벌크 연산 활용</li>
<li><strong>SoftDelete</strong>: Comment, Recomment, Post는 논리 삭제 적용</li>
<li><strong>HardDelete</strong>: Like 관련 데이터와 PostImage는 물리 삭제 적용</li>
</ul>
<h3>성능 최적화</h3>
<ul>
<li><strong>총 쿼리 수</strong>: 8개 (ID 조회 2개 + 삭제 6개)</li>
<li><strong>N+1 문제 방지</strong>: Entity 로딩 없이 ID 기반 벌크 연산</li>
<li><strong>메모리 효율</strong>: 불필요한 Entity 객체 생성 최소화</li>
</ul>
<h2>👀 기타 더 이야기해볼 점</h2>
📖 기술 선택 과정 및 구현 이슈
<h3>🤔 QueryDSL vs EntityGraph 기술 선택 과정</h3>
<h4>📚 <strong>기술 개념 소개</strong></h4>
<ul>
<li><strong>QueryDSL</strong>: 타입 안전한 SQL 빌더로, 복잡한 쿼리와 벌크 연산에 특화된 라이브러리</li>
<li><strong>EntityGraph</strong>: JPA 표준 기능으로, Entity 관계를 활용한 N+1 문제 해결과 객체 탐색에 최적화</li>
</ul>
<h4>⚖️ <strong>두 기술 비교</strong></h4>

측면 | QueryDSL | EntityGraph
-- | -- | --
철학 | SQL 중심적 사고, 성능 최적화 우선 | 객체지향적 사고, JPA 생태계 일관성
제어력 | 완전한 SQL 제어, 세밀한 조건 설정 | JPA 자동 처리, @Where 어노테이션 활용
적합한 용도 | 벌크 연산, 복잡한 쿼리, 통계/집계 | 조회 후 비즈니스 로직, 객체 탐색
성능 | 메모리 효율적, 불필요한 로딩 없음 | 조회 최적화, 하지만 Entity 로딩 필요


<h4>🎯 <strong>QueryDSL 선택 이유</strong></h4>
<p>현재 게시글 삭제 기능의 특성상 QueryDSL이 더 적합하다고 판단했습니다:</p>
<ol>
<li><strong>삭제 전용 작업</strong>: Entity 객체가 필요 없고 ID만으로 충분한 상황</li>
<li><strong>복잡한 삭제 순서</strong>: FK 제약조건을 고려한 정확한 순서 제어 필요</li>
<li><strong>혼재된 삭제 방식</strong>: SoftDelete와 HardDelete를 명확히 구분해서 처리</li>
<li><strong>성능 최우선</strong>: 불필요한 Entity 로딩 없이 메모리 효율적 처리</li>
<li><strong>디버깅 편의</strong>: 각 단계별 쿼리 실행 결과를 명확히 추적 가능</li>
</ol>
<h4>🌟 <strong>EntityGraph가 더 적합한 경우</strong></h4>
<ul>
<li><strong>게시글 상세 조회 + DTO 변환</strong>: 한번의 JOIN으로 모든 데이터를 가져와 객체 탐색</li>
<li><strong>복잡한 비즈니스 로직</strong>: Entity 관계를 활용한 자연스러운 객체 처리</li>
<li><strong>JPA 생명주기 활용</strong>: @PreUpdate, @PostLoad 등 이벤트 처리가 필요한 경우</li>
</ul>
<h3>🚨 <strong>개발 과정에서 마주한 이슈</strong></h3>
<ul>
<li><strong>SoftDelete 필터링</strong>: EntityGraph는 <code>@Where</code> 어노테이션으로 자동 처리되지만, QueryDSL은 수동으로 <code>deletedAt.isNull()</code> 조건 추가 필요</li>
</ul>
<h2>✅ 체크 리스트</h2>
<ul>
<li>[x] PR 템플릿에 맞추어 작성했어요.</li>
<li>[x] 변경 내용에 대한 테스트를 진행했어요.</li>
<li>[x] 프로그램이 정상적으로 동작해요.</li>
<li>[x] PR에 적절한 라벨을 선택했어요.</li>
<li>[x] 불필요한 코드는 삭제했어요.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>