### PR TITLE
[BE - FIX] 알림 API JWT 인증 필수 적용

### DIFF
--- a/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakaobase/snsapp/global/security/jwt/JwtAuthenticationFilter.java
@@ -66,7 +66,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             new PathMethodPattern("/api/recomments/*/likes", "GET"),
             new PathMethodPattern("/api/comments/*/recomments", "GET"),
             new PathMethodPattern("/api/posts/**", "GET"),
-            new PathMethodPattern("/api/users/**", "GET")
+            new PathMethodPattern("/api/users/*", "GET"),
+            new PathMethodPattern("/api/users/*/posts", "GET"),
+            new PathMethodPattern("/api/users/*/comments", "GET")
+
     );
 
     @Override
@@ -93,7 +96,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 익명 접근 가능한 경로인지 확인
         boolean isAnonymousAccessible = anonymousAccessiblePatterns.stream()
-                .anyMatch(pattern -> pattern.matches(path, method, pathMatcher));
+                .anyMatch(pattern -> pattern.matches(path, method, pathMatcher))
+                && !path.equals("/api/users/notifications");
 
         String token = jwtUtil.resolveTokenFromCookie(request);
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #324

## 📌 개요
- `/api/users/notifications` 알림 API가 JWT 인증 없이 접근 가능한 보안 문제 수정
- 외부 사용자의 마이페이지 조회는 유지하면서 알림 API만 선택적으로 인증 필수 적용

## 🔁 변경 사항
- `JwtAuthenticationFilter.java`의 `anonymousAccessiblePatterns` 수정
- `/api/users/**` 패턴을 더 구체적인 패턴들로 분리
- `/api/users/notifications` 경로 명시적 제외 로직 추가
- 유효하지 않은 JWT 토큰으로 알림 API 접근시 401 에러 반환

## 👀 기타 더 이야기해볼 점
- 현재 명시적 제외 방식(`\!path.equals("/api/users/notifications")`)을 사용했으나, 향후 정규표현식 패턴 도입 검토 가능
- 다른 인증이 필요한 `/api/users/**` 엔드포인트들도 동일한 방식으로 처리 가능

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.