### PR TITLE
[BE - FIX] WebSocket 채팅 패킷 파싱 에러 해결

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/common/entity/WebSocketPacket.java
+++ b/src/main/java/com/kakaobase/snsapp/global/common/entity/WebSocketPacket.java
@@ -1,5 +1,16 @@
 package com.kakaobase.snsapp.global.common.entity;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, 
+              include = JsonTypeInfo.As.EXISTING_PROPERTY, 
+              property = "event", 
+              defaultImpl = WebSocketPacketImpl.class,
+              visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = WebSocketPacketImpl.class, name = "default")
+})
 public abstract class WebSocketPacket<T> {
     public final String event;  // 세부 동작 (ex: liked, read, joined, error)
     public final T data;       // 실제 메시지 데이터 (개별 DTO로 분기)


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #295

## 📌 개요
- WebSocket 채팅 패킷(`chat.send`, `chat.typing`) 파싱 시 발생하는 `InstantiationException` 에러 해결
- Jackson 직렬화/역직렬화 과정에서 abstract class 인스턴스화 문제 수정

## 🔁 변경 사항

### 🔧 WebSocketPacket.java
- `@JsonTypeInfo` 어노테이션 복원
- `As.EXISTING_PROPERTY` 사용으로 기존 `event` 필드를 타입 식별자로 활용
- `visible=true` 설정으로 JSON 출력에서 event 필드 유지
- `defaultImpl = WebSocketPacketImpl.class` 설정으로 안전한 fallback 제공

### 🎯 예상 해결
- chat.send 패킷 파싱 실패 해결
- chat.typing 패킷 파싱 실패 해결
- WebSocket 메시지 역직렬화 시 InstantiationException 제거

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.