### PR TITLE
[BE - FIX] AI 서버 전송 데이터 형식 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/chat/converter/ChatConverter.java
@@ -104,9 +104,8 @@ public class ChatConverter {
                 .nickname(member.getNickname())
                 .userId(member.getId())
                 .className(member.getClassName())
-                .content(content)
+                .message(content)
                 .timestamp(LocalDateTime.now())
-                .isRead(false)
                 .build();
     }
 

--- a/src/main/java/com/kakaobase/snsapp/domain/chat/dto/ai/request/ChatBlockData.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/chat/dto/ai/request/ChatBlockData.java
@@ -17,10 +17,8 @@ public record ChatBlockData(
         String nickname,
         @JsonProperty("class_name")
         String className,
-        @JsonProperty("content")
-        String content,
+        @JsonProperty("message")
+        String message,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-        LocalDateTime timestamp,
-        @JsonProperty("is_read")
-        Boolean isRead
+        LocalDateTime timestamp
 ) {}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #295

## 📌 개요
- AI 서버 전송 데이터 형식을 서버 스펙에 맞게 수정
- FastAPI Pydantic 검증 에러 해결
- 불필요한 필드 제거로 데이터 전송 최적화

## 🔁 변경 사항
- **ChatBlockData 필드 수정**: `content` → `message`로 변경
- **불필요한 필드 제거**: `is_read` 필드 완전 제거
- **JSON 프로퍼티 매핑**: `@JsonProperty("content")` → `@JsonProperty("message")`
- **ChatConverter 수정**: `toChatBlockData` 메서드에서 필드명 변경 반영

## 👀 기타 더 이야기해볼 점
- AI 서버(FastAPI)의 Pydantic 모델 스펙에 맞춘 데이터 형식 통일
- 기존 `type`, `loc`, `msg` 필드는 검증 에러 메시지였음을 확인
- 데이터 전송 시 불필요한 필드 제거로 페이로드 최적화

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

🤖 Generated with [Claude Code](https://claude.ai/code)