### PR TITLE
[BE - FIX] 좋아요한 게시글 조회 오류 해결

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/kakaobase/snsapp/domain/posts/repository/custom/PostCustomRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.kakaobase.snsapp.domain.posts.entity.QPostImage;
 import com.kakaobase.snsapp.domain.posts.entity.QPostLike;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.Modifying;
@@ -262,7 +263,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
         QPostLike currentUserLike = new QPostLike("currentUserLike");  // 별칭 사용
         QFollow follow = QFollow.follow;
 
-        return queryFactory
+        JPAQuery<PostResponseDto.PostDetails> query = queryFactory
                 .select(Projections.constructor(PostResponseDto.PostDetails.class,
                         post.id,
 
@@ -291,7 +292,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         // 좋아요 여부 - likedByMemberId가 좋아요한 게시글이므로 조건부 처리
                         likedByMemberId.equals(currentMemberId) ?
                                 Expressions.constant(true) :  // 자신이 좋아요한 게시글 목록이면 모두 true
-                                currentUserLike.id.isNotNull()  // 다른 사람이 좋아요한 게시글이면 현재 사용자 좋아요 여부
+                                (currentMemberId != null && !currentMemberId.equals(likedByMemberId)) ?
+                                        currentUserLike.id.isNotNull() :  // 조인된 경우에만 참조
+                                        Expressions.constant(false)  // 조인되지 않은 경우
                 ))
                 .from(post)
                 .join(post.member, member)
@@ -306,15 +309,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .leftJoin(postImage).on(
                         postImage.post.eq(post)
                                 .and(postImage.sortIndex.eq(0))
-                )
+                );
 
-                // 현재 사용자의 좋아요 여부 확인 (likedByMemberId와 다른 경우만)
-                .leftJoin(currentUserLike).on(
-                        currentMemberId != null && !currentMemberId.equals(likedByMemberId) ?
-                                currentUserLike.post.eq(post).and(currentUserLike.id.memberId.eq(currentMemberId)) :
-                                null
-                )
+        // 현재 사용자의 좋아요 여부 확인 (likedByMemberId와 다른 경우만)
+        if (currentMemberId != null && !currentMemberId.equals(likedByMemberId)) {
+            query = query.leftJoin(currentUserLike).on(
+                    currentUserLike.post.eq(post).and(currentUserLike.id.memberId.eq(currentMemberId))
+            );
+        }
 
+        return query
                 // 현재 사용자가 게시글 작성자를 팔로우하는지
                 .leftJoin(follow).on(
                         currentMemberId != null ? follow.followerUser.id.eq(currentMemberId) : null,


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #281

## 📌 개요
- 좋아요한 게시글 조회 API에서 발생하는 "Duplicate key 53" 오류와 QueryDSL NPE 오류 해결
- PostCustomRepositoryImpl의 findLikedPostsWithCursor 메서드에서 조건부 조인 로직 개선

## 🔁 변경 사항
- QueryDSL에서 중복 데이터 생성을 방지하기 위한 LEFT JOIN 조건 수정
- 조건부 조인된 테이블을 SELECT 절에서 안전하게 참조하도록 로직 개선
- NPE 방지를 위한 3단계 조건문 적용
- 좋아요한 게시글 조회시 currentMemberId와 likedByMemberId가 같을 때의 예외 처리 강화

## 👀 기타 더 이야기해볼 점
- PostStatsCache의 중복 키 오류가 완전히 해결되었는지 모니터링 필요
- 대용량 데이터에서의 성능 테스트 고려

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.