### PR TITLE
[BE - FEAT] 실시간 AI 채팅봇 시스템 개선 및 디버깅 강화

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/chat/controller/ChatController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatController {
 
-    private static final String CHAT_QUEUE_DESTINATION = "/queue/chat";
+    private static final String CHAT_QUEUE_DESTINATION = "/queue/chatbot";
     
     private final ChatService chatService;
     private final ChatConverter chatConveter;

--- a/src/main/java/com/kakaobase/snsapp/domain/chat/service/communication/ChatWebSocketService.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/chat/service/communication/ChatWebSocketService.java
@@ -29,7 +29,7 @@ public class ChatWebSocketService {
     
     private final SimpMessagingTemplate messagingTemplate;
     
-    private static final String CHAT_QUEUE_DESTINATION = "/queue/chat";
+    private static final String CHAT_QUEUE_DESTINATION = "/queue/chatbot";
     
     /**
      * 사용자에게 로딩 상태 전송

--- a/src/main/java/com/kakaobase/snsapp/domain/chat/service/streaming/StreamingSessionManager.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/chat/service/streaming/StreamingSessionManager.java
@@ -13,6 +13,7 @@ import com.kakaobase.snsapp.domain.chat.exception.ChatException;
 import com.kakaobase.snsapp.domain.chat.exception.errorcode.ChatErrorCode;
 import com.kakaobase.snsapp.domain.chat.util.StreamIdGenerator;
 import com.kakaobase.snsapp.domain.chat.exception.StreamException;
+import com.kakaobase.snsapp.global.common.entity.WebSocketPacket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,5 +17,9 @@ logging:
     com.kakaobase.snsapp.global.security: DEBUG
     com.kakaobase.snsapp.domain.auth: DEBUG
     com.kakaobase.snsapp.domain.posts: DEBUG
+    com.kakaobase.snsapp.domain.chat: DEBUG
     org.springframework.security: DEBUG
+    org.springframework.messaging: DEBUG
+    org.springframework.web.socket: DEBUG
+    org.springframework.messaging.simp: DEBUG
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #261

## 📌 개요
- 실시간 AI 채팅봇 시스템의 안정성 및 디버깅 기능 강화
- WebSocket 메시지 처리 문제 해결 및 로깅 시스템 개선
- 스트리밍 중지 요청을 streamId 기반으로 변경하여 다중 스트림 지원
- AI 서버 통신 방식을 동기화하여 성능 최적화

## 🔁 변경 사항

### 1. WebSocket 큐 destination 불일치 문제 해결
- **ChatController**와 **ChatWebSocketService**의 큐 destination을 `/queue/chatbot`으로 통일
- WebSocket 응답 메시지가 클라이언트에 정상 전달되도록 수정
- 불필요한 의존성 제거 및 코드 정리

### 2. Dev 환경 Chat 도메인 로깅 설정 추가
- `com.kakaobase.snsapp.domain.chat: DEBUG` - Chat 도메인 전체 로깅 활성화
- `org.springframework.messaging: DEBUG` - STOMP 메시지 처리 로깅
- `org.springframework.web.socket: DEBUG` - WebSocket 연결 상태 로깅
- `org.springframework.messaging.simp: DEBUG` - SimpMessagingTemplate 로깅
- **WebSocket 메시지 처리 과정 디버깅 가능**

### 3. 로딩 패킷 전송 과정 상세 로깅 추가
- **ChatTimerManager**: 타이머 플로우 및 활성 타이머 수 추적
- **ChatBufferManager**: LoadingEvent 발행 단계별 상세 로깅
- **ChatEventListener**: 비동기 이벤트 처리 타이밍 및 스레드 정보 추적
- **ChatWebSocketService**: WebSocket 패킷 전송 성공/실패 상태 로깅
- 전체 플로우 타이밍 측정을 위한 `System.currentTimeMillis()` 추가

### 4. 스트리밍 중지 요청 streamId 기반 변경
- `AiServerHttpClient.stopStream()` 파라미터를 `userId`에서 `streamId`로 변경
- AI 서버 엔드포인트를 `/chat/stream/{streamId}` 형식으로 수정
- 다중 스트림 지원 및 일관된 식별자 사용으로 시스템 안정성 향상

### 5. AI 서버 헬스체크 동기 방식 변경
- WebFlux 비동기 방식에서 `generalWebClient` 동기 방식으로 변경
- 헬스체크 로깅 레벨을 DEBUG에서 INFO로 변경하여 운영 환경에서 추적 가능
- 에러 처리를 try-catch 방식으로 단순화

### 6. ChatBlockData 데이터 구조 개선
- AI 서버 요청 시 사용자 식별을 위한 `userId` 필드 추가
- JSON 직렬화를 위한 `@JsonProperty` 어노테이션 설정

## 👀 기타 더 이야기해볼 점
- **로딩 패킷 전송 문제 디버깅**: 1초 후에도 로딩 패킷이 전송되지 않는 문제의 근본 원인 추적 가능
- **WebSocket 메시지 처리 과정**: 프론트엔드가 올바른 STOMP 패킷을 보내도 백엔드에서 처리되지 않는 문제 해결
- **타이머 기반 자동 전송 메커니즘**: 각 단계별 상세 추적으로 성능 병목 지점 식별 가능
- **실시간 모니터링**: WebSocket 연결 및 패킷 전송 상태 실시간 추적 가능

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.