### PR TITLE
[BE - FIX] 알림 응답 이벤트명 오타 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/notification/util/ResponseEnum.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/notification/util/ResponseEnum.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 public enum ResponseEnum {
     READ_SUCCESS("notification.read.ack","알림 읽음 처리에 성공하였습니다."),
     READ_FAIL("notification.read.ack", "알림 읽음 처리에 실패하였습니다"),
-    REMOVE_SUCCESS("notificaiton.remove.ack", "알림 삭제 처리에 성공하였습니다"),
-    REMOVE_FAIL("noficiaiton.remove.nack", "알림 삭제 처리에 실패하였습니다");
+    REMOVE_SUCCESS("notification.remove.ack", "알림 삭제 처리에 성공하였습니다"),
+    REMOVE_FAIL("notification.remove.nack", "알림 삭제 처리에 실패하였습니다");
 
     private final String event;
     private final String message;


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #234

## 📌 개요
- ResponseEnum에서 알림 삭제 관련 이벤트명 오타 수정
- WebSocket 응답 패킷의 정확한 이벤트명 보장

## 🔁 변경 사항

### 오타 수정
- `REMOVE_SUCCESS`: `"notificaiton.remove.ack"` → `"notification.remove.ack"`
- `REMOVE_FAIL`: `"noficiaiton.remove.nack"` → `"notification.remove.nack"`

### 영향도
- 알림 삭제 성공/실패 응답 패킷의 정확한 이벤트명 전달
- 클라이언트에서 올바른 이벤트 핸들링 가능

## 👀 기타 더 이야기해볼 점
- 간단한 오타 수정이지만 클라이언트와의 통신에 중요한 부분입니다
- 향후 이벤트명 상수 관리 방안 검토 필요

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.