### PR TITLE
[BE - FIX] 스트림 완료 시 비동기 메서드 호출 문제 수정

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/chat/service/streaming/StreamingSessionManager.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/chat/service/streaming/StreamingSessionManager.java
@@ -122,7 +122,7 @@ public class StreamingSessionManager {
         String finalResponse = session.getFinalResponse();
         if (finalResponse != null && !finalResponse.isBlank()) {
             try {
-                Long botChatId = chatCommandService.saveBotMessage(session.getUserId(), finalResponse);
+                Long botChatId = chatCommandService.saveBotMessageSync(session.getUserId(), finalResponse);
                 StreamEndData endData = new StreamEndData(botChatId, LocalDateTime.now());
                 chatWebSocketService.sendStreamEndDataToUser(userId , endData);
                 log.info("AI 응답 메시지 저장 완됨: streamId={}, userId={}", streamId, session.getUserId());


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #295

## 📌 개요
- 스트림 완료 시 @Async 메서드 반환 타입 문제로 인한 DB 저장 실패 해결
- 프론트엔드에서 chat.stream.error 발생 원인 수정

## 🔁 변경 사항

### 문제 원인
- `ChatCommandService.saveBotMessage()` 메서드가 `@Async` 어노테이션 사용하면서 `Long` 타입 반환
- Spring `@Async` 규칙: 오직 `void` 또는 `Future<T>` 타입만 반환 가능
- 에러 메시지: "Invalid return type for async method (only Future and void supported): class java.lang.Long"

### 해결 방안
```java
// 변경 전
Long botChatId = chatCommandService.saveBotMessage(session.getUserId(), finalResponse);

// 변경 후
Long botChatId = chatCommandService.saveBotMessageSync(session.getUserId(), finalResponse);
```

### 기술적 개선사항
- 스트림 완료 시 즉시 chat_id 반환 가능
- DB 저장 성공 후 정상적인 `chat.stream.end` 이벤트 전송
- 프론트엔드 에러 해결: `chat.stream.error` → `chat.stream.end`

### 안전성 고려
- 기존 `@Async` 메서드는 유지하여 다른 곳에서 사용 중인 코드 영향 최소화
- 이미 존재하는 `saveBotMessageSync()` 동기 메서드 활용

## 👀 기타 더 이야기해볼 점

### 성능 영향
- 스트림 완료 처리는 즉시 chat_id가 필요하므로 동기 처리가 적합
- DB 저장 자체는 빠른 작업이므로 성능 저하 미미

### 향후 고려사항
- 스트림 완료 처리 외에는 여전히 `@Async` 메서드 사용 가능
- 필요에 따라 전체적인 비동기 처리 전략 재검토 가능

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.