### PR TITLE
[BE - REFACTOR] WebSocket 알림 구독 경로 상수화

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/notification/listener/WebSocketSubscriptionListener.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/listener/WebSocketSubscriptionListener.java
@@ -29,7 +29,7 @@ public class WebSocketSubscriptionListener {
         log.info("구독 이벤트 - 사용자: {}, 세션: {}, 구독 경로: {}", userId, sessionId, destination);
         
         // 알림 큐 구독시 해당 사용자의 모든 알림 전송
-        if (destination != null && destination.equals("/user/queue/notifications")) {
+        if (destination != null && destination.equals("/user/queue/notification")) {
             log.info("알림 큐 구독 감지 - 모든 알림 전송 시작: 사용자 {}", userId);
             
             try {

--- a/src/main/java/com/kakaobase/snsapp/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/service/NotificationCommandService.java
@@ -31,6 +31,8 @@ public class NotificationCommandService {
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final NotificationRepository notificationRepository;
 
+    private static final String NOTIFY_SUBSCRIBE_PATH = "/queue/notification";
+
     @Transactional
     public Long createNotification(Long receiverId, NotificationType type, Long targetId) {
         Notification notification = notificationConverter.toEntity(receiverId, type, targetId);
@@ -57,13 +59,13 @@ public class NotificationCommandService {
     @Async
     public void sendNotification(Long receiverId, Long notifId, NotificationType type, String content, Long targetId, MemberResponseDto.UserInfo userInfo) {
         WebSocketPacket<NotificationData> packet = notificationConverter.toNewPacket(notifId, type, targetId, content, userInfo);
-        simpMessagingTemplate.convertAndSendToUser(receiverId.toString(), "/queue/notifications", packet);
+        simpMessagingTemplate.convertAndSendToUser(receiverId.toString(), NOTIFY_SUBSCRIBE_PATH, packet);
     }
 
     @Async
     public void sendNotification(Long receiverId, Long notifId, NotificationType type, MemberResponseDto.UserInfoWithFollowing userInfo) {
         WebSocketPacket<NotificationFollowingData> packet = notificationConverter.toNewPacket(notifId, type, userInfo);
-        simpMessagingTemplate.convertAndSendToUser(receiverId.toString(), "/queue/notifications", packet);
+        simpMessagingTemplate.convertAndSendToUser(receiverId.toString(), NOTIFY_SUBSCRIBE_PATH, packet);
     }
 
     /**
@@ -85,7 +87,7 @@ public class NotificationCommandService {
                 new WebSocketPacketImpl<>("notification.fetch", notifications);
             
             // WebSocket으로 전송
-            simpMessagingTemplate.convertAndSendToUser(userId.toString(), "/queue/notifications", finalPacket);
+            simpMessagingTemplate.convertAndSendToUser(userId.toString(), NOTIFY_SUBSCRIBE_PATH, finalPacket);
             
             log.info("사용자 {}에게 모든 알림 전송 완료", userId);
             


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #234

## 📌 개요
- WebSocket 알림 구독 경로를 상수화하여 코드 일관성 및 유지보수성 향상
- 하드코딩된 경로를 제거하고 중앙집중식 관리

## 🔁 변경 사항
- **NotificationCommandService**: `NOTIFY_SUBSCRIBE_PATH` 상수 추가
- **WebSocketSubscriptionListener**: 구독 경로를 `/user/queue/notification`으로 통일
- 모든 알림 전송 경로를 상수로 일관되게 관리

## 👀 기타 더 이야기해볼 점
- WebSocket 경로 관리 전략 및 네이밍 컨벤션

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.