### PR TITLE
[BE - FIX] 댓글, 대댓글 목록 조회시 lt조건으로 조회하던 로직을 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/CommentCustomRepositoryImpl.java
@@ -132,7 +132,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
 
                 .where(
                         comment.post.id.eq(postId)
-                                .and(cursor != null ? comment.id.lt(cursor) : null)
+                                .and(cursor != null ? comment.id.gt(cursor) : null)
                 )
                 .orderBy(comment.createdAt.asc(), comment.id.asc())
                 .limit(limit)
@@ -197,7 +197,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                         comment.member.id.eq(authorMemberId)
                                 .and(cursor != null ? comment.id.lt(cursor) : null)
                 )
-                .orderBy(comment.createdAt.asc(), comment.id.asc())
+                .orderBy(comment.createdAt.asc(), comment.id.desc())
                 .limit(limit)
                 .fetch();
     }
@@ -269,7 +269,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
                 .where(
                         cursor != null ? comment.id.lt(cursor) : null
                 )
-                .orderBy(comment.createdAt.asc(), comment.id.asc())
+                .orderBy(comment.createdAt.asc(), comment.id.desc())
                 .limit(limit)
                 .fetch();
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/RecommentCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/comments/repository/custom/RecommentCustomRepositoryImpl.java
@@ -128,7 +128,7 @@ public class RecommentCustomRepositoryImpl implements RecommentCustomRepository 
 
                 .where(
                         recomment.comment.id.eq(commentId)
-                                .and(cursor != null ? recomment.id.lt(cursor) : null)
+                                .and(cursor != null ? recomment.id.gt(cursor) : null)
                 )
                 .orderBy(recomment.createdAt.asc(), recomment.id.asc())
                 .limit(limit)


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #250 

## 📌 개요
-  댓글, 대댓글 목록 조회시 순차순 정렬 조건에 lt가 되어있던 로직 수정

## 🔁 변경 사항

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.