### PR TITLE
[BE - FIX] WebSocket 엔드포인트 경로 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/WebSocketConfig.java
@@ -44,8 +44,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
          * withSockJS : WebSocket을 지원하지 않는 브라우저에서도 SockJS를 통해 WebSocket 기능을 사용할 수 있게 합니다.
          */
         registry
-                // 클라이언트가 WebSocket에 연결하기 위한 엔드포인트를 "/ws"로 설정합니다.
-                .addEndpoint("/ws")
+                // 클라이언트가 WebSocket에 연결하기 위한 엔드포인트를 "/ws/info"로 설정합니다.
+                .addEndpoint("/api/ws/info")
                 // 클라이언트의 origin을 명시적으로 지정
                 .setAllowedOrigins(
                         "https://*.kakaobase.com",

--- a/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                         .requestMatchers(HttpMethod.DELETE, "/api/users").authenticated()
-                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/api/ws/**").permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #234

## 📌 개요
- 프론트엔드에서 `/api/ws/info`로 WebSocket 연결 요청 시 발생하는 경로 불일치 문제 해결
- SockJS 라이브러리의 자동 info 엔드포인트 요청에 대응

## 🔁 변경 사항
- **WebSocketConfig**: 엔드포인트를 `/ws`에서 `/api/ws/info`로 변경
- **SecurityConfig**: WebSocket 허용 경로를 `/ws/**`에서 `/api/ws/**`로 수정
- SockJS 자동 `/info` 요청 경로와 서버 설정 일치

## 👀 기타 더 이야기해볼 점
- 향후 WebSocket 경로 표준화 방안
- SockJS vs 순수 WebSocket 선택 기준

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.