### PR TITLE
[BE - FIX] WebSocket 에러 로그 도배 방지를 위한 로그 레벨 조정

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,12 +14,12 @@ logging:
     com.kakaobase.snsapp.domain.posts.scheduler: DEBUG
     com.amazonaws.util.EC2MetadataUtils: ERROR
     com.amazonaws.services.s3: INFO
-    com.kakaobase.snsapp.global.security: DEBUG
     com.kakaobase.snsapp.domain.auth: DEBUG
     com.kakaobase.snsapp.domain.posts: DEBUG
-    com.kakaobase.snsapp.domain.chat: DEBUG
-    org.springframework.security: DEBUG
-    org.springframework.messaging: DEBUG
-    org.springframework.web.socket: DEBUG
-    org.springframework.messaging.simp: DEBUG
     org.hibernate.SQL: debug
+    # WebSocket 에러 로그 도배 방지를 위한 보안 관련 로그 레벨 조정
+    com.kakaobase.snsapp.global.security: WARN
+    org.springframework.security: WARN
+    org.apache.juli: OFF
+    org.apache.catalina: WARN
+    org.apache.tomcat: WARN

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,4 +20,6 @@ logging:
     # WebSocket 에러 로그 도배 방지를 위한 보안 관련 로그 레벨 조정
     com.kakaobase.snsapp.global.security: WARN
     org.springframework.security: WARN
-    org.apache.juli.logging.DirectJDKLog: OFF
+    org.apache.juli: OFF
+    org.apache.catalina: WARN
+    org.apache.tomcat: WARN


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
WebSocket JWT 토큰 만료 에러 로그 도배 문제 임시 해결

## 📌 개요
- WebSocket 연결시 발생하는 만료된 JWT 토큰 에러 로그 도배 문제 임시 해결
- 
## 🔁 변경 사항
- `application-local.yml`, `application-dev.yml`에서 로그 레벨 조정:
  - `com.kakaobase.snsapp.global.security`: DEBUG → WARN
  - `org.springframework.security`: DEBUG → WARN  
  - `org.apache.juli`: OFF로 설정 (DirectJDKLog 포함)
  - `org.apache.catalina`: WARN으로 설정
  - `org.apache.tomcat`: WARN으로 설정

## 👀 기타 더 이야기해볼 점
- 이는 좋아요 게시물 조회의 에러로그를 보기 위한 임시 조치로, 이후 근본적인 원인인 WebSoket연결 문제를 해결할때 수정해야함

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.