### PR TITLE
[BE - FIX] SSE 스트림용 WebClient 무한 타임아웃 설정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/config/WebClientConfig.java
+++ b/src/main/java/com/kakaobase/snsapp/global/config/WebClientConfig.java
@@ -100,10 +100,11 @@ public class WebClientConfig {
     public WebClient aiServerWebClient() {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
-                .responseTimeout(Duration.ofMillis(30000))
+                .responseTimeout(Duration.ZERO)  // 무한 대기
                 .doOnConnected(connection ->
-                        connection.addHandlerLast(new ReadTimeoutHandler(30, TimeUnit.SECONDS))
-                                  .addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS)))
+                        connection.addHandlerLast(new WriteTimeoutHandler(10, TimeUnit.SECONDS))
+                        // ReadTimeoutHandler 제거 - SSE 스트림 무한 대기
+                )
                 .keepAlive(true)
                 .compress(true);
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #295

## 📌 개요
- SSE 스트림용 WebClient 타임아웃 설정을 무한 대기로 변경
- 200 OK 응답 후 ReadTimeoutException 에러 방지
- SSE 장시간 연결 유지를 위한 WebClient 설정 최적화

## 🔁 변경 사항
- **ResponseTimeout 무한 설정**: `Duration.ofMillis(30000)` → `Duration.ZERO`
- **ReadTimeoutHandler 제거**: SSE 스트림 무한 대기를 위해 읽기 타임아웃 제거
- **WriteTimeoutHandler 유지**: 쓰기 작업 안정성을 위해 10초 타임아웃 유지
- **연결 안정성 향상**: 200 OK 응답 후 타임아웃으로 인한 연결 끊김 방지

## 👀 기타 더 이야기해볼 점
- SSE 스트림 특성상 무한 연결 유지가 필요하므로 ResponseTimeout을 ZERO로 설정
- AI 서버에서 데이터가 오지 않아도 연결을 유지하기 위해 ReadTimeoutHandler 제거
- 기존 30초 타임아웃으로 인한 "200 OK but failed" 에러 완전 해결

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

🤖 Generated with [Claude Code](https://claude.ai/code)