### PR TITLE
[BE - FIX] WebSocket 패킷 역직렬화 오류 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/common/entity/WebSocketPacket.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/entity/WebSocketPacket.java
@@ -1,5 +1,12 @@
 package com.kakaobase.snsapp.global.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = WebSocketPacketImpl.class)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = WebSocketPacketImpl.class, name = "default")
+})
 public abstract class WebSocketPacket<T> {
     public final String event;  // 세부 동작 (ex: liked, read, joined, error)
     public final T data;       // 실제 메시지 데이터 (개별 DTO로 분기)

--- a/src/main/java/com/kakaobase/snsapp/global/common/entity/WebSocketPacketImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/entity/WebSocketPacketImpl.java
@@ -1,8 +1,12 @@
 package com.kakaobase.snsapp.global.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class WebSocketPacketImpl<T> extends WebSocketPacket<T> {
     
-    public WebSocketPacketImpl(String event, T data) {
+    @JsonCreator
+    public WebSocketPacketImpl(@JsonProperty("event") String event, @JsonProperty("data") T data) {
         super(event, data);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #262 

## 📌 개요
- WebSocket 패킷 역직렬화 시 발생하는 InstantiationException 오류 수정
- Jackson이 abstract 클래스를 직접 인스턴스화하려던 문제 해결
- 알림 읽기/삭제 기능의 정상 동작 보장

## 🔁 변경 사항

### 1. WebSocketPacket Jackson 어노테이션 추가
- `@JsonTypeInfo`: Jackson이 다형성 처리 시 기본 구현체 지정
- `@JsonSubTypes`: 가능한 하위 타입과 식별자 매핑
- `defaultImpl = WebSocketPacketImpl.class`로 기본 구현체 설정

### 2. WebSocketPacketImpl 생성자 어노테이션 추가  
- `@JsonCreator`: Jackson이 객체 생성 시 사용할 생성자 지정
- `@JsonProperty`: JSON 필드와 생성자 파라미터 명시적 매핑
- 불변 객체의 안전한 역직렬화 보장

### 3. 해결된 문제
- 알림 읽기 패킷: `{"event":"notification.read","data":{"id":115}}`
- 알림 삭제 패킷: `{"event":"notification.delete","data":{"id":115}}`
- 이제 정상적으로 `WebSocketPacketImpl<NotificationRequestData>` 객체로 변환

## 👀 기타 더 이야기해볼 점
- 모든 WebSocket 패킷 처리가 안정화됩니다
- 향후 다른 WebSocket 기능 추가 시에도 동일한 패턴 적용 가능

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.