### PR TITLE
[BE - FIX] 캐싱 필드 감소로직이 필드를 증가시키는 에러 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/controller/CommentController.java
@@ -78,11 +78,9 @@ public class CommentController {
             description = "댓글을 삭제합니다. 자신이 작성한 댓글만 삭제할 수 있습니다."
     )
     public ResponseEntity<CustomResponse<Void>> deleteComment(
-            @PathVariable Long commentId,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @PathVariable Long commentId
     ) {
-        Long memberId = Long.valueOf(userDetails.getId());
-        commentService.deleteComment(memberId, commentId);
+        commentService.deleteComment(commentId);
         return ResponseEntity.ok(CustomResponse.success("댓글이 삭제되었습니다.", null));
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/entity/Comment.java
@@ -58,8 +58,8 @@ public class Comment extends BaseSoftDeletableEntity {
     @Column(name = "recomment_count", nullable = false)
     private Long recommentCount = 0L;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
-    private Set<Recomment> recomments = new HashSet<>();
+    @OneToMany(mappedBy = "comment", fetch = FetchType.LAZY)
+    private final Set<Recomment> recomments = new HashSet<>();
 
     /**
      * 댓글 생성을 위한 생성자

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -132,11 +132,6 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "삭제할 댓글을 찾을 수 없습니다."));
 
-        // 댓글 작성자 확인
-        if (!comment.getMember().getId().equals(memberId)) {
-            throw new CommentException(CommentErrorCode.POST_NOT_AUTHORIZED, "commentId", "본인이 작성한 댓글만 삭제할 수 있습니다.");
-        }
-
         recommentLikeRepository.deleteByCommentId(commentId);
         recommentRepository.deleteByCommentId(commentId);
         commentLikeRepository.deleteByCommentId(commentId);

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/service/CommentService.java
@@ -127,7 +127,7 @@ public class CommentService {
      * 댓글을 삭제합니다.
      */
     @Transactional
-    public void deleteComment(Long memberId, Long commentId) {
+    public void deleteComment(Long commentId) {
         // 댓글 조회
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(GeneralErrorCode.RESOURCE_NOT_FOUND, "commentId", "삭제할 댓글을 찾을 수 없습니다."));
@@ -147,8 +147,6 @@ public class CommentService {
 
         // 댓글 삭제 (Soft Delete)
         commentRepository.delete(comment);
-
-        log.info("댓글 삭제 완료: 댓글 ID={}, 삭제자 ID={}", commentId, memberId);
     }
 
     /**

--- a/src/main/java/com/kakaobase/snsapp/global/common/redis/service/cacheService/AbstractCacheService.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/redis/service/cacheService/AbstractCacheService.java
@@ -185,7 +185,7 @@ public abstract class AbstractCacheService<V, T> implements CacheService<Long, V
     protected void decrementFieldAndSync(Long id, String fieldName) throws CacheException{
         try {
             String key = generateCacheKey(id);
-            Long newValue = redisTemplate.opsForHash().increment(key, fieldName, -(long) -1);
+            Long newValue = redisTemplate.opsForHash().increment(key, fieldName, -1);
 
             // 음수 방지
             if (newValue < 0) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #234 

## 📌 개요
- CacheService의 필드 감소로직의 -부호가 이중처리되어 값이 증가하는 로직 수정

## 🔁 변경 사항
[[FIX] CommentRepo로 delete시 Recomment와의 관계가 CascadeType.ALL로 설정되있어서 FK…에러가 나는 버그 수정
](https://github.com/100-hours-a-week/22-tenten-be/commit/862bd35c15f97f54411e1ad3bd3ad254e4a8829d) 

[[REMOVE] 댓글 삭제시 작성자가 일치하는지 유효성 검사 중복 로직 제거(Controller와 중복됨)](https://github.com/100-hours-a-week/22-tenten-be/commit/64e2e94090afa78b2fef03431efe2cbb3534f734)

[[REFACTOR] 댓글 삭제시 불필요한 매개변수 memberId를 제거](https://github.com/100-hours-a-week/22-tenten-be/commit/8ee924d25e61805a80c4e630f2f57f0e4b86f78e)

[[FIX] CacheService의 필드 감소로직의 -부호가 이중처리되어 값이 증가하는 로직 수정](https://github.com/100-hours-a-week/22-tenten-be/commit/1430369764b53a9a39710b3c13f7554796d79d27)

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.