### PR TITLE
[BE - FIX] WebSocket연결 에러 로그 도배 문제 임시 처리

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,8 +14,10 @@ logging:
     com.kakaobase.snsapp.domain.posts.scheduler: DEBUG
     com.amazonaws.util.EC2MetadataUtils: ERROR
     com.amazonaws.services.s3: INFO
-    com.kakaobase.snsapp.global.security: DEBUG
     com.kakaobase.snsapp.domain.auth: DEBUG
     com.kakaobase.snsapp.domain.posts: DEBUG
-    org.springframework.security: DEBUG
     org.hibernate.SQL: debug
+    # WebSocket 에러 로그 도배 방지를 위한 보안 관련 로그 레벨 조정
+    com.kakaobase.snsapp.global.security: WARN
+    org.springframework.security: WARN
+    org.apache.juli.logging.DirectJDKLog: OFF


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close

## 📌 개요
- WebSocket 연결시 발생하는 만료된 JWT 토큰 에러 로그 도배 문제 해결
- 보안 관련 DEBUG 로그와 Tomcat ERROR 로그 레벨 조정으로 로그 가독성 개선

## 🔁 변경 사항
- `application-local.yml`에서 보안 관련 패키지 로그 레벨 조정:
  - `com.kakaobase.snsapp.global.security`: DEBUG → WARN
  - `org.springframework.security`: DEBUG → WARN  
  - `org.apache.juli.logging.DirectJDKLog`: OFF로 설정
- WebSocket 에러 로그 도배 방지를 위한 주석 추가

## 👀 기타 더 이야기해볼 점
- 이는 좋아요 게시글 에러 로그를 확인하기 위한 임시조치로, 차후 WebSocket QA때 근본적인 해결 필요

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.