### PR TITLE
[BE - FIX] WebSocket 채팅 패킷 파싱 및 타입 안전성 개선

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/WebSocketConfig.java
@@ -50,8 +50,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOrigins(
                         "https://*.kakaobase.com",
                         "https://localhost:3000")
-                .addInterceptors(jwtWebSocketHandshakeInterceptor)
-                .withSockJS()
-                .setSessionCookieNeeded(true);
+                .addInterceptors(jwtWebSocketHandshakeInterceptor);
+                // .withSockJS()
+                // .setSessionCookieNeeded(true);
     }
 }

--- a/src/main/java/com/kakaobase/snsapp/global/config/WebSocketConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/WebSocketConfig.java
@@ -50,8 +50,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOrigins(
                         "https://*.kakaobase.com",
                         "https://localhost:3000")
-                .addInterceptors(jwtWebSocketHandshakeInterceptor);
-                // .withSockJS()
-                // .setSessionCookieNeeded(true);
+                .addInterceptors(jwtWebSocketHandshakeInterceptor)
+                .withSockJS()
+                .setSessionCookieNeeded(true);
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #295

## 📌 개요
- WebSocket 채팅 패킷 파싱 실패 문제 해결
- ChatController 경로별 분리를 통한 타입 안전성 확보
- Principal 타입 체크 오류 수정
- JSON 역직렬화 과정에서 발생하는 ClassCastException 해결

## 🔁 변경 사항

### 🔧 WebSocket 패킷 파싱 수정
- `@JsonTypeInfo` 어노테이션 복원으로 Jackson 역직렬화 문제 해결
- `As.EXISTING_PROPERTY` 사용하여 기존 `event` 필드를 타입 식별자로 활용
- 별도 `type` 필드 없이 하위 호환성 유지

### 🔧 Principal 타입 체크 개선  
- WebSocket에서 `Principal`이 `UsernamePasswordAuthenticationToken` 타입임을 고려
- `token.getPrincipal()` 방식으로 올바른 `CustomUserDetails` 추출
- 공통 `extractUserId()` 유틸 메서드 구현

### 🔧 ChatController 구조 개선
- 통합 `/chat` 엔드포인트를 이벤트별 경로로 분리:
  - `/chat.send` → `WebSocketPacket<ChatData>`
  - `/chat.typing` → `WebSocketPacket<SimpTimeData>`  
  - `/chat.stop` → `WebSocketPacket<StreamStopData>`
  - `/chat.stream.end.ack/nack` → `WebSocketPacket<StreamAckData>`
- `WebSocketPacket<?>` 와일드카드를 구체적 타입으로 변경
- switch문 기반 이벤트 분기 로직 제거
- 수동 캐스팅 및 Map 추출 로직 완전 제거

### 🎯 해결된 문제들
- `chat.typing` 패킷의 `LinkedHashMap` 캐스팅 오류 해결
- `chat.send` 및 기타 패킷들의 InstantiationException 해결
- Principal instanceof 체크 실패 문제 해결
- JSON 역직렬화 시 타입 정보 손실 문제 해결

## 👀 기타 더 이야기해볼 점

### 프론트엔드 변경 필요사항
경로 분리로 인해 프론트엔드에서 WebSocket 전송 경로 변경 필요:
- 기존: `/pub/chat` + event 분기
- 신규: `/pub/chat.{event}` (예: `/pub/chat.typing`)

### 아키텍처 개선 효과
- Notification과 동일한 패턴으로 일관성 확보
- Jackson의 타입 안전한 역직렬화 활용
- 컴파일 타임 타입 체크로 런타임 에러 방지

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.