### PR TITLE
[BE - FIX] 알림 시스템 NPE 및 데이터 매핑 오류 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/converter/NotificationConverter.java
@@ -23,9 +23,10 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class NotificationConverter {
 
-    public Notification toEntity(Long receiverId, NotificationType type, Long targetId){
+    public Notification toEntity(Long receiverId, Long senderId, NotificationType type, Long targetId){
         return Notification.builder()
                 .receiverId(receiverId)
+                .senderId(senderId)
                 .type(type)
                 .targetId(targetId)
                 .build();

--- a/src/main/java/com/kakaobase/snsapp/domain/notification/entity/Notification.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/entity/Notification.java
@@ -24,6 +24,9 @@ public class Notification {
     @Column(name = "receiver_id", nullable = false, columnDefinition = "INT UNSIGNED")
     private Long receiverId;
 
+    @Column(name = "sender_id", nullable = false, columnDefinition = "INT UNSIGNED")
+    private Long senderId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false, length = 20)
     private NotificationType notificationType;
@@ -42,8 +45,9 @@ public class Notification {
     private LocalDateTime createdAt;
 
     @Builder
-    public Notification(Long receiverId, NotificationType type, Long targetId) {
+    public Notification(Long receiverId, Long senderId, NotificationType type, Long targetId) {
         this.receiverId = receiverId;
+        this.senderId = senderId;
         this.notificationType = type;
         this.targetType = type.getTargetType();
         this.targetId = targetId;

--- a/src/main/java/com/kakaobase/snsapp/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/service/NotificationCommandService.java
@@ -37,8 +37,8 @@ public class NotificationCommandService {
     private static final String NOTIFY_SUBSCRIBE_PATH = "/queue/notification";
 
     @Transactional
-    public Long createNotification(Long receiverId, NotificationType type, Long targetId) {
-        Notification notification = notifConverter.toEntity(receiverId, type, targetId);
+    public Long createNotification(Long receiverId, Long senderId, NotificationType type, Long targetId) {
+        Notification notification = notifConverter.toEntity(receiverId, senderId, type, targetId);
         notifRepository.save(notification);
         return notification.getId();
     }

--- a/src/main/java/com/kakaobase/snsapp/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/service/NotificationService.java
@@ -79,13 +79,13 @@ public class NotificationService {
     }
 
     private void sendNotification(Long receiverId, Long targetId, String content, MemberResponseDto.UserInfo userInfo, NotificationType type, Long postId) {
-        Long notifId = commandService.createNotification(receiverId, type, targetId);
+        Long notifId = commandService.createNotification(receiverId, userInfo.id(), type, targetId);
         commandService.sendNotification(receiverId, notifId, type, content, postId, userInfo);
     }
 
     //팔로우 알림용
     private void sendFollowNotification(Long receiverId, Long targetId, MemberResponseDto.UserInfoWithFollowing userInfo, NotificationType type) {
-        Long notifId = commandService.createNotification(receiverId, type, targetId);
+        Long notifId = commandService.createNotification(receiverId, userInfo.id(), type, targetId);
         commandService.sendNotification(receiverId, notifId, type, userInfo);
     }
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #234

## 📌 개요
- 알림 시스템에서 발생하는 NPE(NullPointerException) 문제 해결
- Notification 엔티티에 sender_id 필드 추가로 데이터 구조 개선
- targetId 중복으로 인한 content 매핑 오류 수정
- Like 엔티티 조회 로직 최적화

## 🔁 변경 사항

### 1. Notification 엔티티 구조 개선
- `sender_id` 필드 추가하여 발신자 정보를 직접 저장
- 복잡한 JOIN 쿼리 제거로 성능 향상

### 2. NPE 방지 및 안전성 강화
- 모든 `Collectors.toMap()` 연산에 merge function 추가
- 삭제된 엔티티에 대한 예외 처리 강화
- null 값 처리를 위한 fallback 로직 구현

### 3. 데이터 매핑 로직 개선
- targetId 중복 문제 해결을 위해 notificationId 기반 매핑으로 변경
- Like 엔티티 조회 제거하고 Comment/Recomment 직접 조회
- 타입별 안전한 content 처리 로직 구현

### 4. 성능 최적화
- 복잡한 JOIN 쿼리를 단순한 직접 조회로 변경
- 불필요한 Like 엔티티 조회 제거
- 배치 조회 방식 개선

## 👀 기타 더 이야기해볼 점
- 데이터베이스 마이그레이션이 필요할 수 있습니다 (sender_id 필드 추가)
- 기존 알림 데이터의 sender_id 백필 작업 검토 필요
- 알림 성능이 크게 개선될 것으로 예상됩니다

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.