### PR TITLE
[BE - FIX] 좋아요한 게시글 조회 에러 해결

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/converter/PostConverter.java
@@ -129,7 +129,6 @@ public class PostConverter {
     public List<PostResponseDto.PostDetails> updateWithCachedStats(
             List<PostResponseDto.PostDetails> postDetails) {
 
-
         try{
             Map<Long, CacheRecord.PostStatsCache> postStatsCache = postCacheService.findAllByItems(postDetails);
             if (postDetails == null || postDetails.isEmpty() || postStatsCache == null || postStatsCache.isEmpty()) {

--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepositoryImpl.java
@@ -310,9 +310,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
                 // 현재 사용자의 좋아요 여부 확인 (likedByMemberId와 다른 경우만)
                 .leftJoin(currentUserLike).on(
-                        currentUserLike.post.eq(post)
-                                .and(currentMemberId != null && !currentMemberId.equals(likedByMemberId) ?
-                                        currentUserLike.id.memberId.eq(currentMemberId) : null)
+                        currentMemberId != null && !currentMemberId.equals(likedByMemberId) ?
+                                currentUserLike.post.eq(post).and(currentUserLike.id.memberId.eq(currentMemberId)) :
+                                null
                 )
 
                 // 현재 사용자가 게시글 작성자를 팔로우하는지


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #281

## 📌 개요
- 좋아요한 게시글 조회시 `Duplicate key 53` 에러 해결
- WebSocket 연결시 발생하는 만료된 JWT 토큰 에러 로그 도배 문제 해결
- PostCustomRepositoryImpl의 LEFT JOIN 조건 수정으로 중복 데이터 반환 방지

## 🔁 변경 사항

### 1. 좋아요한 게시글 조회 중복 데이터 문제 해결
- **PostCustomRepositoryImpl.java**: `findLikedPostsWithCursor`에서 LEFT JOIN 조건 수정
- **문제**: `likedByMemberId = currentMemberId`일 때 `currentUserLike.post.eq(post)` 조건이 항상 적용되어 해당 게시글의 모든 좋아요와 JOIN
- **해결**: 조건 자체를 `null`로 설정하여 JOIN 완전 비활성화
- **PostConverter.java**: 불필요한 빈 줄 제거

### 2. WebSocket 에러 로그 도배 방지
- **application-local.yml**, **application-dev.yml**에서 로그 레벨 조정:
  - `com.kakaobase.snsapp.global.security`: DEBUG → WARN
  - `org.springframework.security`: DEBUG → WARN  
  - `org.apache.juli`: OFF로 설정 (DirectJDKLog 포함)
  - `org.apache.catalina`: WARN으로 설정
  - `org.apache.tomcat`: WARN으로 설정

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.